### PR TITLE
Update formik version that uses a good version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
-    "cypress": "^7.0.0",
+    "cypress": "^6.0.0",
     "husky": "^3.0.0",
     "lint-staged": "^9.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   "devDependencies": {
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
-    "cypress": "^6.0.0",
+    "cypress": "^7.0.0",
     "husky": "^3.0.0",
     "lint-staged": "^9.2.0"
   },
   "dependencies": {
     "brace": "0.11.1",
-    "formik": "^2.2.5",
+    "formik": "^2.2.6",
     "lodash": "^4.17.21",
     "query-string": "^6.13.2",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
### Description
Fix lodash dependency where formik uses lodash 4.17.20
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
