### PR TITLE
Refactored query and bucket-level trigger definitions to align with new mocks

### DIFF
--- a/public/pages/CreateMonitor/components/MonitorDefinitionCards/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCards/MonitorDefinitionCard.js
@@ -64,8 +64,8 @@ const MonitorDefinitionCard = ({ values, resetResponse, plugins }) => {
             }}
           />
         </EuiFlexItem>
-        {/* TODO: only show the anomaly detector option when anomaly detection plugin is present */}
-        {hasADPlugin && (
+        {/*// Only show the anomaly detector option when anomaly detection plugin is present, but not for bucket-level monitors.*/}
+        {hasADPlugin && !isBucketLevelMonitor && (
           <EuiFlexItem>
             <EuiSpacer />
             <FormikCheckableCard

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -33,7 +33,6 @@ import {
   EuiPopover,
   EuiButtonEmpty,
   EuiText,
-  EuiSpacer,
   EuiBadge,
 } from '@elastic/eui';
 import _ from 'lodash';
@@ -228,7 +227,6 @@ class WhereExpression extends Component {
         <EuiText size="xs">
           <h4>{whereFilterHeader}</h4>
         </EuiText>
-        <EuiSpacer size="s" />
         <EuiBadge
           iconSide="right"
           iconType="cross"

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -10,13 +10,18 @@
  */
 
 import React from 'react';
+import _ from 'lodash';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import FormikCheckableCard from '../../../../components/FormControls/FormikCheckableCard';
-import { MONITOR_TYPE } from '../../../../utils/constants';
+import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../utils/constants';
+import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../../CreateTrigger/containers/CreateTrigger/utils/constants';
 
 const onChangeDefinition = (e, form) => {
   const type = e.target.value;
   form.setFieldValue('monitor_type', type);
+
+  // Clearing trigger definitions when changing monitor types.
+  form.setFieldValue('triggerDefinitions', FORMIK_INITIAL_TRIGGER_VALUES.triggerConditions);
 };
 
 const MonitorType = ({ values }) => (
@@ -56,6 +61,11 @@ const MonitorType = ({ values }) => (
             checked: values.monitor_type === MONITOR_TYPE.BUCKET_LEVEL,
             value: MONITOR_TYPE.BUCKET_LEVEL,
             onChange: (e, field, form) => {
+              const searchType = _.get(values, 'searchType');
+              // Setting search type to graph when changing monitor type from query-level to bucket-level,
+              // and the search type is not supported by bucket-level monitors.
+              if (searchType !== SEARCH_TYPE.GRAPH || searchType !== SEARCH_TYPE.QUERY)
+                form.setFieldValue('searchType', SEARCH_TYPE.GRAPH);
               onChangeDefinition(e, form);
             },
           }}

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectorData.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectorData.js
@@ -49,8 +49,15 @@ class AnomalyDetectorData extends React.Component {
     };
     this.getPreviewData = this.getPreviewData.bind(this);
   }
+
   async componentDidMount() {
     await this.getPreviewData();
+  }
+
+  async componentDidUpdate(prevProps) {
+    if (prevProps.detectorId !== this.props.detectorId) {
+      await this.getPreviewData();
+    }
   }
 
   async getPreviewData() {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -52,8 +52,6 @@ export function formikToMonitor(values) {
 
 export function formikToInputs(values) {
   switch (values.searchType) {
-    case SEARCH_TYPE.AD:
-      return formikToAd(values);
     default:
       return formikToSearch(values);
   }

--- a/public/pages/CreateTrigger/components/Action/Action.js
+++ b/public/pages/CreateTrigger/components/Action/Action.js
@@ -77,9 +77,10 @@ const Action = ({
               Remove action
             </EuiButton>
           }
+          paddingSize={'s'}
         >
           <EuiHorizontalRule margin="s" />
-          <div>
+          <div style={{ paddingTop: '10px' }}>
             <FormikFieldText
               name={`${fieldPath}actions.${index}.name`}
               formRow

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.js
@@ -38,6 +38,12 @@ const AND_OR_CONDITION_OPTIONS = [
   { value: 'OR', text: 'OR' },
 ];
 
+const GUTTER_WIDTH = 16;
+const AND_OR_FIELD_WIDTH = 90;
+const METRIC_FIELD_WIDTH = 300;
+const THRESHOLD_FIELD_WIDTH = 200;
+const VALUE_FIELD_WIDTH = 200;
+
 class BucketLevelTriggerExpression extends Component {
   constructor(props) {
     super(props);
@@ -73,7 +79,7 @@ class BucketLevelTriggerExpression extends Component {
     return (
       <EuiFlexGroup
         style={{
-          maxWidth: 1000,
+          maxWidth: 1200,
           paddingLeft: '10px',
           paddingTop: '10px',
           whiteSpace: 'nowrap',
@@ -82,7 +88,7 @@ class BucketLevelTriggerExpression extends Component {
         alignItems={'flexStart'}
       >
         {!isFirstCondition ? (
-          <EuiFlexItem grow={false} style={{ width: 90 }}>
+          <EuiFlexItem grow={false} style={{ width: `${AND_OR_FIELD_WIDTH}px` }}>
             <Field name={andOrConditionFieldName}>
               {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
                 <EuiFormRow
@@ -96,7 +102,14 @@ class BucketLevelTriggerExpression extends Component {
           </EuiFlexItem>
         ) : null}
 
-        <EuiFlexItem grow={true} style={{ minWidth: 300, maxWidth: 495 }}>
+        <EuiFlexItem
+          grow={false}
+          style={{
+            minWidth: isFirstCondition
+              ? `${METRIC_FIELD_WIDTH + AND_OR_FIELD_WIDTH + GUTTER_WIDTH}px`
+              : `${METRIC_FIELD_WIDTH}px`,
+          }}
+        >
           <Field name={queryMetricFieldName} fullWidth={true}>
             {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
               <EuiFormRow
@@ -111,10 +124,11 @@ class BucketLevelTriggerExpression extends Component {
           </Field>
         </EuiFlexItem>
 
-        <EuiFlexItem grow={false} style={{ maxWidth: 200 }}>
-          <Field name={enumFieldName}>
+        <EuiFlexItem grow={false} style={{ width: `${THRESHOLD_FIELD_WIDTH}px` }}>
+          <Field name={enumFieldName} fullWidth={true}>
             {({ field: { onBlur, ...rest }, form: { touched, errors } }) => (
               <EuiFormRow
+                fullWidth={true}
                 label={isFirstCondition ? 'Threshold' : null}
                 isInvalid={touched.thresholdEnum && !!errors.thresholdEnum}
                 error={errors.thresholdEnum}
@@ -125,7 +139,7 @@ class BucketLevelTriggerExpression extends Component {
           </Field>
         </EuiFlexItem>
 
-        <EuiFlexItem grow={false} style={{ maxWidth: 200 }}>
+        <EuiFlexItem grow={false} style={{ width: `${VALUE_FIELD_WIDTH}px` }}>
           <Field name={valueFieldName}>
             {({ field, form: { touched, errors } }) => (
               <EuiFormRow
@@ -138,7 +152,6 @@ class BucketLevelTriggerExpression extends Component {
             )}
           </Field>
         </EuiFlexItem>
-
         {!isFirstCondition ? (
           <EuiFlexItem grow={false}>
             <EuiButton

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { EuiSpacer } from '@elastic/eui';
 import BucketLevelTriggerExpression from './BucketLevelTriggerExpression';
 import {
   DEFAULT_AND_OR_CONDITION,
@@ -49,7 +48,7 @@ const BucketLevelTriggerGraph = ({
   const thresholdValue = _.get(triggerValues, `${fieldNamePath}thresholdValue`);
 
   return (
-    <div style={{ padding: '0px 10px' }}>
+    <div style={{ padding: '0px 10px', paddingBottom: '20px' }}>
       <BucketLevelTriggerExpression
         arrayHelpers={arrayHelpers}
         index={index}
@@ -64,7 +63,6 @@ const BucketLevelTriggerGraph = ({
         valueFieldName={`${fieldNamePath}thresholdValue`}
         label="Trigger conditions"
       />
-      <EuiSpacer size={'s'} />
       {/*TODO: Implement VisualGraph illustrating the trigger expression similar to the implementation in TriggerGraph.js*/}
     </div>
   );

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
@@ -35,6 +35,7 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiLink,
+  EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import 'brace/mode/json';
@@ -57,20 +58,42 @@ export const getExecuteMessage = (response) => {
 
 const TriggerQuery = ({
   context,
+  error,
   executeResponse,
   onRun,
+  response,
   triggerValues,
   setFlyout,
   isDarkMode,
   fieldPath,
+  isAd = false,
 }) => {
   const currentTrigger = _.isEmpty(fieldPath)
     ? triggerValues
     : _.get(triggerValues, `${fieldPath.slice(0, -1)}`, {});
   const trigger = { ...formikToTrigger(currentTrigger), actions: [] };
+  const responseToFormat = _.isEmpty(response) && isAd ? onRun([trigger]) : response;
+  const formattedResponse = JSON.stringify(responseToFormat, null, 4);
   const fieldName = `${fieldPath}script.source`;
   return (
     <div style={{ padding: '0px 10px', marginTop: '0px' }}>
+      {isAd ? (
+        <div>
+          <EuiSpacer size={'s'} />
+          <EuiFormRow label="Response">
+            <EuiCodeEditor
+              mode="json"
+              theme={isDarkMode ? 'sense-dark' : 'github'}
+              height="300px"
+              width="90%"
+              value={error || formattedResponse}
+              readOnly
+            />
+          </EuiFormRow>
+          <EuiSpacer size={'l'} />
+        </div>
+      ) : null}
+
       <EuiFlexGrid columns={2} gutterSize={'s'}>
         {/*// Grid slot for the trigger definition code editor header*/}
         <EuiFlexItem>
@@ -98,7 +121,7 @@ const TriggerQuery = ({
         <EuiFlexItem>
           <EuiFlexGroup alignItems={'center'} gutterSize={'none'}>
             <EuiText size={'s'}>
-              <h5>Trigger condition response:</h5>
+              <h5>Trigger condition response</h5>
             </EuiText>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -237,14 +237,12 @@ class ConfigureActions extends React.Component {
     //TODO:: Handle loading Destinations inside the Action which will be more intuitive for customers.
     return (
       <div style={{ paddingLeft: '20px', paddingRight: '15px' }}>
-        <EuiFormRow
-          helpText={'Define actions when trigger conditions are met.'}
-          style={{ paddingBottom: '5px' }}
-        >
-          <EuiText>
-            <h4>{`Actions (${numOfActions})`}</h4>
-          </EuiText>
-        </EuiFormRow>
+        <EuiText>
+          <h4>{`Actions (${numOfActions})`}</h4>
+        </EuiText>
+        <EuiText color={'subdued'} size={'xs'} style={{ paddingBottom: '5px' }}>
+          Define actions when trigger conditions are met.
+        </EuiText>
         <EuiPanel style={{ backgroundColor: '#F7F7F7', padding: '20px' }}>
           {loadingDestinations ? (
             <div style={{ display: 'flex', justifyContent: 'center' }}>Loading Destinations...</div>

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -55,7 +55,7 @@ class ConfigureTriggers extends React.Component {
     const prevMonitorType = _.get(prevProps, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
     const currMonitorType = _.get(this.props, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
     if (prevMonitorType !== currMonitorType)
-      _.set(this.state, 'isBucketLevelMonitor', currMonitorType);
+      _.set(this.state, 'isBucketLevelMonitor', currMonitorType === MONITOR_TYPE.BUCKET_LEVEL);
 
     const prevInputs = prevProps.monitor.inputs[0];
     const currInputs = this.props.monitor.inputs[0];

--- a/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
@@ -249,6 +249,15 @@ class DefineBucketLevelTrigger extends Component {
         <FieldArray name={`${fieldPath}triggerConditions`} validateOnChange={true}>
           {(conditionsArrayHelpers) => (
             <div>
+              <div style={{ paddingLeft: '20px', paddingTop: '10px' }}>
+                <EuiText>
+                  <h4>Trigger conditions</h4>
+                </EuiText>
+                <EuiText color={'subdued'} size={'xs'}>
+                  Specify thresholds for the metrics you have chosen in your query above.
+                </EuiText>
+              </div>
+
               {this.renderBucketLevelTriggerGraph(
                 conditionsArrayHelpers,
                 fieldPath,
@@ -303,8 +312,9 @@ class DefineBucketLevelTrigger extends Component {
             Remove trigger
           </EuiButton>
         }
+        style={{ paddingBottom: '15px', paddingTop: triggerIndex === 0 ? '10px' : '10px' }}
       >
-        <div style={{ padding: '0px 10px' }}>
+        <div style={{ padding: '0px 10px', paddingTop: '20px' }}>
           <FormikFieldText
             name={`${fieldPath}name`}
             fieldProps={{ validate: validateTriggerName(triggers, triggerValues, fieldPath) }}
@@ -321,17 +331,6 @@ class DefineBucketLevelTrigger extends Component {
             inputProps={selectInputProps}
           />
           <EuiSpacer size={'m'} />
-
-          {isGraph ? (
-            <div>
-              <EuiText style={{ paddingLeft: '0px' }}>
-                <h4>Trigger conditions</h4>
-              </EuiText>
-              <EuiText color={'69707D'} size={'xs'} style={{ paddingLeft: '20px' }}>
-                Specify thresholds for the metrics you have chosen in your query above.
-              </EuiText>
-            </div>
-          ) : null}
 
           {bucketLevelTriggerContent}
 
@@ -350,7 +349,6 @@ class DefineBucketLevelTrigger extends Component {
               />
             )}
           </FieldArray>
-          <EuiSpacer />
         </div>
       </EuiAccordion>
     );

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -27,7 +27,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import { EuiAccordion, EuiButton, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiAccordion, EuiButton, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import 'brace/mode/plain_text';
 import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
 import { isInvalid, hasError } from '../../../../utils/validate';
@@ -112,6 +112,8 @@ class DefineTrigger extends Component {
         const searchRequest = buildSearchRequest(formikValues);
         _.set(monitorToExecute, 'inputs[0].search', searchRequest);
         break;
+      case SEARCH_TYPE.AD:
+        break;
       default:
         console.log(`Unsupported searchType found: ${JSON.stringify(searchType)}`, searchType);
     }
@@ -153,6 +155,7 @@ class DefineTrigger extends Component {
     const isAd = _.get(monitorValues, 'searchType') === SEARCH_TYPE.AD;
     const detectorId = _.get(monitorValues, 'detectorId');
     const response = _.get(executeResponse, 'input_results.results[0]');
+    const error = _.get(executeResponse, 'error') || _.get(executeResponse, 'input_results.error');
     const thresholdEnum = _.get(triggerValues, `${fieldPath}thresholdEnum`);
     const thresholdValue = _.get(triggerValues, `${fieldPath}thresholdValue`);
     const adTriggerType = _.get(triggerValues, `${fieldPath}anomalyDetector.triggerType`);
@@ -161,12 +164,15 @@ class DefineTrigger extends Component {
     let triggerContent = (
       <TriggerQuery
         context={context}
+        error={error}
         executeResponse={executeResponse}
         onRun={_.isEmpty(fieldPath) ? onRun : this.onRunExecute}
+        response={response}
         setFlyout={setFlyout}
         triggerValues={triggerValues}
         isDarkMode={isDarkMode}
         fieldPath={fieldPath}
+        isAd={isAd}
       />
     );
     if (isAd && adTriggerType === TRIGGER_TYPE.AD) {
@@ -208,7 +214,7 @@ class DefineTrigger extends Component {
           </EuiButton>
         }
       >
-        <div style={{ padding: '0px 20px' }}>
+        <div style={{ padding: '0px 20px', paddingTop: '20px' }}>
           <FormikFieldText
             name={`${fieldPath}name`}
             fieldProps={{ validate: validateTriggerName(triggers, triggerValues, fieldPath) }}
@@ -226,15 +232,17 @@ class DefineTrigger extends Component {
           />
           <EuiSpacer size={'m'} />
           {isAd ? (
-            <div>
+            <div style={{ paddingLeft: '10px', marginTop: '0px' }}>
+              <EuiText size={'xs'} style={{ paddingBottom: '0px', marginBottom: '0px' }}>
+                <h4>Trigger type</h4>
+              </EuiText>
+              <EuiText color={'subdued'} size={'xs'} style={{ paddingBottom: '5px' }}>
+                Define type of anomaly detector trigger
+              </EuiText>
               <FormikSelect
                 name={`${fieldPath}anomalyDetector.triggerType`}
                 formRow
-                rowProps={{
-                  label: 'Trigger type',
-                  helpText: 'Define type of trigger',
-                  style: { paddingLeft: '10px', marginTop: '0px' },
-                }}
+                rowProps={{ style: { paddingTop: '0px', marginTop: '0px' } }}
                 inputProps={{ options: triggerOptions }}
               />
               <EuiSpacer size={'m'} />


### PR DESCRIPTION
### Description

1. Refactored the visual and response editor options for anomaly detector triggers to align with new mocks.
2. Refactored form reset logic to remove trigger definitions from the form when changing the monitor type.
3. Refactored the visual editor for bucket-level triggers to align with new mocks.
4. Refactored actions panel to align with new mocks. Disabled throttling when `per execution` is selected in the action configuration.
5. Refactored `MonitorType` such that the anomaly detector definition option cannot be selected for bucket-level monitors.
6. Reimplemented the query response display in the trigger panel when defining an anomaly detector trigger condition using the query response option.
7. Implemented logic to set the bucket-level monitor search type to a default value when changing from a query-level monitor with an unsupported search type.

### Screenshots
![trad-visual](https://user-images.githubusercontent.com/79280347/129105745-21e8e4a7-3dfc-4785-94f2-9976f5b97cab.png)

![trad-ext](https://user-images.githubusercontent.com/79280347/129105760-39db6ab5-e644-463f-a2c8-a044c2b739e4.png)

![ad-visual](https://user-images.githubusercontent.com/79280347/129105771-a7b1c336-a4dc-4f46-abe5-efa30fe478e5.png)

![ad-query](https://user-images.githubusercontent.com/79280347/129105803-0e510d7c-2eeb-4724-a512-78eff89fc16f.png)

![agg-visual](https://user-images.githubusercontent.com/79280347/129105824-1b3a9d48-6e41-4e4d-8ef3-176b6d481e2f.png)

![agg-ext](https://user-images.githubusercontent.com/79280347/129105833-ebefceca-a673-428e-9eb4-167aee14cce6.png)


 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
