### PR TITLE
Use destination api to validate destination name

### DIFF
--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
@@ -28,14 +28,15 @@ import { validateDestinationName } from '../validations';
 
 describe('destinations Validations', () => {
   const httpClient = {
-    post: jest.fn(),
+    get: jest.fn(),
   };
   beforeEach(() => {
     jest.resetAllMocks();
   });
   describe('validateDestinationName', () => {
-    httpClient.post.mockResolvedValue({
-      resp: { hits: { total: { value: 0, relation: 'eq' } } },
+    httpClient.get.mockResolvedValue({
+      totalDestinations: 0,
+      relation: 'eq',
     });
     test('should be undefined if name is valid', () => {
       return expect(
@@ -46,23 +47,25 @@ describe('destinations Validations', () => {
       return expect(validateDestinationName(httpClient, null)('')).resolves.toEqual('Required');
     });
     test('should reject if name already is being in used', () => {
-      httpClient.post.mockResolvedValue({
-        resp: { hits: { total: { value: 1, relation: 'eq' } } },
+      httpClient.get.mockResolvedValue({
+        totalDestinations: 1,
+        relation: 'eq',
       });
       return expect(validateDestinationName(httpClient, null)('destinationName')).resolves.toEqual(
         'Destination name is already used'
       );
     });
     test('should reject if name already is being in used while editing destination', () => {
-      httpClient.post.mockResolvedValue({
-        resp: { hits: { total: { value: 1, relation: 'eq' } } },
+      httpClient.get.mockResolvedValue({
+        totalDestinations: 1,
+        relation: 'eq',
       });
       return expect(
         validateDestinationName(httpClient, { name: 'destinationName' })('destinationName Existing')
       ).resolves.toEqual('Destination name is already used');
     });
     test('should rejects if network request has some error', () => {
-      httpClient.post.mockRejectedValue({
+      httpClient.get.mockRejectedValue({
         resp: { ok: false, error: 'There was an issue' },
       });
       return expect(validateDestinationName(httpClient, null)('destinationName')).resolves.toEqual(

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -25,20 +25,15 @@
  */
 
 import _ from 'lodash';
-import { INDEX } from '../../../../../../utils/constants';
 import { getAllowList } from '../../../utils/helpers';
 
 export const validateDestinationName = (httpClient, destinationToEdit) => async (value) => {
   try {
     if (!value) return 'Required';
-    const options = {
-      index: INDEX.SCHEDULED_JOBS,
-      query: { query: { term: { 'destination.name.keyword': value } } },
-    };
-    const response = await httpClient.post('../api/alerting/monitors/_search', {
-      body: JSON.stringify(options),
+    const response = await httpClient.get('../api/alerting/destinations', {
+      query: { search: value, sortField: 'destination.name.keyword' },
     });
-    if (_.get(response, 'resp.hits.total.value', 0)) {
+    if (_.get(response, 'totalDestinations', 0)) {
       if (!destinationToEdit) return 'Destination name is already used';
       if (destinationToEdit && destinationToEdit.name !== value) {
         return 'Destination name is already used';


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

### Description
Previous the searchMonitor API was used to validate destination name, but the getDestination API should be used instead
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
