### PR TITLE
Fixes bucket level monitor can be created by extraction query flaky test

### DIFF
--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -160,6 +160,7 @@ describe('Bucket-Level Monitors', () => {
       cy.get('[data-test-subj="extractionQueryCodeEditor"]').within(() => {
         // If possible, a data-test-subj attribute should be added to access the code editor input directly
         cy.get('.ace_text-input')
+          .focus()
           .clear({ force: true })
           .type(JSON.stringify(sampleAggregationQuery), {
             force: true,


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Fixes the flakey 'rollup can be created by extraction query' test' This test would sometimes fail because the ace code editor would fail to clear the extraction query editor. The query would then have two queries, and would fail when the monitor was created. 
I was able to find a number of issues on the ace code editor github which reported that in older versions of the ace code editor, the editor sometimes needed to be on the screen for typing to register. The cypress tests weren't scrolling, and adding a focus() call before clearing the editor seemed to fix it.

The cypress test is failed with the following error:
```
 1) Bucket-Level Monitors
       can be created
         by extraction query:
     AssertionError: Timed out retrying after 10000ms: Expected to find content: 'This table contains 1 row' but never did.
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/bucket_level_monitor_spec.js:319:10)
 ```
 
### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/106
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
