### PR TITLE
Add Cypress tests for Bucket-Level Alerting

### DIFF
--- a/cypress/fixtures/sample_aggregation_query.json
+++ b/cypress/fixtures/sample_aggregation_query.json
@@ -1,0 +1,41 @@
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "order_date": {
+              "from": "{{period_end}}||-1h",
+              "to": "{{period_end}}",
+              "include_lower": true,
+              "include_upper": true,
+              "format": "epoch_millis",
+              "boost": 1.0
+            }
+          }
+        }
+      ],
+      "adjust_pure_negative": true,
+      "boost": 1.0
+    }
+  },
+  "aggregations": {
+    "composite_agg": {
+      "composite": {
+        "size": 10,
+        "sources": [
+          {
+            "user": {
+              "terms": {
+                "field": "user",
+                "missing_bucket": false,
+                "order": "asc"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cypress/fixtures/sample_extraction_query_bucket_level_monitor.json
+++ b/cypress/fixtures/sample_extraction_query_bucket_level_monitor.json
@@ -1,0 +1,63 @@
+{
+  "name": "sample_extraction_query_bucket_level_monitor",
+  "monitor_type": "bucket_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [
+    {
+      "search": {
+        "indices": ["*"],
+        "query": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "range": {
+                    "order_date": {
+                      "from": "{{period_end}}||-1h",
+                      "to": "{{period_end}}",
+                      "include_lower": true,
+                      "include_upper": true,
+                      "format": "epoch_millis",
+                      "boost": 1.0
+                    }
+                  }
+                }
+              ],
+              "adjust_pure_negative": true,
+              "boost": 1.0
+            }
+          },
+          "aggregations": {
+            "composite_agg": {
+              "composite": {
+                "size": 10,
+                "sources": [
+                  {
+                    "user": {
+                      "terms": {
+                        "field": "user",
+                        "missing_bucket": false,
+                        "order": "asc"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "triggers": [],
+  "ui_metadata": {
+    "schedule": {}
+  }
+}

--- a/cypress/fixtures/sample_query_level_monitor.json
+++ b/cypress/fixtures/sample_query_level_monitor.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample_monitor",
+  "name": "sample_query_level_monitor",
   "enabled": true,
   "schedule": {
     "period": {

--- a/cypress/fixtures/sample_query_level_monitor_with_always_true_trigger.json
+++ b/cypress/fixtures/sample_query_level_monitor_with_always_true_trigger.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample_monitor_with_always_true_trigger",
+  "name": "sample_query_level_monitor_with_always_true_trigger",
   "enabled": true,
   "schedule": {
     "period": {

--- a/cypress/fixtures/sample_query_level_monitor_workflow.json
+++ b/cypress/fixtures/sample_query_level_monitor_workflow.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample_monitor_workflow",
+  "name": "sample_query_level_monitor_workflow",
   "enabled": true,
   "schedule": {
     "period": {

--- a/cypress/fixtures/sample_visual_editor_bucket_level_monitor.json
+++ b/cypress/fixtures/sample_visual_editor_bucket_level_monitor.json
@@ -1,0 +1,127 @@
+{
+  "name": "sample_visual_editor_bucket_level_monitor",
+  "monitor_type": "bucket_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [
+    {
+      "search": {
+        "indices": ["*"],
+        "query": {
+          "size": 0,
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "range": {
+                    "order_date": {
+                      "from": "{{period_end}}||-1h",
+                      "to": "{{period_end}}",
+                      "include_lower": true,
+                      "include_upper": true,
+                      "format": "epoch_millis",
+                      "boost": 1.0
+                    }
+                  }
+                }
+              ],
+              "adjust_pure_negative": true,
+              "boost": 1.0
+            }
+          },
+          "aggregations": {
+            "composite_agg": {
+              "composite": {
+                "size": 10,
+                "sources": [
+                  {
+                    "user": {
+                      "terms": {
+                        "field": "user",
+                        "missing_bucket": false,
+                        "order": "asc"
+                      }
+                    }
+                  }
+                ]
+              },
+              "aggregations": {
+                "count_products_quantity": {
+                  "value_count": {
+                    "field": "products.quantity"
+                  }
+                },
+                "avg_products_base_price": {
+                  "avg": {
+                    "field": "products.base_price"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "triggers": [],
+  "ui_metadata": {
+    "schedule": {
+      "cronExpression": "0 */1 * * *",
+      "period": {
+        "unit": "MINUTES",
+        "interval": 1
+      },
+      "timezone": null,
+      "daily": 0,
+      "monthly": {
+        "type": "day",
+        "day": 1
+      },
+      "weekly": {
+        "tue": false,
+        "wed": false,
+        "thur": false,
+        "sat": false,
+        "fri": false,
+        "mon": false,
+        "sun": false
+      },
+      "frequency": "interval"
+    },
+    "search": {
+      "aggregationType": "avg",
+      "fieldName": "products.base_price",
+      "overDocuments": "all documents",
+      "searchType": "graph",
+      "bucketValue": 1,
+      "timeField": "order_date",
+      "groupedOverTop": 5,
+      "bucketUnitOfTime": "h",
+      "where": {
+        "fieldName": [],
+        "fieldRangeEnd": 0,
+        "fieldRangeStart": 0,
+        "fieldValue": "",
+        "operator": "is"
+      },
+      "groupBy": ["user"],
+      "aggregations": [
+        {
+          "aggregationType": "count",
+          "fieldName": "products.quantity"
+        },
+        {
+          "aggregationType": "avg",
+          "fieldName": "products.base_price"
+        }
+      ],
+      "groupedOverFieldName": "bytes"
+    },
+    "monitor_type": "bucket_level_monitor"
+  }
+}

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -25,8 +25,8 @@
  */
 
 import { PLUGIN_NAME } from '../support/constants';
-import sampleMonitorWithAlwaysTrueTrigger from '../fixtures/sample_monitor_with_always_true_trigger';
-import sampleMonitorWorkflow from '../fixtures/sample_monitor_workflow';
+import sampleQueryLevelMonitorWithAlwaysTrueTrigger from '../fixtures/sample_query_level_monitor_with_always_true_trigger';
+import sampleQueryLevelMonitorWorkflow from '../fixtures/sample_query_level_monitor_workflow';
 
 const TESTING_INDEX = 'alerting_test';
 
@@ -48,8 +48,8 @@ describe('Alerts', () => {
       // Generate a unique number in every test by getting a unix timestamp in milliseconds
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
-      sampleMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
-      cy.createMonitor(sampleMonitorWithAlwaysTrueTrigger);
+      sampleQueryLevelMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
+      cy.createMonitor(sampleQueryLevelMonitorWithAlwaysTrueTrigger);
     });
 
     it('after the monitor starts running', () => {
@@ -77,8 +77,8 @@ describe('Alerts', () => {
       cy.deleteAllMonitors();
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
-      sampleMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
-      cy.createAndExecuteMonitor(sampleMonitorWithAlwaysTrueTrigger);
+      sampleQueryLevelMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
+      cy.createAndExecuteMonitor(sampleQueryLevelMonitorWithAlwaysTrueTrigger);
     });
 
     it('by clicking the button in Dashboard', () => {
@@ -109,8 +109,8 @@ describe('Alerts', () => {
       cy.deleteIndexByName('alerting*');
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
-      sampleMonitorWorkflow.name += `-${Cypress.config('unique_number')}`;
-      cy.createAndExecuteMonitor(sampleMonitorWorkflow);
+      sampleQueryLevelMonitorWorkflow.name += `-${Cypress.config('unique_number')}`;
+      cy.createAndExecuteMonitor(sampleQueryLevelMonitorWorkflow);
     });
 
     it('when the trigger condition is not met after met once', () => {
@@ -155,13 +155,13 @@ describe('Alerts', () => {
     before(() => {
       cy.deleteAllMonitors();
       // modify the JSON object to make an error alert when executing the monitor
-      sampleMonitorWithAlwaysTrueTrigger.triggers[0].actions = [
+      sampleQueryLevelMonitorWithAlwaysTrueTrigger.triggers[0].actions = [
         { name: '', destination_id: '', message_template: { source: '' } },
       ];
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
-      sampleMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
-      cy.createAndExecuteMonitor(sampleMonitorWithAlwaysTrueTrigger);
+      sampleQueryLevelMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
+      cy.createAndExecuteMonitor(sampleQueryLevelMonitorWithAlwaysTrueTrigger);
     });
 
     it('by using a wrong destination', () => {
@@ -180,8 +180,8 @@ describe('Alerts', () => {
       cy.deleteAllMonitors();
       Cypress.config('unique_number', `${Date.now()}`);
       // Modify the monitor name to be unique
-      sampleMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
-      cy.createAndExecuteMonitor(sampleMonitorWithAlwaysTrueTrigger);
+      sampleQueryLevelMonitorWithAlwaysTrueTrigger.name += `-${Cypress.config('unique_number')}`;
+      cy.createAndExecuteMonitor(sampleQueryLevelMonitorWithAlwaysTrueTrigger);
     });
 
     it('by deleting the monitor', () => {

--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -1,0 +1,313 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { INDEX, PLUGIN_NAME } from '../support/constants';
+import sampleAggregationQuery from '../fixtures/sample_aggregation_query';
+import sampleDestination from '../fixtures/sample_destination_custom_webhook';
+import sampleExtractionQueryMonitor from '../fixtures/sample_extraction_query_bucket_level_monitor';
+import sampleVisualEditorMonitor from '../fixtures/sample_visual_editor_bucket_level_monitor';
+
+const SAMPLE_EXTRACTION_QUERY_MONITOR = 'sample_extraction_query_bucket_level_monitor';
+const SAMPLE_VISUAL_EDITOR_MONITOR = 'sample_visual_editor_bucket_level_monitor';
+const UPDATED_MONITOR = 'updated_bucket_level_monitor';
+const SAMPLE_TRIGGER = 'sample_trigger';
+const SAMPLE_ACTION = 'sample_action';
+
+const TIME_FIELD = 'order_date';
+const COUNT_METRIC_FIELD = 'products.quantity';
+const AVERAGE_METRIC_FIELD = 'products.base_price';
+const GROUP_BY_FIELD = 'user';
+const COUNT_METRIC_NAME = 'count_products_quantity';
+const AVERAGE_METRIC_NAME = 'avg_products_base_price';
+
+const addTriggerToVisualEditorMonitor = (triggerName, triggerIndex, actionName, isEdit) => {
+  // Add a trigger
+  cy.contains('Add trigger').click({ force: true });
+
+  // If the monitor is being edited, the trigger accordion will be closed by default
+  // In this case, click on the accordion to open it before proceeding
+  if (isEdit === true) {
+    // TODO: Passing button props in EUI accordion was added in newer versions (31.7.0+).
+    //  If this ever becomes available, it can be used to pass data-test-subj for the button.
+    // Since the above is currently not possible, referring to the accordion button using its content
+    cy.get('button').contains('New trigger').click();
+  }
+
+  // Type in the trigger name
+  cy.get(`input[name="triggerDefinitions[${triggerIndex}].name"]`).type(triggerName);
+
+  // Edit the first metric condition for the trigger
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[0].queryMetric"]`).select(
+    `${AVERAGE_METRIC_NAME}`
+  );
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[0].thresholdValue"]`)
+    .clear()
+    .type('200');
+
+  // Add another metric condition for the trigger
+  cy.get('[data-test-subj="addTriggerConditionButton"]').click();
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[1].andOrCondition"]`).select(
+    'OR'
+  );
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[1].queryMetric"]`).select(
+    `${COUNT_METRIC_NAME}`
+  );
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[1].thresholdEnum"]`).select(
+    'IS BELOW'
+  );
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[1].thresholdValue"]`)
+    .clear()
+    .type('300');
+
+  // Add a trigger where filter
+  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].where.addFilterButton"]`).click();
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.fieldName"]`).type(
+    `${GROUP_BY_FIELD}{downarrow}{enter}`
+  );
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.operator"]`).select('includes');
+
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.fieldValue"]`)
+    .type('a*')
+    .trigger('blur', { force: true });
+
+  // Type in the action name
+  cy.get(`input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`).type(actionName, {
+    force: true,
+  });
+
+  // Click the combo box to list all the destinations
+  // Using key typing instead of clicking the menu option to avoid occasional failure
+  cy.get(`div[name="triggerDefinitions[${triggerIndex}].actions.0.destination_id"]`)
+    .click({ force: true })
+    .type('{downarrow}{enter}');
+};
+
+describe('Bucket-Level Monitors', () => {
+  before(() => {
+    cy.createDestination(sampleDestination);
+
+    // Load sample data
+    cy.loadSampleEcommerceData();
+  });
+
+  beforeEach(() => {
+    // Set welcome screen tracking to false
+    localStorage.setItem('home:welcome:show', 'false');
+
+    // Visit Alerting OpenSearch Dashboards
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/monitors`);
+
+    // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
+    cy.contains('Create monitor', { timeout: 20000 });
+  });
+
+  describe('can be created', () => {
+    beforeEach(() => {
+      cy.deleteAllMonitors();
+      cy.reload();
+    });
+
+    it('by extraction query', () => {
+      // Confirm empty monitor list is loaded
+      cy.contains('There are no existing monitors');
+
+      // Go to create monitor page
+      cy.contains('Create monitor').click();
+
+      // Select the Bucket-Level Monitor type
+      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click();
+
+      // Select extraction query for method of definition
+      cy.get('[data-test-subj="extractionQueryEditorRadioCard"]').click();
+
+      // Wait for input to load and then type in the monitor name
+      cy.get('input[name="name"]').type(SAMPLE_EXTRACTION_QUERY_MONITOR);
+
+      // Wait for input to load and then type in the index name
+      cy.get('#index').type('*{enter}', { force: true });
+
+      // Input extraction query
+      cy.get('[data-test-subj="extractionQueryCodeEditor"]').within(() => {
+        // If possible, a data-test-subj attribute should be added to access the code editor input directly
+        cy.get('.ace_text-input')
+          .clear({ force: true })
+          .type(JSON.stringify(sampleAggregationQuery), {
+            force: true,
+            parseSpecialCharSequences: false,
+            delay: 5,
+            timeout: 20000,
+          })
+          .trigger('blur', { force: true });
+      });
+
+      // Add a trigger
+      cy.contains('Add trigger').click({ force: true });
+
+      // Type in the trigger name
+      cy.get('input[name="triggerDefinitions[0].name"]').type(SAMPLE_TRIGGER);
+
+      // Type in the action name
+      cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
+
+      // Click the combo box to list all the destinations
+      // Using key typing instead of clicking the menu option to avoid occasional failure
+      cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
+        .click({ force: true })
+        .type('{downarrow}{enter}');
+
+      // Click the create button
+      cy.get('button').contains('Create').click();
+
+      // Confirm we can see only one row in the trigger list by checking <caption> element
+      cy.contains('This table contains 1 row');
+
+      // Confirm we can see the new trigger
+      cy.contains(SAMPLE_TRIGGER);
+
+      // Go back to the Monitors list
+      cy.get('a').contains('Monitors').click();
+
+      // Confirm we can see the created monitor in the list
+      cy.contains(SAMPLE_EXTRACTION_QUERY_MONITOR);
+    });
+
+    it('by visual editor', () => {
+      // Confirm empty monitor list is loaded
+      cy.contains('There are no existing monitors');
+
+      // Go to create monitor page
+      cy.contains('Create monitor').click();
+
+      // Select the Bucket-Level Monitor type
+      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click();
+
+      // Select visual editor for method of definition
+      cy.get('[data-test-subj="visualEditorRadioCard"]').click();
+
+      // Wait for input to load and then type in the monitor name
+      cy.get('input[name="name"]').type(SAMPLE_VISUAL_EDITOR_MONITOR);
+
+      // Wait for input to load and then type in the index name
+      // Pressing enter at the end to create combo box entry and trigger change events for time field below
+      cy.get('#index').type(`${INDEX.SAMPLE_DATA_ECOMMERCE}{enter}`, { force: true });
+
+      // Select 'order_date' as the timeField for the data source index
+      cy.get('#timeField').select(`${TIME_FIELD}`);
+
+      // Add a metric for the query
+      cy.get('[data-test-subj="addMetricButton"]').click();
+
+      cy.get('[data-test-subj="metrics.0.aggregationTypeSelect"]').select('count');
+
+      cy.get('[data-test-subj="metrics.0.ofFieldComboBox"]').type(
+        `${COUNT_METRIC_FIELD}{downArrow}{enter}`
+      );
+
+      cy.get('button').contains('Save').click();
+
+      // Add a second metric for the query
+      cy.get('[data-test-subj="addMetricButton"]').click();
+
+      cy.get('[data-test-subj="metrics.1.aggregationTypeSelect"]').select('avg');
+
+      cy.get('[data-test-subj="metrics.1.ofFieldComboBox"]').type(
+        `${AVERAGE_METRIC_FIELD}{downArrow}{enter}`
+      );
+
+      cy.get('button').contains('Save').click();
+
+      // Add a group by field for the query
+      cy.get('[data-test-subj="addGroupByButton"]').click();
+
+      cy.get('[data-test-subj="groupBy.0.ofFieldComboBox"]').type(
+        `${GROUP_BY_FIELD}{downArrow}{enter}`
+      );
+
+      cy.get('button').contains('Save').click();
+
+      // Add trigger
+      addTriggerToVisualEditorMonitor(SAMPLE_TRIGGER, 0, SAMPLE_ACTION, false);
+
+      // Click the create button
+      cy.get('button').contains('Create').click();
+
+      // Confirm we can see only one row in the trigger list by checking <caption> element
+      cy.contains('This table contains 1 row');
+
+      // Confirm we can see the new trigger
+      cy.contains(SAMPLE_TRIGGER);
+
+      // Go back to the Monitors list
+      cy.get('a').contains('Monitors').click({ force: true });
+
+      // Confirm we can see the created monitor in the list
+      cy.contains(SAMPLE_VISUAL_EDITOR_MONITOR);
+    });
+  });
+
+  describe('can be updated', () => {
+    beforeEach(() => {
+      cy.deleteAllMonitors();
+    });
+
+    describe('when defined by extraction query', () => {
+      beforeEach(() => {
+        cy.createMonitor(sampleExtractionQueryMonitor);
+      });
+
+      // by adding trigger
+      it('by adding trigger', () => {});
+    });
+
+    describe('when defined by visual editor', () => {
+      beforeEach(() => {
+        cy.createMonitor(sampleVisualEditorMonitor);
+        cy.reload();
+      });
+
+      it('by adding trigger', () => {
+        // Confirm the created monitor can be seen
+        cy.contains(SAMPLE_VISUAL_EDITOR_MONITOR);
+
+        // Select the monitor
+        cy.get('a').contains(SAMPLE_VISUAL_EDITOR_MONITOR).click({ force: true });
+
+        // Click Edit button
+        cy.contains('Edit').click({ force: true });
+
+        // Add a trigger
+        addTriggerToVisualEditorMonitor(SAMPLE_TRIGGER, 0, SAMPLE_ACTION, true);
+
+        // Click update button to save monitor changes
+        cy.get('button').contains('Update').last().click({ force: true });
+
+        // Confirm we can see only one row in the trigger list by checking <caption> element
+        cy.contains('This table contains 1 row');
+      });
+    });
+  });
+
+  after(() => {
+    // Delete all monitors and destinations
+    cy.deleteAllMonitors();
+    cy.deleteAllDestinations();
+
+    // Delete sample data
+    cy.deleteIndexByName(`${INDEX.SAMPLE_DATA_ECOMMERCE}`);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -189,3 +189,11 @@ Cypress.Commands.add('deleteIndexByName', (indexName) => {
 Cypress.Commands.add('insertDocumentToIndex', (indexName, documentId, documentBody) => {
   cy.request('PUT', `${Cypress.env('opensearch')}/${indexName}/_doc/${documentId}`, documentBody);
 });
+
+Cypress.Commands.add('loadSampleEcommerceData', () => {
+  cy.request({
+    method: 'POST',
+    headers: { 'osd-xsrf': 'opensearch-dashboards' },
+    url: `${Cypress.env('opensearch_dashboards')}/api/sample_data/ecommerce`,
+  });
+});

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -27,7 +27,8 @@
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 
 export const INDEX = {
-  OPENSEARCH_ALERTING_CONFIG: '.opensearch-alerting-config',
+  OPENSEARCH_ALERTING_CONFIG: '.opendistro-alerting-config',
+  SAMPLE_DATA_ECOMMERCE: 'opensearch_dashboards_sample_data_ecommerce',
 };
 
 export const API = {

--- a/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.js
+++ b/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.js
@@ -58,6 +58,7 @@ const ExtractionQuery = ({ isDarkMode, response }) => (
           onBlur: (e, field, form) => {
             form.setFieldTouched('query', true);
           },
+          'data-test-subj': 'extractionQueryCodeEditor',
         }}
       />
     </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCards/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCards/MonitorDefinitionCard.js
@@ -59,6 +59,7 @@ const MonitorDefinitionCard = ({ values, resetResponse, plugins }) => {
               onChange: (e, field, form) => {
                 onChangeDefinition(e, form);
               },
+              'data-test-subj': 'visualEditorRadioCard',
             }}
           />
         </EuiFlexItem>
@@ -75,6 +76,7 @@ const MonitorDefinitionCard = ({ values, resetResponse, plugins }) => {
               onChange: (e, field, form) => {
                 onChangeDefinition(e, form);
               },
+              'data-test-subj': 'extractionQueryEditorRadioCard',
             }}
           />
         </EuiFlexItem>
@@ -92,6 +94,7 @@ const MonitorDefinitionCard = ({ values, resetResponse, plugins }) => {
                 onChange: (e, field, form) => {
                   onChangeDefinition(e, form);
                 },
+                'data-test-subj': 'anomalyDetectorRadioCard',
               }}
             />
           </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
@@ -82,7 +82,7 @@ export default function GroupByPopover(
               onChange: onChangeFieldWrapper,
               isClearable: false,
               singleSelection: { asPlainText: true },
-              'data-test-subj': 'ofFieldComboBox',
+              'data-test-subj': `groupBy.${index}.ofFieldComboBox`,
             }}
           />
         </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
@@ -76,6 +76,7 @@ export default function MetricPopover(
                 inputProps={{
                   onChange: onChangeWrapper,
                   options: AGGREGATION_TYPES,
+                  'data-test-subj': `metrics.${index}.aggregationTypeSelect`,
                 }}
               />
             </EuiFlexItem>
@@ -99,7 +100,7 @@ export default function MetricPopover(
                   onChange: onChangeFieldWrapper,
                   isClearable: false,
                   singleSelection: { asPlainText: true },
-                  'data-test-subj': 'ofFieldComboBox',
+                  'data-test-subj': `metrics.${index}.ofFieldComboBox`,
                 }}
               />
             </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -303,7 +303,7 @@ class WhereExpression extends Component {
         {showAddButtonFlag && (
           <EuiButtonEmpty
             size="xs"
-            data-test-subj="addFilterButton"
+            data-test-subj={`${fieldPath}where.addFilterButton`}
             onClick={() => openExpression(Expressions.WHERE)}
           >
             + Add filter

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -75,6 +75,7 @@ const MonitorType = ({ values }) => (
             onChangeDefinition(e, form);
           },
           children: queryLevelDescription,
+          'data-test-subj': 'queryLevelMonitorRadioCard',
         }}
       />
     </EuiFlexItem>
@@ -97,6 +98,7 @@ const MonitorType = ({ values }) => (
             onChangeDefinition(e, form);
           },
           children: bucketLevelDescription,
+          'data-test-subj': 'bucketLevelMonitorRadioCard',
         }}
       />
     </EuiFlexItem>

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.js
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.js
@@ -23,6 +23,7 @@ const AddTriggerConditionButton = ({ arrayHelpers, disabled }) => {
     <EuiButtonEmpty
       onClick={() => arrayHelpers.push(_.cloneDeep(FORMIK_INITIAL_TRIGGER_CONDITION_VALUES))}
       disabled={disabled}
+      data-test-subj="addTriggerConditionButton"
     >
       + Add condition
     </EuiButtonEmpty>


### PR DESCRIPTION
Added Cypress tests for Bucket-Level Alerting.

The tests were passing right before I rebased from `bucket-level-alerting-dev` but some are failing now. It looks like there was a regression in Monitor creation and Destination deletion flow and was not a false positive from the tests so I'm merging in these tests to help debug the issue.
