### PR TITLE
Fix cypress security enabled dashboard endpoint issue

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
+  OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -29,29 +30,30 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch
           path: OpenSearch
-          ref: '1.0'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
           repository: opensearch-project/common-utils
           path: common-utils
+          ref: 'main'
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: alerting
           repository: opensearch-project/alerting
-          ref: '1.0'
+          ref: 'main'
       - name: Run Opensearch with plugin
         run: |
           cd alerting
-          ./gradlew run -Dopensearch.version=1.0.0 &
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
 jobs:
   tests:
     name: Run unit tests

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "defaultCommandTimeout": 10000,
   "env": {
     "opensearch_url": "localhost:9200",
-    "opensearch_dashboards_url": "localhost:5601",
+    "opensearch_dashboards": "http://localhost:5601",
     "security_enabled": false
   }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -55,10 +55,9 @@ Cypress.on('uncaught:exception', (err) => {
 });
 
 // Switch the base URL of Opensearch when security enabled in the cluster
+// Dashboard endpoint can still be http when security enabled
 if (Cypress.env('security_enabled')) {
   Cypress.env('opensearch', `https://${Cypress.env('opensearch_url')}`);
-  Cypress.env('opensearch_dashboards', `https://${Cypress.env('opensearch_dashboards_url')}`);
 } else {
   Cypress.env('opensearch', `http://${Cypress.env('opensearch_url')}`);
-  Cypress.env('opensearch_dashboards', `http://${Cypress.env('opensearch_dashboards_url')}`);
 }

--- a/integtest.sh
+++ b/integtest.sh
@@ -75,4 +75,4 @@ fi
 
 yarn osd bootstrap
 
-cypress run --env security_enabled=$SECURITY_ENABLED opensearch_url=${BIND_ADDRESS}:${BIND_PORT} opensearch_dashboards_url=${BIND_ADDRESS}:${BIND_PORT}
+cypress run --env security_enabled=$SECURITY_ENABLED opensearch_dashboards=${BIND_ADDRESS}:${BIND_PORT}


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

### Description
For frontend endpoint, even security enabled situation, we are still using `http` by default. 
This change provides user a way to directly specify the whole endpoint by `--env opensearch_dashboards <your_endpoint>`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
