### PR TITLE
Fixed an issue preventing emails from being added to an email group using the Kibana interface.

### DIFF
--- a/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
+++ b/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
@@ -10,7 +10,7 @@
  */
 
 /*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").
  *   You may not use this file except in compliance with the License.
@@ -106,6 +106,7 @@ const EmailGroup = ({ emailGroup, emailOptions, arrayHelpers, context, index, on
             form.setFieldTouched(`emailGroups.${index}.emails`, true);
           },
           onCreateOption: (value, field, form) => {
+            onEmailGroupChange(index, emailGroup, arrayHelpers);
             onCreateOption(`emailGroups.${index}.emails`, value, field.value, form.setFieldValue);
           },
           isClearable: true,


### PR DESCRIPTION
Signed-off-by: Thomas Hurney [hurneyt@amazon.com](mailto:hurneyt@amazon.com)

### Description
The `emailGroup` `state` was not being changed to `updated` in `EmailGroup.js` which was preventing `ManageEmailGroups.js` from updating the group in the `processEmailGroups` method.

Added a call to `onEmailGroupChange` in the `onCreateOption` block in `EmailGroup.js`, allowing the `emailGroup`'s `state` to be changed when a new email is added to the input field. This allows the new emails to successfully be added to the group on the backend, as well as display as expected on the frontend.
 
### Issues Resolved
- [issue 91](https://github.com/opensearch-project/alerting/issues/91)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
