### PR TITLE
Remove pagination

### DIFF
--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -501,7 +501,7 @@ export default class Dashboard extends Component {
            * */
           itemId={getItemId}
           columns={columnType}
-          pagination={pagination}
+          pagination={perAlertView ? pagination : undefined}
           sorting={sorting}
           isSelectable={true}
           selection={selection}


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>
### Description
Remove "Rows per page" selection on Alerts by trigger page when not viewing in per alerts view
 
###Screenshot
![image](https://user-images.githubusercontent.com/71157062/131889726-d586837c-d744-49a0-9863-a6b98fc2da35.png)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
