### PR TITLE
Changes of metrics expression and graph 

### DIFF
--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -56,8 +56,12 @@ const getBucketLevelGraphConditions = (trigger) => {
   conditions = _.replace(conditions, ' && ', '&AND&');
   conditions = _.replace(conditions, ' || ', '&OR&');
   conditions = conditions.split(/&/);
-  return conditions.map((condition) => {
-    return <p style={{ marginBottom: '0px' }}>{condition}</p>;
+  return conditions.map((condition, index) => {
+    return (
+      <p style={{ marginBottom: '0px' }} key={`alerts-dashboard-condition-${index}`}>
+        {condition}
+      </p>
+    );
   });
 };
 
@@ -142,7 +146,7 @@ const alertsDashboard = (payload) => {
     footer: (
       <EuiButtonEmpty
         iconType={'cross'}
-        onClick={setFlyout}
+        onClick={() => setFlyout(null)}
         style={{ paddingLeft: '0px', marginLeft: '0px' }}
       >
         Close

--- a/public/components/FormControls/FormikComboBox/FormikComboBox.js
+++ b/public/components/FormControls/FormikComboBox/FormikComboBox.js
@@ -37,7 +37,6 @@ const FormikComboBox = ({
   fieldProps = {},
   rowProps = {},
   inputProps = {},
-  selectedOption = undefined,
 }) => (
   <FormikInputWrapper
     name={name}
@@ -48,13 +47,7 @@ const FormikComboBox = ({
           <ComboBox name={name} form={form} field={field} inputProps={inputProps} />
         </FormikFormRow>
       ) : (
-        <ComboBox
-          name={name}
-          form={form}
-          field={field}
-          inputProps={inputProps}
-          selectedOption={selectedOption}
-        />
+        <ComboBox name={name} form={form} field={field} inputProps={inputProps} />
       )
     }
   />
@@ -65,7 +58,6 @@ const ComboBox = ({
   form,
   field,
   inputProps: { onBlur, onChange, onCreateOption, ...rest },
-  selectedOption,
 }) => (
   <EuiComboBox
     name={name}
@@ -91,7 +83,13 @@ const ComboBox = ({
           }
         : onBlur
     }
-    selectedOptions={selectedOption ? [selectedOption] : field.value}
+    selectedOptions={
+      typeof field.value === 'string'
+        ? field.value === ''
+          ? undefined
+          : [{ label: field.value }]
+        : field.value
+    }
     {...rest}
   />
 );

--- a/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.js
@@ -33,13 +33,15 @@ import { FieldArray } from 'formik';
 import GroupByExpression from './expressions/GroupByExpression';
 
 export const DEFAULT_CLOSED_STATES = {
+  WHERE: false,
+  // not using
   METRICS: false,
-  WHEN: false,
-  OF_FIELD: false,
-  THRESHOLD: false,
+  GROUP_BY: false,
   OVER: false,
   FOR_THE_LAST: false,
-  WHERE: false,
+  THRESHOLD: false,
+  WHEN: false,
+  OF_FIELD: false,
 };
 
 export default class MonitorExpressions extends Component {
@@ -78,33 +80,22 @@ export default class MonitorExpressions extends Component {
   });
 
   render() {
-    const { dataTypes, errors, touched, isBucketMonitor } = this.props;
+    const { dataTypes, errors } = this.props;
     return (
       <div>
         <FieldArray name="aggregations" validateOnChange={false}>
           {(arrayHelpers) => (
-            <MetricExpression
-              {...this.getExpressionProps()}
-              errors={errors}
-              arrayHelpers={arrayHelpers}
-              dataTypes={dataTypes}
-            />
+            <MetricExpression errors={errors} arrayHelpers={arrayHelpers} dataTypes={dataTypes} />
           )}
         </FieldArray>
         <EuiSpacer size="m" />
-        <ForExpression {...this.getExpressionProps()} />
+        <ForExpression />
         <EuiSpacer size="l" />
         <WhereExpression {...this.getExpressionProps()} dataTypes={dataTypes} />
         <EuiSpacer size="m" />
         <FieldArray name="groupBy" validateOnChange={false}>
           {(arrayHelpers) => (
-            <GroupByExpression
-              {...this.getExpressionProps()}
-              errors={errors}
-              touched={touched}
-              arrayHelpers={arrayHelpers}
-              dataTypes={dataTypes}
-            />
+            <GroupByExpression errors={errors} arrayHelpers={arrayHelpers} dataTypes={dataTypes} />
           )}
         </FieldArray>
         <EuiSpacer size="xs" />

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.js
@@ -25,19 +25,12 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'formik';
 import { EuiText, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { UNITS_OF_TIME } from './utils/constants';
 import { FormikFieldNumber, FormikSelect } from '../../../../../components/FormControls';
 import { hasError, isInvalid, validatePositiveInteger } from '../../../../../utils/validate';
 
 class ForExpression extends Component {
-  onChangeWrapper = (e, field) => {
-    this.props.onMadeChanges();
-    field.onChange(e);
-  };
-
   render() {
     return (
       <div>
@@ -62,7 +55,6 @@ class ForExpression extends Component {
             <FormikSelect
               name="bucketUnitOfTime"
               inputProps={{
-                onChange: this.onChangeWrapper,
                 options: UNITS_OF_TIME,
               }}
             />
@@ -73,9 +65,4 @@ class ForExpression extends Component {
   }
 }
 
-ForExpression.propTypes = {
-  formik: PropTypes.object.isRequired,
-  onMadeChanges: PropTypes.func.isRequired,
-};
-
-export default connect(ForExpression);
+export default ForExpression;

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByExpression.js
@@ -34,29 +34,20 @@ import { GROUP_BY_ERROR } from './utils/constants';
 import { MONITOR_TYPE } from '../../../../../utils/constants';
 
 class GroupByExpression extends Component {
-  state = {
-    addButtonTouched: false,
-  };
   renderFieldItems = (arrayHelpers, fieldOptions, expressionWidth) => {
     const {
       formik: { values },
-      onMadeChanges,
-      openExpression,
-      closeExpression,
     } = this.props;
     return values.groupBy.map((groupByItem, index) => {
       return (
         <span style={{ paddingRight: '5px' }} key={`group-by-expr-${index}`}>
           <GroupByItem
             values={values}
-            onMadeChanges={onMadeChanges}
             arrayHelpers={arrayHelpers}
             fieldOptions={fieldOptions}
             expressionWidth={expressionWidth}
             groupByItem={groupByItem}
             index={index}
-            openExpression={openExpression}
-            closeExpression={closeExpression}
           />
         </span>
       );
@@ -67,7 +58,6 @@ class GroupByExpression extends Component {
     const {
       formik: { values },
       errors,
-      touched,
       arrayHelpers,
       dataTypes,
     } = this.props;
@@ -84,14 +74,12 @@ class GroupByExpression extends Component {
         8 +
       60;
 
-    const isBucketLevelMonitor = monitorType === MONITOR_TYPE.BUCKET_LEVEL;
-
-    if (
-      (this.state.addButtonTouched || touched.groupBy) &&
-      !values.groupBy.length &&
-      values.monitor_type === MONITOR_TYPE.BUCKET_LEVEL
-    )
+    const isBucketLevelMonitor = values.monitor_type === MONITOR_TYPE.BUCKET_LEVEL;
+    if (!values.groupBy.length && !isBucketLevelMonitor) {
       errors.groupBy = GROUP_BY_ERROR;
+    } else {
+      delete errors.groupBy;
+    }
 
     let showAddButtonFlag = false;
     if (!isBucketLevelMonitor && groupBy.length < 1) {
@@ -101,7 +89,7 @@ class GroupByExpression extends Component {
     }
 
     return (
-      <div>
+      <div id="groupBy">
         <EuiText size="xs">
           <strong>Group by</strong>
           {!isBucketLevelMonitor ? <i> - optional</i> : null}
@@ -121,7 +109,6 @@ class GroupByExpression extends Component {
           <EuiButtonEmpty
             size="xs"
             onClick={() => {
-              this.setState({ addButtonTouched: true });
               arrayHelpers.push('');
             }}
             data-test-subj="addGroupByButton"

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByItem.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByItem.js
@@ -12,25 +12,13 @@
 import React, { useState } from 'react';
 import { EuiPopover, EuiBadge, EuiPopoverTitle } from '@elastic/eui';
 import { GroupByPopover } from './index';
-import { Expressions } from './utils/constants';
 
 export default function GroupByItem(
-  {
-    values,
-    onMadeChanges,
-    arrayHelpers,
-    fieldOptions,
-    expressionWidth,
-    groupByItem,
-    index,
-    openExpression,
-    closeExpression,
-  } = this.props
+  { values, arrayHelpers, fieldOptions, expressionWidth, groupByItem, index } = this.props
 ) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(groupByItem === '');
   const closePopover = () => {
     setIsPopoverOpen(false);
-    closeExpression(Expressions.GROUP_BY);
   };
 
   return (
@@ -44,11 +32,9 @@ export default function GroupByItem(
             iconType="cross"
             iconOnClick={() => {
               arrayHelpers.remove(index);
-              onMadeChanges();
             }}
             iconOnClickAriaLabel="Remove group by"
             onClick={() => {
-              openExpression(Expressions.GROUP_BY);
               setIsPopoverOpen(true);
             }}
             onClickAriaLabel="Edit group by"
@@ -65,15 +51,13 @@ export default function GroupByItem(
       anchorPosition="downLeft"
     >
       <EuiPopoverTitle> ADD GROUP BY </EuiPopoverTitle>
+
       <GroupByPopover
         values={values}
-        onMadeChanges={onMadeChanges}
-        arrayHelpers={arrayHelpers}
         options={fieldOptions}
         closePopover={closePopover}
         expressionWidth={expressionWidth}
         index={index}
-        groupByItem={groupByItem}
       />
     </EuiPopover>
   );

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   EuiText,
@@ -24,37 +24,22 @@ import { EXPRESSION_STYLE, POPOVER_STYLE } from './utils/constants';
 import { FormikComboBox } from '../../../../../components/FormControls';
 
 export default function GroupByPopover(
-  {
-    values,
-    onMadeChanges,
-    arrayHelpers,
-    options,
-    closePopover,
-    expressionWidth,
-    index,
-    groupByItem,
-  } = this.props
+  { values, options, closePopover, expressionWidth, index } = this.props
 ) {
-  let defaultIndex = 0;
   const disableOption = (label) => {
-    options[0].options.forEach((element, index) => {
+    options[0].options.forEach((element) => {
       if (element.label === label) {
         element.disabled = true;
-        if (defaultIndex === index) defaultIndex++;
       }
     });
   };
+
   values.groupBy.forEach((label) => {
     disableOption(label);
   });
 
-  const defaultOption = options[0]?.options[defaultIndex];
-  const [comboOption, setComboOption] = useState(groupByItem ? groupByItem : defaultOption.label);
-
   const onChangeFieldWrapper = (options, field, form) => {
-    onMadeChanges();
-    form.setFieldError('groupBy', undefined);
-    setComboOption(options[0].label);
+    form.setFieldValue(`groupBy.${index}`, options[0].label);
   };
 
   return (
@@ -74,8 +59,7 @@ export default function GroupByPopover(
         </EuiFlexItem>
         <EuiFlexItem>
           <FormikComboBox
-            name="groupByField"
-            selectedOption={{ label: comboOption }}
+            name={`groupBy.${index}`}
             inputProps={{
               placeholder: 'Select a field',
               options,
@@ -92,22 +76,10 @@ export default function GroupByPopover(
 
       <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            onClick={() => {
-              closePopover();
-            }}
-          >
-            Cancel
-          </EuiButtonEmpty>
+          <EuiButtonEmpty onClick={closePopover}>Cancel</EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
-            fill
-            onClick={() => {
-              arrayHelpers.replace(index, comboOption);
-              closePopover();
-            }}
-          >
+          <EuiButton fill onClick={closePopover}>
             Save
           </EuiButton>
         </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricItem.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricItem.js
@@ -12,35 +12,14 @@
 import React, { useState } from 'react';
 import { EuiPopover, EuiBadge, EuiPopoverTitle } from '@elastic/eui';
 import MetricPopover from './MetricPopover';
-import { Expressions } from './utils/constants';
 
 export default function MetricItem(
-  {
-    values,
-    onMadeChanges,
-    arrayHelpers,
-    fieldOptions,
-    expressionWidth,
-    aggregation,
-    index,
-    openExpression,
-    closeExpression,
-  } = this.props
+  { arrayHelpers, fieldOptions, expressionWidth, aggregation, index } = this.props
 ) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(aggregation.fieldName === '');
   const closePopover = () => {
     setIsPopoverOpen(false);
-    closeExpression(Expressions.METRICS);
   };
-
-  // TODO: Commenting this out for now since the 'count_of_all_documents` metric is malformed
-  //The first metric is read only
-  // if (index == 0)
-  //   return (
-  //     <EuiBadge>
-  //       {aggregation.aggregationType} of {aggregation.fieldName}
-  //     </EuiBadge>
-  //   );
 
   return (
     <EuiPopover
@@ -54,8 +33,6 @@ export default function MetricItem(
             iconOnClick={() => arrayHelpers.remove(index)}
             iconOnClickAriaLabel="Remove metric"
             onClick={() => {
-              //TODO: Set options to the current agg values
-              openExpression(Expressions.METRICS);
               setIsPopoverOpen(true);
             }}
             onClickAriaLabel="Edit metric"
@@ -73,13 +50,9 @@ export default function MetricItem(
     >
       <EuiPopoverTitle> ADD METRIC </EuiPopoverTitle>
       <MetricPopover
-        values={values}
-        onMadeChanges={onMadeChanges}
-        arrayHelpers={arrayHelpers}
         options={fieldOptions}
         closePopover={closePopover}
         expressionWidth={expressionWidth}
-        aggregation={aggregation}
         index={index}
       />
     </EuiPopover>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   EuiText,
@@ -24,32 +24,10 @@ import { AGGREGATION_TYPES, EXPRESSION_STYLE, POPOVER_STYLE } from './utils/cons
 import { FormikComboBox, FormikSelect } from '../../../../../components/FormControls';
 
 export default function MetricPopover(
-  {
-    values,
-    onMadeChanges,
-    arrayHelpers,
-    options,
-    closePopover,
-    expressionWidth,
-    aggregation,
-    index,
-  } = this.props
+  { options, closePopover, expressionWidth, index } = this.props
 ) {
-  const [selectOption, setSelectOption] = useState(aggregation.aggregationType);
-
-  const defaultOption = options[0]?.options[0];
-  const [comboOption, setComboOption] = useState(
-    aggregation.fieldName ? aggregation.fieldName : defaultOption.label
-  );
-
-  const onChangeWrapper = (e, field) => {
-    onMadeChanges();
-    setSelectOption(e.target.value);
-  };
-
   const onChangeFieldWrapper = (options, field, form) => {
-    onMadeChanges();
-    setComboOption(options[0].label);
+    form.setFieldValue(`aggregations.${index}.fieldName`, options[0].label);
   };
 
   return (
@@ -71,10 +49,8 @@ export default function MetricPopover(
             </EuiFlexItem>
             <EuiFlexItem>
               <FormikSelect
-                name="aggregationType"
-                selectedOption={selectOption}
+                name={`aggregations.${index}.aggregationType`}
                 inputProps={{
-                  onChange: onChangeWrapper,
                   options: AGGREGATION_TYPES,
                   'data-test-subj': `metrics.${index}.aggregationTypeSelect`,
                 }}
@@ -92,8 +68,7 @@ export default function MetricPopover(
             </EuiFlexItem>
             <EuiFlexItem>
               <FormikComboBox
-                name="fieldName"
-                selectedOption={{ label: comboOption }}
+                name={`aggregations.${index}.fieldName`}
                 inputProps={{
                   placeholder: 'Select a field',
                   options,
@@ -124,10 +99,6 @@ export default function MetricPopover(
           <EuiButton
             fill
             onClick={() => {
-              arrayHelpers.replace(index, {
-                aggregationType: selectOption,
-                fieldName: comboOption,
-              });
               closePopover();
             }}
           >

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
@@ -36,12 +36,18 @@ export function getOfExpressionAllowedTypes(values) {
 
 export function getMetricExpressionAllowedTypes(values) {
   const types = ['number'];
+
+  // Check if the aggregation types includes any of 'min', 'max', or 'count'.
+  // If so, add 'date' to the allowed type for metric expression field.
   if (
     values.aggregations.some((e) => {
       return ['min', 'max', 'count'].includes(e.aggregationType);
     })
   )
     types.push('date');
+
+  // Check if the aggregations types includes 'count'.
+  // If so, add 'keyword' to the allowed type for metric expression field.
   if (
     values.aggregations.some((e) => {
       return ['count'].includes(e.aggregationType);

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
@@ -36,13 +36,33 @@ export function getOfExpressionAllowedTypes(values) {
 
 export function getMetricExpressionAllowedTypes(values) {
   const types = ['number'];
-  if (['min', 'max', 'count'].includes(values.aggregationType)) types.push('date');
-  if (['count'].includes(values.aggregationType)) types.push('keyword');
-
+  if (
+    values.aggregations.some((e) => {
+      return ['min', 'max', 'count'].includes(e.aggregationType);
+    })
+  )
+    types.push('date');
+  if (
+    values.aggregations.some((e) => {
+      return ['count'].includes(e.aggregationType);
+    })
+  )
+    types.push('keyword');
   return types;
 }
 
 export function getGroupByExpressionAllowedTypes() {
-  const types = ['keyword'];
-  return types;
+  return ['keyword'];
 }
+
+export const validateAggregationsDuplicates = (aggregations) => {
+  let duplicates = 0;
+  aggregations.forEach((e1, index) => {
+    aggregations.slice(index + 1).forEach((e2) => {
+      if (e1.aggregationType === e2.aggregationType && e1.fieldName === e2.fieldName) {
+        duplicates++;
+      }
+    });
+  });
+  return duplicates > 0;
+};

--- a/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
@@ -29,25 +29,32 @@ import PropTypes from 'prop-types';
 import FormikSelect from '../../../../components/FormControls/FormikSelect/FormikSelect';
 import { hasError, isInvalid } from '../../../../utils/validate';
 import { validateTimeField } from './utils/validation';
+import { FormikComboBox } from '../../../../components/FormControls';
 
 const MonitorTimeField = ({ dataTypes }) => {
   // Default empty option + options from index mappings mapped to ui select form
   const dateFields = Array.from(dataTypes.date || []);
-  const options = [''].concat(dateFields).map((option) => ({ value: option, text: option }));
+  const options = [].concat(dateFields).map((option) => ({ label: option }));
   return (
-    <FormikSelect
+    <FormikComboBox
       name="timeField"
       formRow
       fieldProps={{ validate: validateTimeField(dateFields) }}
       rowProps={{
         label: 'Time field',
-        style: { paddingLeft: '10px' },
         helpText: 'Choose the time field you want to use for your x-axis',
         isInvalid,
         error: hasError,
+        style: { paddingLeft: '10px' },
       }}
       inputProps={{
+        placeholder: 'Select a time field',
         options,
+        onChange: (options, field, form) => {
+          form.setFieldValue('timeField', options[0].label);
+        },
+        isClearable: false,
+        singleSelection: { asPlainText: true },
       }}
     />
   );

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
@@ -46,8 +46,6 @@ import {
   getAnnotationData,
   getDataFromResponse,
   getMarkData,
-  getAggregationTitle,
-  getCustomAggregationTitle,
   getMapDataFromResponse,
   getRectData,
   computeBarWidth,
@@ -79,12 +77,16 @@ export default class VisualGraph extends Component {
   };
 
   renderXYPlot = (data) => {
-    const { annotation, thresholdValue, values, aggregationType, fieldName } = this.props;
-    const { bucketValue, bucketUnitOfTime, groupBy } = values;
+    const { annotation, thresholdValue, values } = this.props;
+    const { bucketValue, bucketUnitOfTime, groupBy, aggregations } = values;
+    const aggregationType = aggregations[0]?.aggregationType;
+    const fieldName = aggregations[0]?.fieldName;
     const { hint } = this.state;
+
     const xDomain = getXDomain(data);
     const yDomain = getYDomain(data);
     const annotations = getAnnotationData(xDomain, yDomain, thresholdValue);
+
     const xTitle = values.timeField;
     const yTitle = getYTitle(values);
     const leftPadding = getLeftPadding(yDomain);
@@ -93,6 +95,7 @@ export default class VisualGraph extends Component {
       ? `${aggregationType?.toUpperCase()} OF ${fieldName}`
       : 'COUNT of documents';
     const description = getGraphDescription(bucketValue, bucketUnitOfTime, groupBy);
+
     return (
       <ContentPanel
         title={title}
@@ -133,55 +136,58 @@ export default class VisualGraph extends Component {
     const yTitle = fieldName;
     const leftPadding = getLeftPadding(yDomain);
     const width = computeBarWidth(xDomain);
+
+    const title = aggregationType
+      ? `${aggregationType?.toUpperCase()} OF ${fieldName}`
+      : 'COUNT of documents';
     const legends = groupedData.map((dataSeries) => dataSeries.key);
+
     return (
-      <div>
-        <ContentPanel
-          title={`${aggregationType?.toUpperCase()} OF ${fieldName}`}
-          titleSize="s"
-          panelStyles={{ paddingLeft: '10px' }}
-          description={
-            <span>
-              FOR THE LAST {values.bucketValue}{' '}
-              {selectOptionValueToText(values.bucketUnitOfTime, UNITS_OF_TIME)}, GROUP BY{' '}
-              {`${values.groupBy}`}, Showing top 3 buckets.
-            </span>
-          }
+      <ContentPanel
+        title={title}
+        titleSize="s"
+        panelStyles={{ paddingLeft: '10px' }}
+        description={
+          <span>
+            FOR THE LAST {values.bucketValue}{' '}
+            {selectOptionValueToText(values.bucketUnitOfTime, UNITS_OF_TIME)}, GROUP BY{' '}
+            {`${values.groupBy}`}, Showing top 3 buckets.
+          </span>
+        }
+      >
+        <FlexibleXYPlot
+          height={400}
+          xType="time"
+          margin={{ top: 20, right: 20, bottom: 70, left: leftPadding }}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          onMouseLeave={this.resetHint}
         >
-          <FlexibleXYPlot
-            height={400}
-            xType="time"
-            margin={{ top: 20, right: 20, bottom: 70, left: leftPadding }}
-            xDomain={xDomain}
-            yDomain={yDomain}
-            onMouseLeave={this.resetHint}
-          >
-            <XAxis title={xTitle} />
-            <YAxis title={yTitle} tickFormat={formatYAxisTick} />
-            <DiscreteColorLegend
-              style={{ position: 'absolute', right: '50px', top: '10px' }}
-              items={legends}
-            />
-            {groupedData.map((dataSeries, index, arr) => {
-              const rectData = getRectData(dataSeries.data, width, index, arr.length);
-              return (
-                <VerticalRectSeries
-                  key={`vertical-rect-${index}`}
-                  className={dataSeries.key}
-                  data={rectData}
-                  onValueMouseOver={(d) => this.onValueMouseOver(d, dataSeries.key)}
-                />
-              );
-            })}
-            {annotation && <LineSeries data={annotations} style={ANNOTATION_STYLES} />}
-            {hint && (
-              <Hint value={hint}>
-                <div style={HINT_STYLES}>{getAggregationGraphHint(hint)}</div>
-              </Hint>
-            )}
-          </FlexibleXYPlot>
-        </ContentPanel>
-      </div>
+          <XAxis title={xTitle} />
+          <YAxis title={yTitle} tickFormat={formatYAxisTick} />
+          <DiscreteColorLegend
+            style={{ position: 'absolute', right: '50px', top: '10px' }}
+            items={legends}
+          />
+          {groupedData.map((dataSeries, index, arr) => {
+            const rectData = getRectData(dataSeries.data, width, index, arr.length);
+            return (
+              <VerticalRectSeries
+                key={`vertical-rect-${index}`}
+                className={dataSeries.key}
+                data={rectData}
+                onValueMouseOver={(d) => this.onValueMouseOver(d, dataSeries.key)}
+              />
+            );
+          })}
+          {annotation && <LineSeries data={annotations} style={ANNOTATION_STYLES} />}
+          {hint && (
+            <Hint value={hint}>
+              <div style={HINT_STYLES}>{getAggregationGraphHint(hint)}</div>
+            </Hint>
+          )}
+        </FlexibleXYPlot>
+      </ContentPanel>
     );
   };
 
@@ -194,7 +200,7 @@ export default class VisualGraph extends Component {
   );
 
   render() {
-    const { response, fieldName, values, aggregationType } = this.props;
+    const { values, response, fieldName, aggregationType } = this.props;
     const monitorType = values.monitor_type;
     const isQueryMonitor = monitorType === MONITOR_TYPE.QUERY_LEVEL;
     const aggTypeFieldName = `${aggregationType}_${fieldName}`;
@@ -207,13 +213,13 @@ export default class VisualGraph extends Component {
       !data.length || (monitorType == MONITOR_TYPE.BUCKET_LEVEL && !values.groupBy.length);
 
     return (
-      <div style={{ padding: '20px', border: '1px solid #D9D9D9', borderRadius: '5px' }}>
+      <>
         {showEmpty
           ? this.renderEmptyData()
           : isQueryMonitor
           ? this.renderXYPlot(data)
           : this.renderAggregationXYPlot(data, groupedData)}
-      </div>
+      </>
     );
   }
 }

--- a/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
@@ -41,7 +41,7 @@ import {
 import { MONITOR_TYPE } from '../../../../../utils/constants';
 
 export function getYTitle(values) {
-  return _.get(values, 'fieldName[0].label', 'count');
+  return _.get(values, `aggregations[0].fieldName`, 'doc_count');
 }
 
 export function getLeftPadding(yDomain) {
@@ -148,7 +148,7 @@ export function getXYValuesByFieldName(bucket, fieldName) {
 
 export function getXYValues(bucket) {
   const x = new Date(bucket.key_as_string);
-  const path = bucket.when ? 'when.value' : 'doc_count';
+  const path = bucket.metric ? 'metric.value' : 'doc_count';
   const y = _.get(bucket, path, null);
   return { x, y };
 }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -259,11 +259,11 @@ export default class CreateMonitor extends Component {
 
   showJsonModal = () => {
     this.setState({ isJsonModalOpen: true });
-  }
+  };
 
   closeJsonModal = () => {
     this.setState({ isJsonModalOpen: false });
-  }
+  };
 
   componentWillUnmount() {
     this.props.setFlyout(null);
@@ -272,6 +272,7 @@ export default class CreateMonitor extends Component {
   render() {
     const { initialValues, plugins, isJsonModalOpen } = this.state;
     const { edit, httpClient, monitorToEdit, notifications, isDarkMode } = this.props;
+
     return (
       <div style={{ padding: '25px 50px' }}>
         <Formik initialValues={initialValues} onSubmit={this.onSubmit} validateOnChange={false}>
@@ -281,6 +282,7 @@ export default class CreateMonitor extends Component {
                 <h1>{edit ? 'Edit' : 'Create'} monitor</h1>
               </EuiTitle>
               <EuiSpacer />
+
               <MonitorDetails
                 values={values}
                 errors={errors}
@@ -323,6 +325,7 @@ export default class CreateMonitor extends Component {
                   />
                 )}
               </FieldArray>
+
               <EuiSpacer />
               <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
                 <EuiFlexItem grow={false}>
@@ -348,15 +351,22 @@ export default class CreateMonitor extends Component {
                   })
                 }
               />
-              { isJsonModalOpen && (
+              {isJsonModalOpen && (
                 <EuiOverlayMask>
-                  <EuiModal onClose={this.closeJsonModal} style={{ padding: "5px 30px" }}>
+                  <EuiModal onClose={this.closeJsonModal} style={{ padding: '5px 30px' }}>
                     <EuiModalHeader>
-                      <EuiModalHeaderTitle>{"View JSON of " + values.name} </EuiModalHeaderTitle>
+                      <EuiModalHeaderTitle>{'View JSON of ' + values.name} </EuiModalHeaderTitle>
                     </EuiModalHeader>
 
                     <EuiModalBody>
-                      <EuiCodeBlock language="json" fontSize="m" paddingSize="m" overflowHeight={600} inline={false} isCopyable>
+                      <EuiCodeBlock
+                        language="json"
+                        fontSize="m"
+                        paddingSize="m"
+                        overflowHeight={600}
+                        inline={false}
+                        isCopyable
+                      >
                         {JSON.stringify(formikToMonitor(values))}
                       </EuiCodeBlock>
                     </EuiModalBody>
@@ -370,8 +380,6 @@ export default class CreateMonitor extends Component {
             </Fragment>
           )}
         </Formik>
-
-
       </div>
     );
   }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
@@ -34,7 +34,7 @@ import {
   formikToGraphQuery,
   formikToUiGraphQuery,
   formikToUiOverAggregation,
-  formikToWhenAggregation,
+  formikToMetricAggregation,
   formikToUiSchedule,
   buildSchedule,
   formikToWhereClause,
@@ -153,13 +153,13 @@ describe('formikToWhenAggregation', () => {
   const formikValues = _.cloneDeep(FORMIK_INITIAL_VALUES);
 
   test('can build when (count) aggregation', () => {
-    expect(formikToWhenAggregation(formikValues)).toMatchSnapshot();
+    expect(formikToMetricAggregation(formikValues)).toMatchSnapshot();
   });
 
   test('can build when aggregation', () => {
     formikValues.aggregationType = 'avg';
     formikValues.fieldName = [{ label: 'bytes' }];
-    expect(formikToWhenAggregation(formikValues)).toMatchSnapshot();
+    expect(formikToMetricAggregation(formikValues)).toMatchSnapshot();
   });
 });
 

--- a/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
@@ -43,6 +43,7 @@ class TriggerExpressions extends Component {
 
   render() {
     const { label, keyFieldName, valueFieldName } = this.props;
+
     return (
       <EuiFormRow label={label} style={{ width: '390px' }}>
         <EuiFlexGroup alignItems={'flexStart'} gutterSize={'m'}>

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
@@ -74,6 +74,7 @@ const TriggerQuery = ({
   const responseToFormat = _.isEmpty(response) && isAd ? onRun([trigger]) : response;
   const formattedResponse = JSON.stringify(responseToFormat, null, 4);
   const fieldName = `${fieldPath}script.source`;
+
   return (
     <EuiFlexGroup direction={'column'}>
       <EuiFlexItem style={{ paddingLeft: '10px', paddingRight: '10px' }}>

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -150,6 +150,7 @@ class ConfigureTriggers extends React.Component {
       httpClient,
       notifications,
     } = this.props;
+
     const { dataTypes, executeResponse, isBucketLevelMonitor } = this.state;
     const hasTriggers = !_.isEmpty(_.get(triggerValues, 'triggerDefinitions'));
     return hasTriggers ? (

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -93,7 +93,7 @@ export const FORMIK_INITIAL_TRIGGER_VALUES = {
 };
 
 export const HITS_TOTAL_RESULTS_PATH = 'ctx.results[0].hits.total.value';
-export const AGGREGATION_RESULTS_PATH = 'ctx.results[0].aggregations.when.value';
+export const AGGREGATION_RESULTS_PATH = 'ctx.results[0].aggregations.metric.value';
 export const ANOMALY_GRADE_RESULT_PATH = 'ctx.results[0].aggregations.max_anomaly_grade.value';
 export const ANOMALY_CONFIDENCE_RESULT_PATH = 'ctx.results[0].hits.hits[0]._source.confidence';
 export const NOT_EMPTY_RESULT =

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -196,12 +196,13 @@ export function formikToTriggerUiMetadata(values, monitorUiMetadata) {
 export function formikToCondition(values, monitorUiMetadata = {}) {
   const { thresholdValue, thresholdEnum } = values;
   const searchType = _.get(monitorUiMetadata, 'search.searchType', 'query');
-  const aggregationType = _.get(monitorUiMetadata, 'search.aggregationType', 'count');
+  const aggregationType = _.get(monitorUiMetadata, 'search.aggregations.0.aggregationType');
 
   if (searchType === SEARCH_TYPE.QUERY) return { script: values.script };
   if (searchType === SEARCH_TYPE.AD) return getADCondition(values);
 
-  const isCount = aggregationType === 'count';
+  // If no aggregation type defined, default to count of documents situation
+  const isCount = !aggregationType;
   const resultsPath = getResultsPath(isCount);
   const operator = getRelationalOperator(thresholdEnum);
   return getCondition(resultsPath, operator, thresholdValue, isCount);

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -100,6 +100,13 @@ class DefineTrigger extends Component {
     this.state = {};
   }
 
+  // TODO query-level monitor trigger graph only get the input
+  //  when this component mount (new trigger added)
+  //  see how to subscribe the formik related value change
+  componentDidMount() {
+    this.onRunExecute();
+  }
+
   onRunExecute = (triggers = []) => {
     const { httpClient, monitor, notifications } = this.props;
     const formikValues = monitorToFormik(monitor);
@@ -233,6 +240,7 @@ class DefineTrigger extends Component {
             inputProps={selectInputProps}
           />
           <EuiSpacer size={'m'} />
+
           {isAd ? (
             <div style={{ paddingLeft: '10px', marginTop: '0px' }}>
               <EuiText size={'xs'} style={{ paddingBottom: '0px', marginBottom: '0px' }}>
@@ -250,7 +258,9 @@ class DefineTrigger extends Component {
               <EuiSpacer size={'m'} />
             </div>
           ) : null}
+
           {triggerContent}
+
           <EuiSpacer size={'l'} />
           <FieldArray name={`${fieldPath}actions`} validateOnChange={true}>
             {(arrayHelpers) => (

--- a/public/pages/MonitorDetails/containers/MonitorHistory/MonitorHistory.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/MonitorHistory.js
@@ -377,7 +377,7 @@ class MonitorHistory extends PureComponent {
 MonitorHistory.propTypes = {
   triggers: PropTypes.array.isRequired,
   onShowTrigger: PropTypes.func.isRequired,
-  isDarkMode: PropTypes.object.isRequired,
+  isDarkMode: PropTypes.bool.isRequired,
   notifications: PropTypes.object.isRequired,
   monitorType: PropTypes.string.isRequired,
 };

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-export const OPEN_SEARCH_PREFIX = 'opendistro';
+export const OPEN_SEARCH_PREFIX = 'opensearch';
 
 export const PLUGIN_NAME = `alerting`;
 export const INDEX_PREFIX = `${OPEN_SEARCH_PREFIX}-alerting`;

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-export const OPEN_SEARCH_PREFIX = 'opensearch';
+export const OPEN_SEARCH_PREFIX = 'opendistro';
 
 export const PLUGIN_NAME = `alerting`;
 export const INDEX_PREFIX = `${OPEN_SEARCH_PREFIX}-alerting`;


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>

Original PR: [#58](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/58)

### Bucket-level expressions
- Refactor Metric, GroupBy expressions component to directly use Formik array fields `aggregations` and `groupBy`
  - Update places using `aggregationType` to `aggregations[0].aggregationType`
  - - [ ] TODO: haven't checked for `groupBy` regression
- Clean up deprecated formik field from uiMetadata `aggregationType, fieldName, overDocuments, groupedOverTop, groupedOverFieldName`
- Add a default `COUNT OF documents` graph when using Bucket-level monitor

---

### Query-level expressions
- Previous `when` aggregation in Query-level monitor now renamed to `metric` aggregation
- User can only choose one metric in Query-level metric aggregation, or use default `COUNT OF documents`; Dynamically hide `COUNT OF documents` badge if user choose one metric aggregation.
- Fix Extraction query and Trigger condition accordingly to use `metric` aggregation namespace.

---

### Visual Graph
- Remove redundant container around VisualGraph

--- 

### Trigger

- Query level trigger now can show graph (run monitor query when `DefineTrigger` mount) 
  - - [ ] It only renders when creating the trigger, if user go back change the metric aggregation, they will need to create new trigger to see the new graph.

---

- Time field change from select to combobox

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
