### PR TITLE
Added DCO section to CONTRIBUTING.md and GitHub workflows. Updated copyright notice.

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,18 @@
+name: Developer Certificate of Origin Check
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR Commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: DCO Check
+        uses: tim-actions/dco@v1.1.0
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,47 @@
-## Contributing to this Project
+## Contributing to OpenSearch
 
 OpenSearch is a community project that is built and maintained by people just like **you**.
 [This document](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md) explains how you can contribute to this and related projects.
+
+## Developer Certificate of Origin
+
+OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache](https://www.apache.org/licenses/LICENSE-2.0) site or the [LICENSE.txt file](https://github.com/opensearch-project/.github/blob/main/LICENSE.txt)). The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+
+We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
+
+The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](http://developercertificate.org/).
+````
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+have the right to submit it under the open source license
+indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the
+best of my knowledge, is covered under an appropriate open
+source license and I have the right under that license to
+submit that work with modifications, whether created in whole
+or in part by me, under the same open source license (unless
+I am permitted to submit under a different license), as
+Indicated in the file; or
+
+(c) The contribution was provided directly to me by some other
+person who certified (a), (b) or (c) and I have not modified
+it.
+
+(d) I understand and agree that this project and the contribution
+are public and that a record of the contribution (including
+all personal information I submit with it, including my
+sign-off) is maintained indefinitely and may be redistributed
+consistent with this project or the open source license(s)
+involved.
+````
+We require that every contribution to OpenSearch is signed with a Developer Certificate of Origin. Additionally, please use your real name. We do not accept anonymous contributors nor those utilizing pseudonyms.
+
+Each commit must include a DCO which looks like this
+````
+Signed-off-by: Jane Smith <jane.smith@email.com>
+````
+You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `–-signoff` to add the `Signed-off-by` line to the end of the commit message.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-OpenSearch
-Copyright 2021 OpenSearch Contributors
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors
 
 This product includes software developed by
 Elasticsearch (http://www.elastic.co).


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description

1. Added DCO section to CONTRIBUTING.md and GitHub workflows. 
2. Updated copyright notice.
 
### Issues Resolved
[35](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/35)
[120](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/120)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
