### PR TITLE
Fix error handling when config index is not found

### DIFF
--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -25,6 +25,7 @@
  */
 
 import _ from 'lodash';
+import { isIndexNotFoundError } from './utils/helpers';
 
 export default class DestinationsService {
   constructor(esDriver) {
@@ -198,6 +199,11 @@ export default class DestinationsService {
         },
       });
     } catch (err) {
+      if (isIndexNotFoundError(err)) {
+        return res.ok({
+          body: { ok: true, resp: { totalDestinations: 0, destinations: [] } },
+        });
+      }
       return res.ok({
         body: {
           ok: false,

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -27,6 +27,7 @@
 import _ from 'lodash';
 
 import { INDEX } from '../../utils/constants';
+import { isIndexNotFoundError } from './utils/helpers';
 
 export default class MonitorService {
   constructor(esDriver) {
@@ -350,6 +351,11 @@ export default class MonitorService {
       });
     } catch (err) {
       console.error('Alerting - MonitorService - getMonitors', err);
+      if (isIndexNotFoundError(err)) {
+        return res.ok({
+          body: { ok: false, resp: { totalMonitors: 0, monitors: [] } },
+        });
+      }
       return res.ok({
         body: {
           ok: false,

--- a/server/services/utils/helpers.js
+++ b/server/services/utils/helpers.js
@@ -24,7 +24,7 @@
  *   permissions and limitations under the License.
  */
 
-import { map, mapKeys, mapValues, isPlainObject, snakeCase, camelCase } from 'lodash';
+import { get, map, mapKeys, mapValues, isPlainObject, snakeCase, camelCase } from 'lodash';
 
 export function mapKeysDeep(obj, fn) {
   if (Array.isArray(obj)) {
@@ -39,3 +39,11 @@ export function mapKeysDeep(obj, fn) {
 export const toSnake = (value, key) => snakeCase(key);
 
 export const toCamel = (value, key) => camelCase(key);
+
+export const isIndexNotFoundError = (err) => {
+  return (
+    err.statusCode === 404 &&
+    get(err, 'body.error.reason', '') ===
+      'Configured indices are not found: [.opendistro-alerting-config]'
+  );
+};


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>

### Description
When no destinations or monitors are defined in a cluster, the alerting config index would not exist. And when users loads the Monitors page or try to add a trigger at Create Monitor page, they will see an error message about config index not found. This fix will check if the error type is `indexNotFoundError` and return a response with empty destinations/monitors without showing error toast message to users.
 
[Reference from AD plugin](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/routes/ad.ts#L492-L494)

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
