### PR TITLE
Update formik conversion for Bucket-Level Trigger to handle throttle change

### DIFF
--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -162,9 +162,10 @@ export default function Message(
   const isBucketLevelMonitor =
     _.get(context, 'ctx.monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL) ===
     MONITOR_TYPE.BUCKET_LEVEL;
+  const actionPath = `${fieldPath}actions.${index}`;
   const actionExecutionPolicyPath = isBucketLevelMonitor
-    ? `${fieldPath}actions.${index}.action_execution_policy`
-    : `${fieldPath}actions.${index}`;
+    ? `${actionPath}.action_execution_policy`
+    : actionPath;
 
   let actionExecutionScopeId = isBucketLevelMonitor
     ? _.get(
@@ -182,8 +183,8 @@ export default function Message(
   );
 
   if (actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT) {
-    if (_.get(values, `${actionExecutionPolicyPath}.throttle.value`) === undefined) {
-      _.set(values, `${actionExecutionPolicyPath}.throttle.value`, 10);
+    if (_.get(values, `${actionPath}.throttle.value`) === undefined) {
+      _.set(values, `${actionPath}.throttle.value`, 10);
     }
 
     if (actionableAlertsSelections === undefined) {
@@ -390,7 +391,7 @@ export default function Message(
               <EuiFlexItem grow={false} style={{ marginRight: '0px' }}>
                 <EuiFormRow label="Throttle actions to only trigger every">
                   <FormikFieldNumber
-                    name={`${actionExecutionPolicyPath}.throttle.value`}
+                    name={`${actionPath}.throttle.value`}
                     fieldProps={{ validate: validateActionThrottle(action) }}
                     formRow={true}
                     rowProps={{

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -109,17 +109,10 @@ export function formikToBucketLevelTriggerAction(values) {
 
       switch (formattedAction.throttle_enabled) {
         case true:
-          _.set(
-            formattedAction,
-            'action_execution_policy.throttle.unit',
-            FORMIK_INITIAL_ACTION_VALUES.throttle.unit
-          );
+          _.set(formattedAction, 'throttle.unit', FORMIK_INITIAL_ACTION_VALUES.throttle.unit);
           break;
         case false:
-          formattedAction = _.omit(formattedAction, [
-            'throttle',
-            `${executionPolicyPath}.throttle`,
-          ]);
+          formattedAction = _.omit(formattedAction, ['throttle']);
           break;
       }
 


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

### Description
This PR updates the setting and retrieval of the `throttle` value for Actions in Bucket-Level Triggers which was removed from the `action_execution_policy` in [this backend PR](https://github.com/opensearch-project/alerting/pull/165)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
