### PR TITLE
Cherry-picking commits from main to 1.x branch for 1.2 release

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -24,26 +24,6 @@ jobs:
         with:
           # TODO: Parse this from alerting plugin
           java-version: 14
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: opensearch-project/OpenSearch
-          path: OpenSearch
-          ref: '1.x'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-      # dependencies: common-utils
-      - name: Checkout common-utils
-        uses: actions/checkout@v2
-        with:
-          repository: opensearch-project/common-utils
-          path: common-utils
-          ref: 'main'
-      - name: Build common-utils
-        working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -160,6 +160,7 @@ describe('Bucket-Level Monitors', () => {
       cy.get('[data-test-subj="extractionQueryCodeEditor"]').within(() => {
         // If possible, a data-test-subj attribute should be added to access the code editor input directly
         cy.get('.ace_text-input')
+          .focus()
           .clear({ force: true })
           .type(JSON.stringify(sampleAggregationQuery), {
             force: true,

--- a/release-notes/opensearch-alerting-dashboards-plugin.release-notes-1.2.0.0.md
+++ b/release-notes/opensearch-alerting-dashboards-plugin.release-notes-1.2.0.0.md
@@ -1,0 +1,11 @@
+## Version 1.2.0.0 2021-11-04
+
+Compatible with OpenSearch Dashboards 1.2.0
+
+### Maintenance
+* Bumps version to 1.2 ([#128](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/128))
+* Added 1.2 release notes. ([#141](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/141))
+
+### Bug Fixes
+* Fixes flaky test and removes local publishing of plugin dependencies ([#135](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/135))
+* Update copyright notice ([#140](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/140))


### PR DESCRIPTION
### Description
Cherry-picking commits from `main` to `1.x` branch for `1.2` release.
 
### Issues Resolved
#118 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
