### PR TITLE
Fix anomaly detection plugin name reference

### DIFF
--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -65,7 +65,7 @@ export const DATA_TYPES = {
   KEYWORD: 'keyword',
 };
 
-export const ES_AD_PLUGIN = 'opendistro-anomaly-detection';
+export const ES_AD_PLUGIN = 'opensearch-anomaly-detection';
 export const OPENSEARCH_DASHBOARDS_AD_PLUGIN = 'anomaly-detection-dashboards';
 
 export const INPUTS_DETECTOR_ID = '0.search.query.query.bool.filter[1].term.detector_id.value';


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
A leftover reference to the old name for the backend anomaly detection plugin causes the alerting plugin to not recognize its installation, giving unnecessary warnings on the UI, even if the plugin is installed:
![Screen Shot 2021-05-05 at 10 39 11 AM](https://user-images.githubusercontent.com/62119629/117187219-8dc00680-ad90-11eb-8a04-017a3197e9a5.png)
 
This PR updates the backend anomaly detection plugin name from `opendistro-anomaly-detection` to `opensearch-anomaly-detection`.

Confirmed that after the change, the warning goes away, and monitors are able to be successfully created from anomaly detectors.
 
### Check List
- [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
