### PR TITLE
Added Export JSON button and modal to create/edit Monitor page

### DIFF
--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -27,7 +27,7 @@
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 
 export const INDEX = {
-  OPENSEARCH_ALERTING_CONFIG: '.opendistro-alerting-config',
+  OPENSEARCH_ALERTING_CONFIG: '.opensearch-alerting-config',
 };
 
 export const API = {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -35,6 +35,13 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiTitle,
+  EuiOverlayMask,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiCodeBlock,
+  EuiModalFooter,
 } from '@elastic/eui';
 
 import DefineMonitor from '../DefineMonitor';
@@ -77,6 +84,7 @@ export default class CreateMonitor extends Component {
       plugins: [],
       response: null,
       performanceResponse: null,
+      isJsonModalOpen: false,
     };
 
     if (this.props.edit && this.props.monitorToEdit) {
@@ -249,12 +257,20 @@ export default class CreateMonitor extends Component {
     this.props.history.push({ ...this.props.location, search: '' });
   };
 
+  showJsonModal = () => {
+    this.setState({ isJsonModalOpen: true });
+  }
+
+  closeJsonModal = () => {
+    this.setState({ isJsonModalOpen: false });
+  }
+
   componentWillUnmount() {
     this.props.setFlyout(null);
   }
 
   render() {
-    const { initialValues, plugins } = this.state;
+    const { initialValues, plugins, isJsonModalOpen } = this.state;
     const { edit, httpClient, monitorToEdit, notifications, isDarkMode } = this.props;
     return (
       <div style={{ padding: '25px 50px' }}>
@@ -313,6 +329,9 @@ export default class CreateMonitor extends Component {
                   <EuiButtonEmpty onClick={this.onCancel}>Cancel</EuiButtonEmpty>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
+                  <EuiButton onClick={this.showJsonModal}>Export as JSON</EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
                   <EuiButton fill onClick={handleSubmit} isLoading={isSubmitting}>
                     {edit ? 'Update' : 'Create'}
                   </EuiButton>
@@ -329,9 +348,30 @@ export default class CreateMonitor extends Component {
                   })
                 }
               />
+              { isJsonModalOpen && (
+                <EuiOverlayMask>
+                  <EuiModal onClose={this.closeJsonModal} style={{ padding: "5px 30px" }}>
+                    <EuiModalHeader>
+                      <EuiModalHeaderTitle>{"View JSON of " + values.name} </EuiModalHeaderTitle>
+                    </EuiModalHeader>
+
+                    <EuiModalBody>
+                      <EuiCodeBlock language="json" fontSize="m" paddingSize="m" overflowHeight={600} inline={false} isCopyable>
+                        {JSON.stringify(formikToMonitor(values))}
+                      </EuiCodeBlock>
+                    </EuiModalBody>
+
+                    <EuiModalFooter>
+                      <EuiButtonEmpty onClick={this.closeJsonModal}>Close</EuiButtonEmpty>
+                    </EuiModalFooter>
+                  </EuiModal>
+                </EuiOverlayMask>
+              )}
             </Fragment>
           )}
         </Formik>
+
+
       </div>
     );
   }

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-export const OPEN_SEARCH_PREFIX = 'opendistro';
+export const OPEN_SEARCH_PREFIX = 'opensearch';
 
 export const PLUGIN_NAME = `alerting`;
 export const INDEX_PREFIX = `${OPEN_SEARCH_PREFIX}-alerting`;


### PR DESCRIPTION
Signed-off-by: Eric Lobdell <lobdelle@amazon.com>

### Description
Adds Export as JSON button that presents modal like in Rollups and Transforms with JSON text of Monitor. Available on create and edit mode of page. 

![Screen Shot 2021-08-18 at 2 24 12 PM](https://user-images.githubusercontent.com/78931475/129975725-535cc494-59df-4685-82d3-b2f78e5f3c0f.png)
![Screen Shot 2021-08-18 at 2 24 30 PM](https://user-images.githubusercontent.com/78931475/129975742-6de6eaec-8110-46c1-9b3c-9e02a0779553.png)
 
### Check List
- [ ] New functionality includes testing. (Tests already out of date on destination branch and need major update outside the scope of this commit.)
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
