### PR TITLE
Added Monitor state EuiHealth element, replaced state item in overvie…

### DIFF
--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -28,7 +28,11 @@ import _ from 'lodash';
 import moment from 'moment-timezone';
 
 import getScheduleFromMonitor from './getScheduleFromMonitor';
-import { DEFAULT_EMPTY_DATA, SEARCH_TYPE } from '../../../../../utils/constants';
+import {
+   DEFAULT_EMPTY_DATA,
+   SEARCH_TYPE,
+   MONITOR_TYPE
+ } from '../../../../../utils/constants';
 
 // TODO: used in multiple places, move into helper
 export function getTime(time) {
@@ -49,12 +53,25 @@ function getMonitorType(searchType) {
   }
 }
 
+function getMonitorLevelType(monitorType) {
+  console.log(monitorType);
+  switch (monitorType) {
+    case  MONITOR_TYPE.QUERY_LEVEL:
+      return 'Per query monitor';
+    case MONITOR_TYPE.BUCKET_LEVEL:
+      return 'Per bucket monitor';
+    default:
+      return '-';
+  }
+}
+
 export default function getOverviewStats(monitor, monitorId, monitorVersion, activeCount) {
   const searchType = _.get(monitor, 'ui_metadata.search.searchType', 'query');
+  const monitorLevelType = _.get(monitor, 'ui_metadata.monitor_type', 'query_level_monitor');
   return [
     {
-      header: 'State',
-      value: monitor.enabled ? 'Enabled' : 'Disabled',
+      header: 'Monitor type',
+      value: getMonitorLevelType(monitorLevelType),
     },
     {
       header: 'Monitor definition type',

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -304,7 +304,7 @@ export default class MonitorDetails extends Component {
             {monitor.enabled ? (
               <EuiHealth color="success">Enabled</EuiHealth>
             ) : (
-              <EuiHealth color="danger">Disabled</EuiHealth>
+              <EuiHealth color="subdued">Disabled</EuiHealth>
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -38,6 +38,7 @@ import {
   EuiText,
   EuiTitle,
   EuiIcon,
+  EuiHealth,
 } from '@elastic/eui';
 
 import CreateMonitor from '../../CreateMonitor';
@@ -272,7 +273,7 @@ export default class MonitorDetails extends Component {
       <div style={{ padding: '25px 50px' }}>
         {this.renderNoTriggersCallOut()}
         <EuiFlexGroup alignItems="center">
-          <EuiFlexItem>
+          <EuiFlexItem grow={false}>
             <EuiTitle size="l" style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
               <h1
                 style={{
@@ -285,7 +286,6 @@ export default class MonitorDetails extends Component {
                 {monitor.name}
               </h1>
             </EuiTitle>
-
             {detector ? (
               <EuiFlexItem grow={false}>
                 <EuiText size="s">
@@ -300,7 +300,13 @@ export default class MonitorDetails extends Component {
               </EuiFlexItem>
             ) : null}
           </EuiFlexItem>
-
+          <EuiFlexItem>
+            {monitor.enabled ? (
+              <EuiHealth color="success">Enabled</EuiHealth>
+            ) : (
+              <EuiHealth color="danger">Disabled</EuiHealth>
+            )}
+          </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiButton
               onClick={() => {


### PR DESCRIPTION
…w with Monitor level type

Signed-off-by: Eric Lobdell <lobdelle@amazon.com>

### Description
Moves Monitor state to an icon next to the title. Replaces state display in overview with the Monitor level type, bucket level vs query level.

![Screen Shot 2021-08-19 at 10 29 28 AM](https://user-images.githubusercontent.com/78931475/130116089-0d28e9a4-bd1f-4667-8c96-c8adc9c7eaf6.png)

![Screen Shot 2021-08-19 at 10 28 41 AM](https://user-images.githubusercontent.com/78931475/130115957-fe15b20e-ab57-4b6c-bb5e-813f519664b2.png)
(Updated with new Disabled color)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
