### PR TITLE
Update API, settings, and doc link renaming

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch
           path: OpenSearch
-          ref: '1.0.0-beta1'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=beta1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=rc1 -Dbuild.snapshot=false
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-rc1
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Run Opensearch with plugin
         run: |
           cd alerting
-          ./gradlew run -Dopensearch.version=1.0.0-beta1 &
+          ./gradlew run -Dopensearch.version=1.0.0-rc1 &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           repository: opensearch-project/common-utils
           path: common-utils
-          ref: '1.0.0-beta1'
       - name: Build common-utils
         working-directory: ./common-utils
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-beta1
@@ -47,7 +46,6 @@ jobs:
         with:
           path: alerting
           repository: opensearch-project/alerting
-          ref: '1.0.0-beta1'
       - name: Run Opensearch with plugin
         run: |
           cd alerting

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release workflow
-# This workflow is triggered on creating tags to main or an opendistro release branch
+# This workflow is triggered on creating tags to main or an opensearch release branch
 on:
   push:
     tags:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The OpenSearch Alerting Dashboards plugin lets you manage your [OpenSearch Alert
 
 ## Documentation
 
-Please see our [documentation](https://opendistro.github.io/for-elasticsearch-docs/).
+Please see our [documentation](https://docs-beta.opensearch.org/).
 
 
 ## Setup
@@ -42,7 +42,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/opendistroAlertingDashboards-1.0.0.0.zip`
+Example output: `./build/alertingDashboards-1.0.0-beta1.zip`
 
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/alertingDashboards-1.0.0-beta1.zip`
+Example output: `./build/alertingDashboards-1.0.0-rc1.zip`
 
 
 ## Run

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -27,7 +27,7 @@
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 
 export const INDEX = {
-  OPENDISTRO_ALERTING_CONFIG: '.opendistro-alerting-config',
+  OPENSEARCH_ALERTING_CONFIG: '.opendistro-alerting-config',
 };
 
 export const API = {

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -24,7 +24,7 @@
  * permissions and limitations under the License.
  */
 
-export const API_ROUTE_PREFIX = '/_opendistro/_alerting';
+export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 
 export const INDEX = {
   OPENDISTRO_ALERTING_CONFIG: '.opendistro-alerting-config',

--- a/gather-info.js
+++ b/gather-info.js
@@ -1,16 +1,16 @@
 const templatePkg = require('./package.json');
-const kibanaPkg = require('../../package.json');
+const opensearchDashboardsPkg = require('../../package.json');
 
 const debugInfo = {
-  kibana: {
-    version: kibanaPkg.version,
-    build: kibanaPkg.build,
-    engines: kibanaPkg.engines,
+  opensearchDashboards: {
+    version: opensearchDashboardsPkg.version,
+    build: opensearchDashboardsPkg.build,
+    engines: opensearchDashboardsPkg.engines,
   },
   plugin: {
     name: templatePkg.name,
     version: templatePkg.version,
-    kibana: templatePkg.kibana,
+    opensearchDashboards: templatePkg.opensearchDashboards,
     dependencies: templatePkg.dependencies,
   },
 };

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "1.0.0.0-beta1",
-  "opensearchDashboardsVersion": "1.0.0-beta1",
+  "version": "1.0.0.0-rc1",
+  "opensearchDashboardsVersion": "1.0.0-rc1",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "1.0.0.0-beta1",
+  "version": "1.0.0.0-rc1",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
@@ -26,7 +26,7 @@
 
 import React from 'react';
 import FormikSelect from '../../../../components/FormControls/FormikSelect/FormikSelect';
-import { ES_AD_PLUGIN } from '../../../../utils/constants';
+import { OS_AD_PLUGIN } from '../../../../utils/constants';
 
 const defaultSelectDefinitions = [
   { value: 'graph', text: 'Define using visual graph' },
@@ -40,7 +40,7 @@ const onChangeDefinition = (e, form, resetResponse) => {
 };
 
 const selectDefinitions = (plugins) => {
-  return plugins === undefined || plugins.indexOf(ES_AD_PLUGIN) == -1
+  return plugins === undefined || plugins.indexOf(OS_AD_PLUGIN) == -1
     ? defaultSelectDefinitions
     : [...defaultSelectDefinitions, { value: 'ad', text: 'Define using anomaly detector' }];
 };

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -18,7 +18,7 @@ Array [
     <span>
       Check the performance of your query and make sure to follow best practices. 
       <a
-        href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/"
+        href="https://docs-beta.opensearch.org/docs/alerting/"
       >
         Learn more
       </a>

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
@@ -45,7 +45,7 @@ exports[`Frequencies renders CustomCron 1`] = `
             Use 
             <a
               class="euiLink euiLink--primary"
-              href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/"
+              href="https://docs-beta.opensearch.org/docs/alerting/"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -39,7 +39,7 @@ import MonitorTimeField from '../../components/MonitorTimeField';
 import { formikToMonitor } from '../CreateMonitor/utils/formikToMonitor';
 import { getPathsPerDataType } from './utils/mappings';
 import { buildSearchRequest } from './utils/searchRequests';
-import { SEARCH_TYPE, ES_AD_PLUGIN } from '../../../../utils/constants';
+import { SEARCH_TYPE, OS_AD_PLUGIN } from '../../../../utils/constants';
 import AnomalyDetectors from '../AnomalyDetectors/AnomalyDetectors';
 import { backendErrorNotification } from '../../../../utils/helpers';
 
@@ -346,7 +346,7 @@ class DefineMonitor extends Component {
   showPluginWarning() {
     const { values } = this.props;
     const { plugins } = this.state;
-    return values.searchType == SEARCH_TYPE.AD && plugins.indexOf(ES_AD_PLUGIN) == -1;
+    return values.searchType == SEARCH_TYPE.AD && plugins.indexOf(OS_AD_PLUGIN) == -1;
   }
 
   render() {

--- a/public/pages/Destinations/components/createDestinations/Email/Sender.js
+++ b/public/pages/Destinations/components/createDestinations/Email/Sender.js
@@ -160,8 +160,8 @@ const Sender = ({ sender, arrayHelpers, context, index, onDelete }) => {
           label: 'Encryption method',
           helpText: `SSL or TLS is recommended for security.
           SSL and TLS requires validation by adding the following fields to the Opensearch keystore:
-          opendistro.alerting.destination.email.${!name ? '[sender name]' : name}.username
-          opendistro.alerting.destination.email.${!name ? '[sender name]' : name}.password`,
+          plugins.alerting.destination.email.${!name ? '[sender name]' : name}.username
+          plugins.alerting.destination.email.${!name ? '[sender name]' : name}.password`,
           style: { padding: '10px 0px' },
         }}
         inputProps={{

--- a/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
+++ b/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
@@ -47,7 +47,7 @@ describe('DestinationsList', () => {
   test('renders', async () => {
     const mockSettings = {
       defaults: {
-        opendistro: {
+        plugins: {
           alerting: {
             destination: {
               allow_list: Object.values(DESTINATION_TYPE),
@@ -83,7 +83,7 @@ describe('DestinationsList', () => {
     const mockAllowList = ['chime', 'slack', 'custom_webhook'];
     const mockSettings = {
       defaults: {
-        opendistro: {
+        plugins: {
           alerting: {
             destination: {
               allow_list: mockAllowList,
@@ -120,7 +120,7 @@ describe('DestinationsList', () => {
   test('getDestinations', async () => {
     const mockSettings = {
       defaults: {
-        opendistro: {
+        plugins: {
           alerting: {
             destination: {
               allow_list: Object.values(DESTINATION_TYPE),

--- a/public/pages/Destinations/utils/constants.js
+++ b/public/pages/Destinations/utils/constants.js
@@ -38,4 +38,4 @@ export const DESTINATION_OPTIONS = [
   { value: DESTINATION_TYPE.EMAIL, text: 'Email' },
 ];
 
-export const ALLOW_LIST_SETTING_PATH = 'opendistro.alerting.destination.allow_list';
+export const ALLOW_LIST_SETTING_PATH = 'plugins.alerting.destination.allow_list';

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -65,7 +65,7 @@ export const DATA_TYPES = {
   KEYWORD: 'keyword',
 };
 
-export const ES_AD_PLUGIN = 'opensearch-anomaly-detection';
+export const OS_AD_PLUGIN = 'opensearch-anomaly-detection';
 export const OPENSEARCH_DASHBOARDS_AD_PLUGIN = 'anomaly-detection-dashboards';
 
 export const INPUTS_DETECTOR_ID = '0.search.query.query.bool.filter[1].term.detector_id.value';

--- a/server/services/utils/constants.js
+++ b/server/services/utils/constants.js
@@ -24,9 +24,9 @@
  *   permissions and limitations under the License.
  */
 
-export const API_ROUTE_PREFIX = '/_opendistro/_alerting';
+export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 export const MONITOR_BASE_API = `${API_ROUTE_PREFIX}/monitors`;
-export const AD_BASE_API = `/_opendistro/_anomaly_detection/detectors`;
+export const AD_BASE_API = `/_plugins/_anomaly_detection/detectors`;
 export const DESTINATION_BASE_API = `${API_ROUTE_PREFIX}/destinations`;
 export const EMAIL_ACCOUNT_BASE_API = `${DESTINATION_BASE_API}/email_accounts`;
 export const EMAIL_GROUP_BASE_API = `${DESTINATION_BASE_API}/email_groups`;

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -9,10 +9,10 @@
  * GitHub history for details.
  */
 
-export const OPEN_DISTRO_PREFIX = 'opendistro';
+export const OPEN_SEARCH_PREFIX = 'opendistro';
 
 export const PLUGIN_NAME = `alerting`;
-export const INDEX_PREFIX = `${OPEN_DISTRO_PREFIX}-alerting`;
+export const INDEX_PREFIX = `${OPEN_SEARCH_PREFIX}-alerting`;
 export const INDEX = {
   SCHEDULED_JOBS: `.${INDEX_PREFIX}-config`,
   ALERTS: `.${INDEX_PREFIX}-alerts`,

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -22,7 +22,7 @@ export const INDEX = {
 
 export const URL = {
   MUSTACHE: 'https://mustache.github.io/mustache.5.html',
-  DOCUMENTATION: 'https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/',
+  DOCUMENTATION: 'https://docs-beta.opensearch.org/docs/alerting/',
 };
 
 export const MAX_THROTTLE_VALUE = 1440;


### PR DESCRIPTION
### Description
* Updates the API calls to use the new `_plugins/` endpoint prefix in favor of the legacy `_opendistro/*` endpoint prefix.
* Updates the settings naming to use the new `plugins` prefix in favor of the legacy `opendistro` prefix.
* Updates the documentation links to point to the new home for docs: https://docs-beta.opensearch.org/

Performed local testing with cypress tests and end to end testing, which succeeded. Github workflow currently failing since Alerting github repso is not updated yet.
 
### Issues Resolved
#10 
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
