### PR TITLE
Show Error Toast Message whenever action execution fails from backend due to incorrect configurations

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -98,8 +98,7 @@ class ConfigureActions extends React.Component {
     }
   };
 
-  checkForError = (response) => {
-    let error =  null;
+  checkForError = (response, error) => {
     for (const trigger_name in response.resp.trigger_results) {
       // Check for errors in the trigger response
       if (!response.resp.trigger_results[trigger_name].error) {
@@ -111,7 +110,6 @@ class ConfigureActions extends React.Component {
         error = response.resp.trigger_results[trigger_name].error
       }
     }
-    console.log("Here is the Error Response", error)
     return error
   }
 
@@ -129,10 +127,14 @@ class ConfigureActions extends React.Component {
         query: { dryrun: false },
         body: JSON.stringify(testMonitor),
       });
-      const error = this.checkForError(response)
-      if (error) {
-        console.error('There was an error trying to send test message', error);
-        backendErrorNotification(notifications, 'send', 'test message', error);
+      let error = null
+      if (response.ok) {
+        error = this.checkForError(response, error)
+      }
+      if (error || !response.ok) {
+        const errorMessage = error==null ? response.resp : error
+        console.error('There was an error trying to send test message', errorMessage);
+        backendErrorNotification(notifications, 'send', 'test message', errorMessage);
       }
     } catch (err) {
       console.error('There was an error trying to send test message', err);

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -98,6 +98,23 @@ class ConfigureActions extends React.Component {
     }
   };
 
+  checkForError = (response) => {
+    let error =  null;
+    for (const trigger_name in response.resp.trigger_results) {
+      // Check for errors in the trigger response
+      if (!response.resp.trigger_results[trigger_name].error) {
+        // Check for errors in the actions configured
+        for (const action_result in response.resp.trigger_results[trigger_name].action_results) {
+          error = response.resp.trigger_results[trigger_name].action_results[action_result].error
+        }
+      } else {
+        error = response.resp.trigger_results[trigger_name].error
+      }
+    }
+    console.log("Here is the Error Response", error)
+    return error
+  }
+
   sendTestMessage = async (index) => {
     const {
       context: { monitor, trigger },
@@ -112,9 +129,10 @@ class ConfigureActions extends React.Component {
         query: { dryrun: false },
         body: JSON.stringify(testMonitor),
       });
-      if (!response.ok) {
-        console.error('There was an error trying to send test message', response.resp);
-        backendErrorNotification(notifications, 'send', 'test message', response.resp);
+      const error = this.checkForError(response)
+      if (error) {
+        console.error('There was an error trying to send test message', error);
+        backendErrorNotification(notifications, 'send', 'test message', error);
       }
     } catch (err) {
       console.error('There was an error trying to send test message', err);

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.test.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.test.js
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { checkForError } from './ConfigureActions';
+
+const error =
+  'java.io.IOException: Failed: HttpResponseProxy{HTTP/1.1 403 Forbidden [Content-Type: application/json, Content-Length: 82, Connection: keep-alive, Date: Fri, 02 Jul 2021 03:54:57 GMT, x-amzn-ErrorType: ForbiddenException';
+
+const noErrorInResponse = {
+  resp: {
+    monitor_name: 'TestMonitor',
+    period_start: 1625198037084,
+    period_end: 1625198097084,
+    error: null,
+    input_results: {
+      results: [],
+      error: null,
+    },
+    trigger_results: {
+      PgxaZXoB3e90jg4z8ga8: {
+        name: '',
+        triggered: true,
+        error: null,
+        action_results: {
+          PwxaZXoB3e90jg4z8ga8: {
+            id: 'PwxaZXoB3e90jg4z8ga8',
+            name: 'sdlkmdslfdsfds',
+            output: {},
+            throttled: false,
+            executionTime: 1625198097035,
+            error: null,
+          },
+        },
+      },
+    },
+  },
+};
+
+const errorInActionResponse = {
+  resp: {
+    monitor_name: 'TestMonitor',
+    period_start: 1625198037084,
+    period_end: 1625198097084,
+    error: null,
+    input_results: {
+      results: [],
+      error: null,
+    },
+    trigger_results: {
+      PgxaZXoB3e90jg4z8ga8: {
+        name: '',
+        triggered: true,
+        error: null,
+        action_results: {
+          PwxaZXoB3e90jg4z8ga8: {
+            id: 'PwxaZXoB3e90jg4z8ga8',
+            name: 'sdlkmdslfdsfds',
+            output: {},
+            throttled: false,
+            executionTime: 1625198097035,
+            error: error,
+          },
+        },
+      },
+    },
+  },
+};
+
+const errorInTriggerResponse = {
+  resp: {
+    monitor_name: 'TestMonitor',
+    period_start: 1625198037084,
+    period_end: 1625198097084,
+    error: null,
+    input_results: {
+      results: [],
+      error: null,
+    },
+    trigger_results: {
+      PgxaZXoB3e90jg4z8ga8: {
+        name: '',
+        triggered: true,
+        error: error,
+        action_results: {
+          PwxaZXoB3e90jg4z8ga8: {
+            id: 'PwxaZXoB3e90jg4z8ga8',
+            name: 'sdlkmdslfdsfds',
+            output: {},
+            throttled: false,
+            executionTime: 1625198097035,
+            error: null,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('checkForError', () => {
+  test('return no error in response', () => {
+    expect(checkForError(noErrorInResponse, null)).toBe(null);
+  });
+
+  test('return error in action response', () => {
+    expect(checkForError(errorInActionResponse, null)).toBe(error);
+  });
+
+  test('return error in trigger response', () => {
+    expect(checkForError(errorInTriggerResponse, null)).toBe(error);
+  });
+});


### PR DESCRIPTION

### Description

By design we don't throw an exception whenever we are not able to send an alert. We mark that alert in the error state and send that error as a part of the response of the monitor execution result. Since the monitor execution succeeds the response doesn't throw any error and in the [frontend code](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js#L116) we check for the response status of the request and not the status of the action (which is present in the response content). This results in the front end not showing an error for the action which was not executed.

This implementation is correct from the backend as the monitor execution succeeded and the action is marked in the error state. The problem lies in the front-end response parsing where we should check explicitly for the action response.

This PR addresses that and parses the response to specifically check
 
### Issues Resolved
https://github.com/opensearch-project/alerting/issues/100
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
  - [X] Added unit tests
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

Tested by providing an incorrectly configured Web-hook URL. The `Send Test Message` button shows an error toast message. 


<img width="1633" alt="Screen Shot 2021-06-30 at 3 38 06 PM" src="https://user-images.githubusercontent.com/13850971/124042527-dd503680-d9bd-11eb-9716-c53cf07ae8e0.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
