### PR TITLE
Refactored query trigger definition components to align with mocks.

### DIFF
--- a/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyDetectorMessage/EmptyDetectorMessage.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyDetectorMessage/EmptyDetectorMessage.js
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
+
+const EmptyDetectorMessage = (props) => (
+  <div
+    style={{
+      borderRadius: '5px',
+      padding: '10px',
+      border: '1px solid #D9D9D9',
+      height: '250px',
+      width: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      ...props.containerStyle,
+    }}
+  >
+    <EuiEmptyPrompt
+      style={{ maxWidth: '45em' }}
+      body={<EuiText>You must specify a detector.</EuiText>}
+    />
+  </div>
+);
+
+EmptyDetectorMessage.propTypes = {
+  containerStyle: PropTypes.object,
+};
+EmptyDetectorMessage.defaultProps = {
+  containerStyle: {},
+};
+
+export { EmptyDetectorMessage };

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/BucketLevelTriggerQuery.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/BucketLevelTriggerQuery.js
@@ -1,4 +1,15 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
  * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -19,7 +30,6 @@ import _ from 'lodash';
 import {
   EuiButton,
   EuiCodeEditor,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
@@ -73,86 +83,90 @@ const BucketLevelTriggerQuery = ({
   _.set(trigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.actions`, []);
   const fieldName = `${fieldPath}bucketSelector`;
   return (
-    <div style={{ padding: '0px 20px', marginTop: '0px' }}>
-      <EuiFlexGrid columns={2} gutterSize={'s'}>
-        {/*// Grid slot for the trigger definition code editor header*/}
-        <EuiFlexItem>
-          <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
-            <EuiFlexItem grow={false}>
-              <EuiText size={'s'}>
-                <h5>Trigger condition</h5>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText>
-                <EuiLink
-                  onClick={() => {
-                    setFlyout({ type: 'triggerCondition', payload: context });
-                  }}
+    <EuiFlexGroup direction={'column'} style={{ paddingLeft: '20px', paddingRight: '20px' }}>
+      <EuiFlexItem style={{ marginBottom: '0px' }}>
+        <EuiFlexGroup alignItems={'flexEnd'} gutterSize={'m'}>
+          <EuiFlexItem grow={1}>
+            <Field name={fieldName} validate={validateExtractionQuery}>
+              {({
+                field: { value },
+                form: { errors, touched, setFieldValue, setFieldTouched },
+              }) => (
+                <EuiFormRow
+                  label={
+                    <EuiFlexGroup alignItems={'flexEnd'} gutterSize={'s'}>
+                      <EuiFlexItem grow={false}>
+                        <EuiText size={'xs'}>
+                          <strong>Trigger condition</strong>
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiText>
+                          <EuiLink
+                            onClick={() => {
+                              setFlyout({ type: 'triggerCondition', payload: context });
+                            }}
+                          >
+                            Info
+                          </EuiLink>
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  }
+                  fullWidth={true}
+                  isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
+                  error={_.get(errors, fieldName)}
                 >
-                  Info
-                </EuiLink>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+                  <EuiCodeEditor
+                    grow={true}
+                    mode="json"
+                    theme={isDarkMode ? 'sense-dark' : 'github'}
+                    height="200px"
+                    width="100%"
+                    onChange={(source) => {
+                      setFieldValue(fieldName, source);
+                    }}
+                    onBlur={() => setFieldTouched(fieldName, true)}
+                    value={value}
+                  />
+                </EuiFormRow>
+              )}
+            </Field>
+          </EuiFlexItem>
 
-        {/*// Grid slot for the trigger condition response code editor header*/}
-        <EuiFlexItem>
-          <EuiFlexGroup alignItems={'center'} gutterSize={'none'}>
-            <EuiText size={'s'}>
-              <h5>Trigger condition response:</h5>
-            </EuiText>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+          <EuiFlexItem grow={1}>
+            <EuiFormRow
+              fullWidth={true}
+              label={
+                <EuiText size={'xs'}>
+                  <strong>Trigger condition response</strong>
+                </EuiText>
+              }
+            >
+              <EuiCodeEditor
+                grow={true}
+                mode="plain_text"
+                theme={isDarkMode ? 'sense-dark' : 'github'}
+                height="200px"
+                width="100%"
+                value={getExecuteMessage(executeResponse)}
+                readOnly
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
 
-        {/*// Grid slot for the trigger condition code editor box*/}
-        <EuiFlexItem>
-          <Field name={fieldName} validate={validateExtractionQuery}>
-            {({ field: { value }, form: { errors, touched, setFieldValue, setFieldTouched } }) => (
-              <EuiFormRow
-                fullWidth
-                isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
-                error={_.get(errors, fieldName)}
-              >
-                <EuiCodeEditor
-                  mode="json"
-                  theme={isDarkMode ? 'sense-dark' : 'github'}
-                  height="200px"
-                  width="100%"
-                  onChange={(source) => {
-                    setFieldValue(fieldName, source);
-                  }}
-                  onBlur={() => setFieldTouched(fieldName, true)}
-                  value={value}
-                />
-              </EuiFormRow>
-            )}
-          </Field>
-        </EuiFlexItem>
-
-        {/*// Grid slot for the trigger condition response code editor box*/}
-        <EuiFlexItem>
-          <EuiFormRow fullWidth>
-            <EuiCodeEditor
-              mode="plain_text"
-              theme={isDarkMode ? 'sense-dark' : 'github'}
-              height="200px"
-              width="100%"
-              value={getExecuteMessage(executeResponse)}
-              readOnly
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-
-        {/*// Grid slot for the execute trigger condition button*/}
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => onRun(_.isArray(trigger) ? trigger : [trigger])} size={'s'}>
-            Run for condition response
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGrid>
-    </div>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          onClick={() => onRun(_.isArray(trigger) ? trigger : [trigger])}
+          size={'s'}
+          style={{ width: '250px' }}
+        >
+          Run for condition response
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };
 

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
@@ -30,7 +30,6 @@ import _ from 'lodash';
 import {
   EuiButton,
   EuiCodeEditor,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
@@ -76,103 +75,106 @@ const TriggerQuery = ({
   const formattedResponse = JSON.stringify(responseToFormat, null, 4);
   const fieldName = `${fieldPath}script.source`;
   return (
-    <div style={{ padding: '0px 10px', marginTop: '0px' }}>
-      {isAd ? (
-        <div>
-          <EuiSpacer size={'s'} />
-          <EuiFormRow label="Response">
-            <EuiCodeEditor
-              mode="json"
-              theme={isDarkMode ? 'sense-dark' : 'github'}
-              height="300px"
-              width="90%"
-              value={error || formattedResponse}
-              readOnly
-            />
-          </EuiFormRow>
-          <EuiSpacer size={'l'} />
-        </div>
-      ) : null}
+    <EuiFlexGroup direction={'column'}>
+      <EuiFlexItem style={{ paddingLeft: '10px', paddingRight: '10px' }}>
+        <EuiFlexGroup alignItems={'flexEnd'} gutterSize={'m'}>
+          <EuiFlexItem grow={1} style={{ marginBottom: '0px' }}>
+            <div>
+              {isAd ? (
+                <div>
+                  <EuiSpacer size={'s'} />
+                  <EuiFormRow label="Response" fullWidth={true}>
+                    <EuiCodeEditor
+                      grow={true}
+                      mode="json"
+                      theme={isDarkMode ? 'sense-dark' : 'github'}
+                      height="200px"
+                      width="100%"
+                      value={error || formattedResponse}
+                      readOnly
+                    />
+                  </EuiFormRow>
+                  <EuiSpacer size={'l'} />
+                </div>
+              ) : null}
 
-      <EuiFlexGrid columns={2} gutterSize={'s'}>
-        {/*// Grid slot for the trigger definition code editor header*/}
-        <EuiFlexItem>
-          <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
-            <EuiFlexItem grow={false}>
-              <EuiText size={'s'}>
-                <h5>Trigger condition</h5>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText>
-                <EuiLink
-                  onClick={() => {
-                    setFlyout({ type: 'triggerCondition', payload: context });
-                  }}
-                >
-                  Info
-                </EuiLink>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+              <Field name={fieldName}>
+                {({
+                  field: { value },
+                  form: { errors, touched, setFieldValue, setFieldTouched },
+                }) => (
+                  <EuiFormRow
+                    label={
+                      <EuiFlexGroup alignItems={'flexEnd'} gutterSize={'s'}>
+                        <EuiFlexItem grow={false}>
+                          <EuiText size={'xs'}>
+                            <strong>Trigger condition</strong>
+                          </EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <EuiText>
+                            <EuiLink
+                              onClick={() => {
+                                setFlyout({ type: 'triggerCondition', payload: context });
+                              }}
+                            >
+                              Info
+                            </EuiLink>
+                          </EuiText>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    }
+                    fullWidth={true}
+                    isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
+                    error={_.get(errors, fieldName)}
+                  >
+                    <EuiCodeEditor
+                      grow={true}
+                      mode="plain_text"
+                      theme={isDarkMode ? 'sense-dark' : 'github'}
+                      height="200px"
+                      width="100%"
+                      onChange={(source) => {
+                        setFieldValue(fieldName, source);
+                      }}
+                      onBlur={() => setFieldTouched(fieldName, true)}
+                      value={value}
+                    />
+                  </EuiFormRow>
+                )}
+              </Field>
+            </div>
+          </EuiFlexItem>
 
-        {/*// Grid slot for the trigger condition response code editor header*/}
-        <EuiFlexItem>
-          <EuiFlexGroup alignItems={'center'} gutterSize={'none'}>
-            <EuiText size={'s'}>
-              <h5>Trigger condition response</h5>
-            </EuiText>
-          </EuiFlexGroup>
-        </EuiFlexItem>
+          <EuiFlexItem grow={1} style={{ marginBottom: '0px' }}>
+            <EuiFormRow
+              fullWidth={true}
+              label={
+                <EuiText size={'xs'}>
+                  <strong>Trigger condition response</strong>
+                </EuiText>
+              }
+            >
+              <EuiCodeEditor
+                grow={true}
+                mode="plain_text"
+                theme={isDarkMode ? 'sense-dark' : 'github'}
+                height="200px"
+                width="100%"
+                value={getExecuteMessage(executeResponse)}
+                readOnly
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
 
-        {/*// Grid slot for the trigger condition code editor box*/}
-        <EuiFlexItem>
-          <Field name={fieldName}>
-            {({ field: { value }, form: { errors, touched, setFieldValue, setFieldTouched } }) => (
-              <EuiFormRow
-                fullWidth
-                isInvalid={_.get(touched, fieldName, false) && !!_.get(errors, fieldName)}
-                error={_.get(errors, fieldName)}
-              >
-                <EuiCodeEditor
-                  mode="plain_text"
-                  theme={isDarkMode ? 'sense-dark' : 'github'}
-                  height="200px"
-                  width="100%"
-                  onChange={(source) => {
-                    setFieldValue(fieldName, source);
-                  }}
-                  onBlur={() => setFieldTouched(fieldName, true)}
-                  value={value}
-                />
-              </EuiFormRow>
-            )}
-          </Field>
-        </EuiFlexItem>
-
-        {/*// Grid slot for the trigger condition response code editor box*/}
-        <EuiFlexItem>
-          <EuiFormRow fullWidth>
-            <EuiCodeEditor
-              mode="plain_text"
-              theme={isDarkMode ? 'sense-dark' : 'github'}
-              height="200px"
-              width="100%"
-              value={getExecuteMessage(executeResponse)}
-              readOnly
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-
-        {/*// Grid slot for the execute trigger condition button*/}
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => onRun([trigger])} size={'s'}>
-            Run for condition response
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGrid>
-    </div>
+      <EuiFlexItem style={{ paddingLeft: '10px' }}>
+        <EuiButton onClick={() => onRun([trigger])} size={'s'} style={{ width: '250px' }}>
+          Run for condition response
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };
 

--- a/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
@@ -25,26 +25,27 @@
  */
 
 import React from 'react';
-import { get } from 'lodash';
+import _ from 'lodash';
 import { EuiSpacer } from '@elastic/eui';
 import { AnomalyDetectorData } from '../../../CreateMonitor/containers/AnomalyDetectors/AnomalyDetectorData';
 import TriggerExpressions from '../../components/TriggerExpressions';
 import { AnomaliesChart } from '../../../CreateMonitor/components/AnomalyDetectors/AnomaliesChart';
 import { EmptyFeaturesMessage } from '../../../CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/EmptyFeaturesMessage';
+import { EmptyDetectorMessage } from '../../../CreateMonitor/components/AnomalyDetectors/EmptyDetectorMessage/EmptyDetectorMessage';
 
 class AnomalyDetectorTrigger extends React.Component {
   constructor(props) {
     super(props);
   }
   render() {
-    const { adValues, fieldPath } = this.props;
+    const { adValues, detectorId, fieldPath } = this.props;
     return (
       <div style={{ padding: '0px 10px' }}>
         <AnomalyDetectorData
-          detectorId={this.props.detectorId}
+          detectorId={detectorId}
           render={(anomalyData) => {
             // using lodash.get without worrying about whether an intermediate property is null or undefined.
-            if (get(anomalyData, 'anomalyResult.anomalies', []).length > 0) {
+            if (_.get(anomalyData, 'anomalyResult.anomalies', []).length > 0) {
               return (
                 <React.Fragment>
                   <TriggerExpressions
@@ -87,11 +88,10 @@ class AnomalyDetectorTrigger extends React.Component {
                 </React.Fragment>
               );
             } else {
-              return (
-                <EmptyFeaturesMessage
-                  detectorId={this.props.detectorId}
-                  isLoading={anomalyData.isLoading}
-                />
+              return _.isEmpty(detectorId) ? (
+                <EmptyDetectorMessage />
+              ) : (
+                <EmptyFeaturesMessage detectorId={detectorId} isLoading={anomalyData.isLoading} />
               );
             }
           }}

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -243,7 +243,7 @@ class DefineTrigger extends Component {
               <FormikSelect
                 name={`${fieldPath}anomalyDetector.triggerType`}
                 formRow
-                rowProps={{ style: { paddingTop: '0px', marginTop: '0px' } }}
+                rowProps={{ style: { paddingTop: '0px', marginTop: '0px', width: '390px' } }}
                 inputProps={{ options: triggerOptions }}
               />
               <EuiSpacer size={'m'} />


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>

### Description
1. Refactored query trigger definition components so code editor box sizes align with mocks. 
2. Added a prompt to select a detector for anomaly detection monitors where the preview graphs would render.

### Screenshots
<img width="942" alt="Screen Shot 2021-08-18 at 5 05 55 PM" src="https://user-images.githubusercontent.com/79280347/129988306-923f9da8-a0ec-4e73-967f-903ef7af4441.png">

![Screen Shot 2021-08-18 at 5 06 56 PM](https://user-images.githubusercontent.com/79280347/129988313-2a7d5aa2-6a14-4055-b34e-a1fd9650a5af.png)

<img width="923" alt="Screen Shot 2021-08-18 at 5 14 41 PM" src="https://user-images.githubusercontent.com/79280347/129988330-2c1fddda-eb10-48ac-bd87-e73df9ab99df.png">

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
