### PR TITLE
Remove validation constraints for characters used in the Date Math

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "brace": "0.11.1",
     "formik": "^2.2.5",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "query-string": "^6.13.2",
     "react-router-dom": "^5.2.0",
     "react-vis": "^1.8.1"

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -243,10 +243,11 @@ class MonitorIndex extends React.Component {
         fieldProps={{ validate: validateIndex }}
         rowProps={{
           label: 'Index',
-          helpText: 'You can use a * as a wildcard in your index pattern',
+          helpText:
+            'You can use a * as a wildcard or date math index resolution in your index pattern',
           isInvalid,
           error: hasError,
-          style: { paddingLeft: '10px' },
+          style: { paddingLeft: '10px', textAlign: 'center' },
         }}
         inputProps={{
           placeholder: 'Select indices',

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -92,11 +92,12 @@ exports[`MonitorIndex renders 1`] = `
       rowProps={
         Object {
           "error": [Function],
-          "helpText": "You can use a * as a wildcard in your index pattern",
+          "helpText": "You can use a * as a wildcard or date math index resolution in your index pattern",
           "isInvalid": [Function],
           "label": "Index",
           "style": Object {
             "paddingLeft": "10px",
+            "textAlign": "center",
           },
         }
       }
@@ -257,11 +258,12 @@ exports[`MonitorIndex renders 1`] = `
             rowProps={
               Object {
                 "error": [Function],
-                "helpText": "You can use a * as a wildcard in your index pattern",
+                "helpText": "You can use a * as a wildcard or date math index resolution in your index pattern",
                 "isInvalid": [Function],
                 "label": "Index",
                 "style": Object {
                   "paddingLeft": "10px",
+                  "textAlign": "center",
                 },
               }
             }
@@ -272,7 +274,7 @@ exports[`MonitorIndex renders 1`] = `
               fullWidth={false}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
-              helpText="You can use a * as a wildcard in your index pattern"
+              helpText="You can use a * as a wildcard or date math index resolution in your index pattern"
               id="index-form-row"
               isInvalid={false}
               label="Index"
@@ -280,6 +282,7 @@ exports[`MonitorIndex renders 1`] = `
               style={
                 Object {
                   "paddingLeft": "10px",
+                  "textAlign": "center",
                 }
               }
             >
@@ -289,6 +292,7 @@ exports[`MonitorIndex renders 1`] = `
                 style={
                   Object {
                     "paddingLeft": "10px",
+                    "textAlign": "center",
                   }
                 }
               >
@@ -717,7 +721,7 @@ exports[`MonitorIndex renders 1`] = `
                       className="euiFormHelpText euiFormRow__text"
                       id="index-form-row-help"
                     >
-                      You can use a * as a wildcard in your index pattern
+                      You can use a * as a wildcard or date math index resolution in your index pattern
                     </div>
                   </EuiFormHelpText>
                 </div>

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -101,7 +101,7 @@ export const validateMonthlyDay = (value) => {
     return 'Must be a positive integer between 1-31';
 };
 
-export const ILLEGAL_CHARACTERS = ['\\', '/', '?', '"', '<', '>', '|', ',', ' '];
+export const ILLEGAL_CHARACTERS = ['?', '"', ',', ' '];
 
 export const validateDetector = (detectorId, selectedDetector) => {
   if (!detectorId) return 'Must select detector';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,12 +2787,12 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.14, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.17.4:
+lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

### Description
This change removes the validation for characters which are used to define the index pattern to resolve the index date to a date.
 
### Issues Resolved
#17 https://github.com/opensearch-project/alerting/issues/74
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Documentation is in progress. 

After this change we will be able to define the indices:

<img width="420" alt="Screen Shot 2021-06-16 at 3 45 36 PM" src="https://user-images.githubusercontent.com/13850971/122304469-254d6480-ceba-11eb-8c11-dbcc013cdbe5.png">

Current date is 2021.06.16
<my-\{index\}-{now/d{yyyy.MM.dd|+12:00}}> resolves to my-{index}-2021.06.17
<my-index-{now/d}> resolves to my-index-2021.06.16 
