### PR TITLE
Allow for custom endpoints for cypress tests (#29)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,8 +1,8 @@
 {
   "defaultCommandTimeout": 10000,
   "env": {
-    "opensearch": "localhost:9200",
-    "opensearch_dashboards": "localhost:5601",
+    "opensearch_url": "localhost:9200",
+    "opensearch_dashboards_url": "localhost:5601",
     "security_enabled": false
   }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -56,5 +56,9 @@ Cypress.on('uncaught:exception', (err) => {
 
 // Switch the base URL of Opensearch when security enabled in the cluster
 if (Cypress.env('security_enabled')) {
-  Cypress.env('opensearch', 'https://localhost:9200');
+  Cypress.env('opensearch', `https://${Cypress.env('opensearch_url')}`);
+  Cypress.env('opensearch_dashboards', `https://${Cypress.env('opensearch_dashboards_url')}`);
+} else {
+  Cypress.env('opensearch', `http://${Cypress.env('opensearch_url')}`);
+  Cypress.env('opensearch_dashboards', `http://${Cypress.env('opensearch_dashboards_url')}`);
 }

--- a/integtest.sh
+++ b/integtest.sh
@@ -74,4 +74,5 @@ then
 fi
 
 yarn osd bootstrap
-cypress run --env security_enabled=$SECURITY_ENABLED
+
+cypress run --env security_enabled=$SECURITY_ENABLED opensearch_url=${BIND_ADDRESS}:${BIND_PORT} opensearch_dashboards_url=${BIND_ADDRESS}:${BIND_PORT}


### PR DESCRIPTION
* Update integration tests to support custom endpoints

Original PR: https://github.com/opensearch-project/alerting-dashboards-plugin/pull/29

Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

### Description
Backport to allow for custom endpoints for cypress tests in 1.0
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
