### PR TITLE
Update AD API call endpoints

### DIFF
--- a/server/services/utils/constants.js
+++ b/server/services/utils/constants.js
@@ -26,7 +26,7 @@
 
 export const API_ROUTE_PREFIX = '/_opendistro/_alerting';
 export const MONITOR_BASE_API = `${API_ROUTE_PREFIX}/monitors`;
-export const AD_BASE_API = `/_opendistro/_anomaly_detection/detectors`;
+export const AD_BASE_API = `/_plugins/_anomaly_detection/detectors`;
 export const DESTINATION_BASE_API = `${API_ROUTE_PREFIX}/destinations`;
 export const EMAIL_ACCOUNT_BASE_API = `${DESTINATION_BASE_API}/email_accounts`;
 export const EMAIL_GROUP_BASE_API = `${DESTINATION_BASE_API}/email_groups`;


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Update AD API calls to use the new `_plugins/` prefix in favor of the legacy `_opendistro` prefix.
APIs were changed in Anomaly Detection [PR #35](https://github.com/opensearch-project/anomaly-detection/pull/35).
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
