### PR TITLE
support creating monitor for anomaly detector with custom result index

### DIFF
--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
@@ -58,6 +58,7 @@ class AnomalyDetectors extends React.Component {
             value: detector.id,
             features: detector.featureAttributes,
             interval: detector.detectionInterval,
+            resultIndex: detector.resultIndex,
           }));
         this.setState({ detectorOptions });
       } else {
@@ -111,6 +112,7 @@ class AnomalyDetectors extends React.Component {
                 interval: 2 * get(options, '0.interval.period.interval'),
                 unit: get(options, '0.interval.period.unit', 'MINUTES').toUpperCase(),
               });
+              form.setFieldValue('adResultIndex', get(options, '0.resultIndex'));
             },
             singleSelection: { asPlaintext: true },
             isClearable: false,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -11,6 +11,7 @@ exports[`CreateMonitor renders 1`] = `
   <Formik
     initialValues={
       Object {
+        "adResultIndex": undefined,
         "aggregationType": "count",
         "aggregations": Array [],
         "bucketUnitOfTime": "h",

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -60,7 +60,8 @@ export function formikToInputs(values) {
 export function formikToSearch(values) {
   const isAD = values.searchType === SEARCH_TYPE.AD;
   let query = isAD ? formikToAdQuery(values) : formikToQuery(values);
-  const indices = isAD ? ['.opendistro-anomaly-results*'] : formikToIndices(values);
+  const adResultIndex = _.get(values, 'adResultIndex', '.opendistro-anomaly-results*');
+  const indices = isAD ? [adResultIndex] : formikToIndices(values);
 
   return {
     search: {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorQueryParams.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorQueryParams.js
@@ -35,5 +35,6 @@ export const initializeFromQueryParams = (queryParams) => {
       queryParams.interval && queryParams.unit
         ? { interval: parseInt(queryParams.interval), unit: queryParams.unit }
         : undefined,
+    adResultIndex: queryParams.adResultIndex || undefined,
   };
 };

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -66,6 +66,7 @@ export default function monitorToFormik(monitor) {
 
     detectorId: isAD ? _.get(inputs, INPUTS_DETECTOR_ID) : undefined,
     index: inputs[0].search.indices.map((index) => ({ label: index })),
+    adResultIndex: isAD ? _.get(inputs, '0.search.indices.0') : undefined,
     query: JSON.stringify(inputs[0].search.query, null, 4),
   };
 }

--- a/release-notes/opensearch-alerting-dashboards-plugin.release-notes-1.2.0.0.md
+++ b/release-notes/opensearch-alerting-dashboards-plugin.release-notes-1.2.0.0.md
@@ -2,6 +2,9 @@
 
 Compatible with OpenSearch Dashboards 1.2.0
 
+### Features
+* support creating monitor for anomaly detector with custom result index ([#143](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/143))
+
 ### Maintenance
 * Bumps version to 1.2 ([#128](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/128))
 * Added 1.2 release notes. ([#141](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/141))


### PR DESCRIPTION
### Description
AD plugin supports sotring anomaly result to custom index, and will release this feature in 1.2. Check more details in this PR https://github.com/opensearch-project/anomaly-detection/pull/276

In current alerting plugin, user can only create AD monitor with default index ".opendistro-anomaly-results*". This can't support detector with custom result index. This PR will get AD result index so we support create monitor for detectors with custom result index.
Related PR: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/123
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
