### PR TITLE
Cherry-pick commits from main to 1.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/alerting-plugin

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,29 @@
+
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Backport
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Backport
+        uses: VachaShah/backport@v1.1.4
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,7 @@ on:
       - main
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - main
+      - 1.x
   push:
     branches:
       - main
+      - 1.x
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
   OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,15 @@
+name: Delete merged branch of the backport PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - 1.x
   pull_request:
     branches:
       - main
+      - 1.x
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
 jobs:

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,15 @@
+{
+  "scanSettings": {
+    "configMode": "AUTO",
+    "configExternalURL": "",
+    "projectToken": "",
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,4 @@
-## Contributing to OpenSearch
+## Contributing to this Project
 
 OpenSearch is a community project that is built and maintained by people just like **you**.
 [This document](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md) explains how you can contribute to this and related projects.
-
-## Developer Certificate of Origin
-
-OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache](https://www.apache.org/licenses/LICENSE-2.0) site or the [LICENSE.txt file](https://github.com/opensearch-project/.github/blob/main/LICENSE.txt)). The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
-
-We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
-
-The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](http://developercertificate.org/).
-````
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-have the right to submit it under the open source license
-indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the
-best of my knowledge, is covered under an appropriate open
-source license and I have the right under that license to
-submit that work with modifications, whether created in whole
-or in part by me, under the same open source license (unless
-I am permitted to submit under a different license), as
-Indicated in the file; or
-
-(c) The contribution was provided directly to me by some other
-person who certified (a), (b) or (c) and I have not modified
-it.
-
-(d) I understand and agree that this project and the contribution
-are public and that a record of the contribution (including
-all personal information I submit with it, including my
-sign-off) is maintained indefinitely and may be redistributed
-consistent with this project or the open source license(s)
-involved.
-````
-We require that every contribution to OpenSearch is signed with a Developer Certificate of Origin. Additionally, please use your real name. We do not accept anonymous contributors nor those utilizing pseudonyms.
-
-Each commit must include a DCO which looks like this
-````
-Signed-off-by: Jane Smith <jane.smith@email.com>
-````
-You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `–-signoff` to add the `Signed-off-by` line to the end of the commit message.

--- a/NOTICE
+++ b/NOTICE
@@ -1,12 +1,2 @@
 OpenSearch (https://opensearch.org/)
 Copyright OpenSearch Contributors
-
-This product includes software developed by
-Elasticsearch (http://www.elastic.co).
-Copyright 2009-2018 Elasticsearch
-
-This product includes software developed by The Apache Software
-Foundation (http://www.apache.org/).
-
-This product includes software developed by
-Joda.org (http://www.joda.org/).

--- a/cypress/fixtures/sample_alerts_flyout_bucket_level_monitor.json
+++ b/cypress/fixtures/sample_alerts_flyout_bucket_level_monitor.json
@@ -1,0 +1,134 @@
+{
+  "name": "sample_alerts_flyout_bucket_level_monitor",
+  "type": "monitor",
+  "monitor_type": "bucket_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "unit": "MINUTES",
+      "interval": 1
+    }
+  },
+  "inputs": [
+    {
+      "search": {
+        "indices": ["opensearch_dashboards_sample_data_ecommerce"],
+        "query": {
+          "size": 0,
+          "aggregations": {
+            "composite_agg": {
+              "composite": {
+                "sources": [
+                  {
+                    "customer_gender": {
+                      "terms": {
+                        "field": "customer_gender"
+                      }
+                    }
+                  },
+                  {
+                    "user": {
+                      "terms": {
+                        "field": "user"
+                      }
+                    }
+                  }
+                ]
+              },
+              "aggs": {
+                "avg_products_price": {
+                  "avg": {
+                    "field": "products.price"
+                  }
+                }
+              }
+            }
+          },
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "range": {
+                    "order_date": {
+                      "gte": "{{period_end}}||-10d",
+                      "lte": "{{period_end}}",
+                      "format": "epoch_millis"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "triggers": [
+    {
+      "bucket_level_trigger": {
+        "id": "JHpsfH0BYHgJ26-yS5n7",
+        "name": "sample_alerts_flyout_bucket_level_trigger",
+        "severity": "4",
+        "condition": {
+          "buckets_path": {
+            "_count": "_count",
+            "avg_products_price": "avg_products_price"
+          },
+          "parent_bucket_path": "composite_agg",
+          "script": {
+            "source": "params._count < 10000 || params.avg_products_price == 10",
+            "lang": "painless"
+          },
+          "gap_policy": "skip"
+        },
+        "actions": []
+      }
+    }
+  ],
+  "ui_metadata": {
+    "schedule": {
+      "timezone": null,
+      "frequency": "interval",
+      "period": {
+        "unit": "MINUTES",
+        "interval": 1
+      },
+      "daily": 0,
+      "weekly": {
+        "tue": false,
+        "wed": false,
+        "thur": false,
+        "sat": false,
+        "fri": false,
+        "mon": false,
+        "sun": false
+      },
+      "monthly": {
+        "type": "day",
+        "day": 1
+      },
+      "cronExpression": "0 */1 * * *"
+    },
+    "search": {
+      "searchType": "graph",
+      "timeField": "order_date",
+      "aggregations": [
+        {
+          "aggregationType": "avg",
+          "fieldName": "products.price"
+        }
+      ],
+      "groupBy": ["customer_gender", "user"],
+      "bucketValue": 10,
+      "bucketUnitOfTime": "d",
+      "where": {
+        "fieldName": [],
+        "fieldRangeEnd": 0,
+        "fieldRangeStart": 0,
+        "fieldValue": "",
+        "operator": "is"
+      }
+    },
+    "monitor_type": "bucket_level_monitor"
+  }
+}

--- a/cypress/fixtures/sample_alerts_flyout_query_level_monitor.json
+++ b/cypress/fixtures/sample_alerts_flyout_query_level_monitor.json
@@ -1,0 +1,101 @@
+{
+  "name": "sample_alerts_flyout_query_level_monitor",
+  "type": "monitor",
+  "monitor_type": "query_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "unit": "MINUTES",
+      "interval": 1
+    }
+  },
+  "inputs": [
+    {
+      "search": {
+        "indices": ["opensearch_dashboards_sample_data_ecommerce"],
+        "query": {
+          "size": 0,
+          "aggregations": {
+            "terms_agg": {
+              "terms": {
+                "field": "user"
+              }
+            }
+          },
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "range": {
+                    "order_date": {
+                      "gte": "{{period_end}}||-10d",
+                      "lte": "{{period_end}}",
+                      "format": "epoch_millis"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "triggers": [
+    {
+      "query_level_trigger": {
+        "id": "YHpufH0BYHgJ26-yhJm-",
+        "name": "sample_alerts_flyout_query_level_trigger",
+        "severity": "2",
+        "condition": {
+          "script": {
+            "source": "ctx.results[0].hits.total.value < 10000",
+            "lang": "painless"
+          }
+        },
+        "actions": []
+      }
+    }
+  ],
+  "ui_metadata": {
+    "schedule": {
+      "timezone": null,
+      "frequency": "interval",
+      "period": {
+        "unit": "MINUTES",
+        "interval": 1
+      },
+      "daily": 0,
+      "weekly": {
+        "tue": false,
+        "wed": false,
+        "thur": false,
+        "sat": false,
+        "fri": false,
+        "mon": false,
+        "sun": false
+      },
+      "monthly": {
+        "type": "day",
+        "day": 1
+      },
+      "cronExpression": "0 */1 * * *"
+    },
+    "search": {
+      "searchType": "graph",
+      "timeField": "order_date",
+      "aggregations": [],
+      "groupBy": ["user"],
+      "bucketValue": 10,
+      "bucketUnitOfTime": "d",
+      "where": {
+        "fieldName": [],
+        "fieldRangeEnd": 0,
+        "fieldRangeStart": 0,
+        "fieldValue": "",
+        "operator": "is"
+      }
+    },
+    "monitor_type": "query_level_monitor"
+  }
+}

--- a/cypress/integration/acknowledge_alerts_modal_spec.js
+++ b/cypress/integration/acknowledge_alerts_modal_spec.js
@@ -1,0 +1,192 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { INDEX, PLUGIN_NAME } from '../support/constants';
+import sampleAlertsFlyoutBucketMonitor from '../fixtures/sample_alerts_flyout_bucket_level_monitor.json';
+import sampleAlertsFlyoutQueryMonitor from '../fixtures/sample_alerts_flyout_query_level_monitor.json';
+
+const BUCKET_MONITOR = 'sample_alerts_flyout_bucket_level_monitor';
+const BUCKET_TRIGGER = 'sample_alerts_flyout_bucket_level_trigger';
+const QUERY_MONITOR = 'sample_alerts_flyout_query_level_monitor';
+const QUERY_TRIGGER = 'sample_alerts_flyout_query_level_trigger';
+
+const TWENTY_SECONDS = 20000;
+
+describe('AcknowledgeAlertsModal', () => {
+  before(() => {
+    // Delete any existing monitors
+    cy.deleteAllMonitors();
+
+    // Load sample data
+    cy.loadSampleEcommerceData();
+
+    // Create the test monitors
+    cy.createMonitor(sampleAlertsFlyoutBucketMonitor);
+    cy.createMonitor(sampleAlertsFlyoutQueryMonitor);
+
+    // Visit Alerting OpenSearch Dashboards
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/monitors`);
+
+    // Confirm test monitors were created successfully
+    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+
+    // Wait 1 minute for the test monitors to trigger alerts, then go to the 'Alerts by trigger' dashboard page to view alerts
+    cy.wait(60000);
+  });
+
+  beforeEach(() => {
+    // Reloading the page to close any modals that were not closed by other tests that had failures.
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/dashboard`);
+
+    // Confirm dashboard is displaying rows for the test monitors.
+    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+  });
+
+  it('Acknowledge button disabled when more than 1 trigger selected', () => {
+    // Set the 'severity' filter to only display rows with ACTIVE alerts.
+    cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+
+    // Confirm the 'Alerts by trigger' dashboard contains more than 1 row.
+    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+      expect($tr).to.have.length.greaterThan(1)
+    );
+
+    // Select the first and last rows in the table.
+    cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+    cy.get('input[data-test-subj^="checkboxSelectRow-"]').last().click();
+
+    // Click the 'Alerts by trigger' dashboard 'Acknowledge' button.
+    cy.get('[data-test-subj="acknowledgeAlertsButton"]').should('be.disabled');
+  });
+
+  it('Bucket-level monitor modal test', () => {
+    // To simplify testing, filter the dashboard to only display the desired trigger.
+    cy.get(`input[type="search"]`).focus().type(BUCKET_TRIGGER);
+
+    // Confirm the dashboard is displaying only 1 row.
+    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+      expect($tr).to.have.length(1)
+    );
+
+    // Find the row for the trigger, and check off the checkbox.
+    cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+
+    // Click the 'Alerts by trigger' dashboard 'Acknowledge' button.
+    cy.get('[data-test-subj="acknowledgeAlertsButton"]').click();
+
+    // Perform the test checks within the modal component.
+    cy.get(`[data-test-subj="alertsDashboardModal_${BUCKET_TRIGGER}"]`).within(() => {
+      // Confirm modal header contains expected text.
+      cy.get(`[data-test-subj="alertsDashboardModal_header_${BUCKET_TRIGGER}"]`).contains(
+        `Select which alerts to acknowledge for ${BUCKET_TRIGGER}`
+      );
+
+      // Set the 'severity' filter to only display ACTIVE alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+
+      // This monitor configuration consistently returns 46 alerts when testing locally.
+      // Confirm the modal dashboard contains more than 1 ACTIVE alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length.greaterThan(1)
+      );
+
+      // Select the first and last alerts in the table.
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]', { timeout: TWENTY_SECONDS })
+        .first()
+        .click();
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]', { timeout: TWENTY_SECONDS })
+        .last()
+        .click();
+
+      // Press the modal 'Acknowledge button, and wait for the AcknowledgeAlerts API call to complete.
+      cy.get('[data-test-subj="alertsDashboardModal_acknowledgeAlertsButton"]').click();
+    });
+
+    // Confirm acknowledge alerts toast displays expected text.
+    cy.contains('Successfully acknowledged 2 alerts.');
+
+    // Confirm alerts were acknowledged as expected.
+    cy.get(`[data-test-subj="alertsDashboardModal_${BUCKET_TRIGGER}"]`).within(() => {
+      // Set the 'severity' filter to only display ACKNOWLEDGED alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Acknowledged');
+
+      // Confirm the table displays 2 acknowledged alerts.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(2)
+      );
+    });
+
+    // Confirm close button hides the modal.
+    cy.get(`[data-test-subj="alertsDashboardModal_closeButton_${BUCKET_TRIGGER}"]`).click();
+    cy.contains(`[data-test-subj="alertsDashboardModal_${BUCKET_TRIGGER}"]`).should('not.exist');
+  });
+
+  it('Query-level monitor modal test', () => {
+    // To simplify testing, filter the dashboard to only display the desired trigger.
+    cy.get(`input[type="search"]`).focus().type(QUERY_TRIGGER);
+
+    // Confirm the dashboard is displaying only 1 row.
+    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+      expect($tr).to.have.length(1)
+    );
+
+    // Find the row for the trigger, and check off the checkbox.
+    cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+
+    // Click the 'Alerts by trigger' dashboard 'Acknowledge' button.
+    cy.get('[data-test-subj="acknowledgeAlertsButton"]').click();
+
+    // Perform the test checks within the modal component.
+    cy.get(`[data-test-subj="alertsDashboardModal_${QUERY_TRIGGER}"]`).within(() => {
+      // Confirm modal header contains expected text.
+      cy.get(`[data-test-subj="alertsDashboardModal_header_${QUERY_TRIGGER}"]`).contains(
+        `Select which alerts to acknowledge for ${QUERY_TRIGGER}`
+      );
+
+      // Set the 'severity' filter to only display ACTIVE alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+
+      // Confirm the modal dashboard contains 1 alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(1)
+      );
+
+      // Select the alert.
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+
+      // Press the modal 'Acknowledge' button, and wait for the AcknowledgeAlerts API call to complete.
+      cy.get('[data-test-subj="alertsDashboardModal_acknowledgeAlertsButton"]').click();
+    });
+
+    // Confirm acknowledge alerts toast displays expected text.
+    cy.contains('Successfully acknowledged 1 alert.');
+
+    // Confirm alerts were acknowledged as expected.
+    cy.get(`[data-test-subj="alertsDashboardModal_${QUERY_TRIGGER}"]`).within(() => {
+      // Set the 'severity' filter to only display ACKNOWLEDGED alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Acknowledged');
+
+      // Confirm the table displays 1 acknowledged alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(1)
+      );
+    });
+
+    // Confirm close button hides the modal.
+    cy.get(`[data-test-subj="alertsDashboardModal_closeButton_${QUERY_TRIGGER}"]`).click();
+    cy.contains(`[data-test-subj="alertsDashboardModal_${QUERY_TRIGGER}"]`).should('not.exist');
+  });
+
+  after(() => {
+    // Delete all monitors
+    cy.deleteAllMonitors();
+
+    // Delete sample data
+    cy.deleteIndexByName(`${INDEX.SAMPLE_DATA_ECOMMERCE}`);
+  });
+});

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import { PLUGIN_NAME } from '../support/constants';

--- a/cypress/integration/alerts_dashboard_flyout_spec.js
+++ b/cypress/integration/alerts_dashboard_flyout_spec.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/cypress/integration/alerts_dashboard_flyout_spec.js
+++ b/cypress/integration/alerts_dashboard_flyout_spec.js
@@ -1,0 +1,264 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { INDEX, PLUGIN_NAME } from '../support/constants';
+import sampleAlertsFlyoutBucketMonitor from '../fixtures/sample_alerts_flyout_bucket_level_monitor.json';
+import sampleAlertsFlyoutQueryMonitor from '../fixtures/sample_alerts_flyout_query_level_monitor.json';
+
+const BUCKET_MONITOR = 'sample_alerts_flyout_bucket_level_monitor';
+const BUCKET_TRIGGER = 'sample_alerts_flyout_bucket_level_trigger';
+const QUERY_MONITOR = 'sample_alerts_flyout_query_level_monitor';
+const QUERY_TRIGGER = 'sample_alerts_flyout_query_level_trigger';
+
+const TWENTY_SECONDS = 20000;
+
+describe('Alerts by trigger flyout', () => {
+  before(() => {
+    // Delete any existing monitors
+    cy.deleteAllMonitors();
+
+    // Load sample data
+    cy.loadSampleEcommerceData();
+
+    // Create the test monitors
+    cy.createMonitor(sampleAlertsFlyoutBucketMonitor);
+    cy.createMonitor(sampleAlertsFlyoutQueryMonitor);
+
+    // Visit Alerting OpenSearch Dashboards
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/monitors`);
+
+    // Confirm test monitors were created successfully
+    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+
+    // Wait 1 minutes for the test monitors to trigger alerts, then go to the 'Alerts by trigger' dashboard page to view alerts
+    cy.wait(60000);
+  });
+
+  beforeEach(() => {
+    // Reloading the page to close any flyouts that were not closed by other tests that had failures.
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/dashboard`);
+
+    // Waiting 5 seconds for alerts to finish loading.
+    // This short wait period alleviates flakiness observed during these tests.
+    cy.wait(5000);
+
+    // Confirm dashboard is displaying rows for the test monitors.
+    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+  });
+
+  it('Bucket-level monitor flyout test', () => {
+    // Click the link for the flyout.
+    cy.get(`[data-test-subj="euiLink_${BUCKET_TRIGGER}"]`).click();
+
+    // Perform the test checks within the flyout component.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`, {
+      timeout: TWENTY_SECONDS,
+    }).within(() => {
+      // Confirm flyout header contains expected text.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_header_${BUCKET_TRIGGER}"]`
+      ).contains(`Alerts by ${BUCKET_TRIGGER}`, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Trigger name' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_triggerName_${BUCKET_TRIGGER}"]`).as(
+        'triggerName'
+      );
+      cy.get('@triggerName').contains('Trigger name');
+      cy.get('@triggerName').contains(BUCKET_TRIGGER, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Severity' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_severity_${BUCKET_TRIGGER}"]`).as('severity');
+      cy.get('@severity').contains('Severity');
+      cy.get('@severity').contains('4 (Low)', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Monitor' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_monitor_${BUCKET_TRIGGER}"]`).as('monitor');
+      cy.get('@monitor').contains('Monitor');
+      cy.get('@monitor').contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Conditions' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_conditions_${BUCKET_TRIGGER}"]`).as(
+        'conditions'
+      );
+      cy.get('@conditions').contains('Conditions');
+
+      // Confirm the 'Conditions' sections renders with all of the expected conditions.
+      ['params._count < 10000', 'OR', 'params.avg_products_price == 10'].forEach((entry) =>
+        cy.get('@conditions').contains(entry, { timeout: TWENTY_SECONDS })
+      );
+
+      // Confirm 'Time range for the last' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_timeRange_${BUCKET_TRIGGER}"]`).as(
+        'timeRange'
+      );
+      cy.get('@timeRange').contains('Time range for the last');
+      cy.get('@timeRange').contains('10 day(s)', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Filters' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_filters_${BUCKET_TRIGGER}"]`).as('filters');
+      cy.get('@filters').contains('Filters');
+      cy.get('@filters').contains('All fields are included', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Group by' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_groupBy_${BUCKET_TRIGGER}"]`).as('groupBy');
+      cy.get('@groupBy').contains('Group by');
+      cy.get('@groupBy').contains('customer_gender, user', { timeout: TWENTY_SECONDS });
+
+      // Set the 'severity' filter to only display ACTIVE alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+
+      // This monitor configuration consistently returns 46 alerts when testing locally.
+      // Confirm the flyout dashboard contains more than 1 ACTIVE alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length.greaterThan(1)
+      );
+
+      // Select the first and last alerts in the table.
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]').last().click();
+
+      // Press the flyout 'Acknowledge button, and wait for the AcknowledgeAlerts API call to complete.
+      cy.get('[data-test-subj="flyoutAcknowledgeAlertsButton"]').click();
+    });
+
+    // Confirm acknowledge alerts toast displays expected text.
+    cy.contains('Successfully acknowledged 2 alerts.', { timeout: TWENTY_SECONDS });
+
+    // Confirm alerts were acknowledged as expected.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`).within(() => {
+      // Set the 'severity' filter to only display ACKNOWLEDGED alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Acknowledged');
+
+      // Confirm the table displays 2 acknowledged alerts.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(2)
+      );
+    });
+
+    // Confirm close button hides the flyout.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_closeButton_${BUCKET_TRIGGER}"]`).click();
+    cy.contains(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`).should('not.exist');
+  });
+
+  it('Query-level monitor flyout test', () => {
+    // Click the link for the flyout.
+    cy.get(`[data-test-subj="euiLink_${QUERY_TRIGGER}"]`).click();
+
+    // Perform the test checks within the flyout component.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_${QUERY_TRIGGER}"]`, {
+      timeout: TWENTY_SECONDS,
+    }).within(() => {
+      // Confirm flyout header contains expected text.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_header_${QUERY_TRIGGER}"]`
+      ).contains(`Alerts by ${QUERY_TRIGGER}`, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Trigger name' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_triggerName_${QUERY_TRIGGER}"]`).as(
+        'triggerName'
+      );
+      cy.get('@triggerName').contains('Trigger name');
+      cy.get('@triggerName').contains(QUERY_TRIGGER, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Severity' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_severity_${QUERY_TRIGGER}"]`).as('severity');
+      cy.get('@severity').contains('Severity');
+      cy.get('@severity').contains('2 (High)', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Monitor' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_monitor_${QUERY_TRIGGER}"]`).as('monitor');
+      cy.get('@monitor').contains('Monitor');
+      cy.get('@monitor').contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Conditions' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_conditions_${QUERY_TRIGGER}"]`).as(
+        'conditions'
+      );
+      cy.get('@conditions').contains('Condition');
+      cy.get('@conditions').contains(`ctx.results[0].hits.total.value < 10000`, {
+        timeout: TWENTY_SECONDS,
+      });
+
+      // Confirm 'Time range for the last' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_timeRange_${QUERY_TRIGGER}"]`).as('timeRange');
+      cy.get('@timeRange').contains('Time range for the last');
+      cy.get('@timeRange').contains('10 day(s)', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Filters' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_filters_${QUERY_TRIGGER}"]`).as('filters');
+      cy.get('@filters').contains('Filters');
+      cy.get('@filters').contains('-', { timeout: TWENTY_SECONDS });
+
+      // Confirm 'Group by' sections renders as expected.
+      cy.get(`[data-test-subj="alertsDashboardFlyout_groupBy_${QUERY_TRIGGER}"]`).as('groupBy');
+      cy.get('@groupBy').contains('Group by');
+      cy.get('@groupBy').contains('user', { timeout: TWENTY_SECONDS });
+
+      // Set the 'severity' filter to only display ACTIVE alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+
+      // Confirm the flyout dashboard contains 1 alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(1)
+      );
+
+      // Select the alert.
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
+
+      // Press the flyout 'Acknowledge button, and wait for the AcknowledgeAlerts API call to complete.
+      cy.get('[data-test-subj="flyoutAcknowledgeAlertsButton"]').click();
+    });
+
+    // Confirm acknowledge alerts toast displays expected text.
+    cy.contains('Successfully acknowledged 1 alert.', { timeout: TWENTY_SECONDS });
+
+    // Confirm alerts were acknowledged as expected.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_${QUERY_TRIGGER}"]`).within(() => {
+      // Set the 'severity' filter to only display ACKNOWLEDGED alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Acknowledged');
+
+      // Confirm the table displays 1 acknowledged alert.
+      cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+        expect($tr).to.have.length(1)
+      );
+    });
+
+    // Confirm close button hides the flyout.
+    cy.get(`[data-test-subj="alertsDashboardFlyout_closeButton_${QUERY_TRIGGER}"]`).click();
+    cy.contains(`[data-test-subj="alertsDashboardFlyout_${QUERY_TRIGGER}"]`).should('not.exist');
+  });
+
+  after(() => {
+    // Delete all monitors
+    cy.deleteAllMonitors();
+
+    // Delete sample data
+    cy.deleteIndexByName(`${INDEX.SAMPLE_DATA_ECOMMERCE}`);
+  });
+});

--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import { INDEX, PLUGIN_NAME } from '../support/constants';

--- a/cypress/integration/destination_spec.js
+++ b/cypress/integration/destination_spec.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import { PLUGIN_NAME } from '../support/constants';

--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import { PLUGIN_NAME } from '../support/constants';

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 /// <reference types="cypress" />

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 const { API, ADMIN_AUTH } = require('./constants');

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 // ***********************************************************

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "1.2.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "version": "1.3.0.0",
+  "opensearchDashboardsVersion": "1.3.0",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "1.2.0.0",
+  "version": "1.3.0.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "formik": "^2.2.6",
     "lodash": "^4.17.21",
     "query-string": "^6.13.2",
-    "react-router-dom": "^5.2.0",
     "react-vis": "^1.8.1"
   },
   "resolutions": {
@@ -46,7 +45,6 @@
     "glob-parent": "^5.1.2"
   },
   "engines": {
-    "node": "10.24.1",
     "yarn": "^1.21.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "osd": "node ../../scripts/osd",
     "opensearch": "node ../../scripts/opensearch",
     "lint": "../../node_modules/.bin/eslint '**/*.js' -c .eslintrc --ignore-path .gitignore",
-    "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
+    "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",
     "postbuild": "echo Renaming build artifact to [$npm_package_config_id-$npm_package_version.zip] && mv build/$npm_package_config_id*.zip build/$npm_package_config_id-$npm_package_version.zip"

--- a/public/__tests__/index.js
+++ b/public/__tests__/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import expect from 'expect.js';

--- a/public/app.js
+++ b/public/app.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/AttributeEditor/AttributeEditor.js
+++ b/public/components/AttributeEditor/AttributeEditor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/AttributeEditor/index.js
+++ b/public/components/AttributeEditor/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import AttributeEditor from './AttributeEditor';

--- a/public/components/Breadcrumbs/Breadcrumbs.js
+++ b/public/components/Breadcrumbs/Breadcrumbs.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/public/components/Breadcrumbs/Breadcrumbs.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Breadcrumbs/index.js
+++ b/public/components/Breadcrumbs/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Breadcrumbs from './Breadcrumbs';

--- a/public/components/ChartContainer/ChartContainer.js
+++ b/public/components/ChartContainer/ChartContainer.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import PropTypes from 'prop-types';

--- a/public/components/Charts/Highlight/Highlight.js
+++ b/public/components/Charts/Highlight/Highlight.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 /*

--- a/public/components/ContentPanel/ContentPanel.js
+++ b/public/components/ContentPanel/ContentPanel.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/ContentPanel/ContentPanel.test.js
+++ b/public/components/ContentPanel/ContentPanel.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/ContentPanel/index.js
+++ b/public/components/ContentPanel/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ContentPanel from './ContentPanel';

--- a/public/components/DelayedLoader/DelayedLoader.js
+++ b/public/components/DelayedLoader/DelayedLoader.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/DelayedLoader/__tests__/DelayedLoader.test.js
+++ b/public/components/DelayedLoader/__tests__/DelayedLoader.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/DelayedLoader/index.js
+++ b/public/components/DelayedLoader/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DelayedLoader from './DelayedLoader';

--- a/public/components/Flyout/Flyout.js
+++ b/public/components/Flyout/Flyout.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/Flyout.test.js
+++ b/public/components/Flyout/Flyout.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Flyouts.alertsDashboard generates message JSON 1`] = `
+Object {
+  "body": <AlertsDashboardFlyoutComponent />,
+  "flyoutProps": Object {
+    "aria-labelledby": "alertsDashboardFlyout",
+    "data-test-subj": "alertsDashboardFlyout_undefined",
+    "hideCloseButton": true,
+    "size": "m",
+  },
+  "footer": <EuiButtonEmpty
+    data-test-subj="alertsDashboardFlyout_closeButton_undefined"
+    iconType="cross"
+    onClick={[Function]}
+    style={
+      Object {
+        "marginLeft": "0px",
+        "paddingLeft": "0px",
+      }
+    }
+  >
+    Close
+  </EuiButtonEmpty>,
+  "footerProps": Object {
+    "style": Object {
+      "backgroundColor": "#F5F7FA",
+    },
+  },
+  "header": <EuiText
+    data-test-subj="alertsDashboardFlyout_header_undefined"
+  >
+    <h2>
+      Alerts by undefined
+    </h2>
+  </EuiText>,
+  "headerProps": Object {
+    "hasBorder": true,
+  },
+}
+`;
+
 exports[`Flyouts.message generates message JSON 1`] = `
 Object {
   "body": <EuiText

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -25,121 +25,21 @@
  */
 
 import React from 'react';
-import _ from 'lodash';
-import {
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiLink,
-  EuiSpacer,
-  EuiText,
-} from '@elastic/eui';
-import { getTime } from '../../../pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats';
-import { PLUGIN_NAME } from '../../../../utils/constants';
-import {
-  MONITOR_GROUP_BY,
-  MONITOR_INPUT_DETECTOR_ID,
-  MONITOR_TYPE,
-  SEARCH_TYPE,
-} from '../../../utils/constants';
-import { TRIGGER_TYPE } from '../../../pages/CreateTrigger/containers/CreateTrigger/utils/constants';
-import { SEVERITY_OPTIONS } from '../../../pages/CreateTrigger/containers/DefineTrigger/DefineTrigger';
-import Dashboard from '../../../pages/Dashboard/containers/Dashboard';
-import { UNITS_OF_TIME } from '../../../pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants';
-import { DEFAULT_WHERE_EXPRESSION_TEXT } from '../../../pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers';
-
-export const DEFAULT_NUM_FLYOUT_ROWS = 10;
-
-const getBucketLevelGraphConditions = (trigger) => {
-  let conditions = _.get(trigger, 'condition.script.source', '-');
-  conditions = _.replace(conditions, ' && ', '&AND&');
-  conditions = _.replace(conditions, ' || ', '&OR&');
-  conditions = conditions.split(/&/);
-  return conditions.map((condition, index) => {
-    return (
-      <p style={{ marginBottom: '0px' }} key={`alerts-dashboard-condition-${index}`}>
-        {condition}
-      </p>
-    );
-  });
-};
-
-const getSeverityText = (severity) => {
-  return _.get(_.find(SEVERITY_OPTIONS, { value: severity }), 'text');
-};
-
-const getBucketLevelGraphFilter = (trigger) => {
-  const compositeAggFilter = _.get(trigger, 'condition.composite_agg_filter');
-  if (_.isEmpty(compositeAggFilter)) return DEFAULT_WHERE_EXPRESSION_TEXT;
-  const keyword = _.keys(compositeAggFilter)[0];
-  const operator = _.keys(compositeAggFilter[keyword])[0];
-  const value = _.get(compositeAggFilter, `${keyword}.${operator}`);
-  return `${keyword} ${_.upperCase(operator)}S ${value}`;
-};
+import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import AlertsDashboardFlyoutComponent from './components/AlertsDashboardFlyoutComponent';
 
 const alertsDashboard = (payload) => {
-  const {
-    alerts,
-    history,
-    httpClient,
-    last_notification_time,
-    loadingMonitors,
-    location,
-    monitors,
-    monitor_id,
-    monitor_name,
-    notifications,
-    setFlyout,
-    start_time,
-    triggerID,
-    trigger_name,
-  } = payload;
-  const monitor = _.get(_.find(monitors, { _id: monitor_id }), '_source');
-  const monitorType = _.get(monitor, 'monitor_type', MONITOR_TYPE.QUERY_LEVEL);
-  const searchType = _.get(monitor, 'ui_metadata.search.searchType', SEARCH_TYPE.GRAPH);
-  const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
-
-  const triggerType =
-    monitorType === MONITOR_TYPE.QUERY_LEVEL ? TRIGGER_TYPE.QUERY_LEVEL : TRIGGER_TYPE.BUCKET_LEVEL;
-
-  let trigger = _.get(monitor, 'triggers', []).find((trigger) => {
-    return trigger[triggerType].id === triggerID;
-  });
-  trigger = _.get(trigger, triggerType);
-
-  const severity = _.get(trigger, 'severity');
-  const groupBy = _.get(monitor, MONITOR_GROUP_BY);
-
-  const condition =
-    monitorType === MONITOR_TYPE.BUCKET_LEVEL && searchType === SEARCH_TYPE.GRAPH
-      ? getBucketLevelGraphConditions(trigger)
-      : _.get(trigger, 'condition.script.source', '-');
-
-  const filters =
-    monitorType === MONITOR_TYPE.BUCKET_LEVEL && searchType === SEARCH_TYPE.GRAPH
-      ? getBucketLevelGraphFilter(trigger)
-      : '-';
-
-  const bucketValue = _.get(monitor, 'ui_metadata.search.bucketValue');
-  let bucketUnitOfTime = _.get(monitor, 'ui_metadata.search.bucketUnitOfTime');
-  UNITS_OF_TIME.map((entry) => {
-    if (entry.value === bucketUnitOfTime) bucketUnitOfTime = entry.text;
-  });
-  const timeRangeForLast =
-    bucketValue !== undefined && !_.isEmpty(bucketUnitOfTime)
-      ? `${bucketValue} ${bucketUnitOfTime}`
-      : '-';
-
+  const { closeFlyout, trigger_name } = payload;
   return {
     flyoutProps: {
       'aria-labelledby': 'alertsDashboardFlyout',
       size: 'm',
       hideCloseButton: true,
+      'data-test-subj': `alertsDashboardFlyout_${trigger_name}`,
     },
     headerProps: { hasBorder: true },
     header: (
-      <EuiText>
+      <EuiText data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}>
         <h2>{`Alerts by ${trigger_name}`}</h2>
       </EuiText>
     ),
@@ -147,127 +47,14 @@ const alertsDashboard = (payload) => {
     footer: (
       <EuiButtonEmpty
         iconType={'cross'}
-        onClick={() => setFlyout(null)}
+        onClick={() => closeFlyout()}
         style={{ paddingLeft: '0px', marginLeft: '0px' }}
+        data-test-subj={`alertsDashboardFlyout_closeButton_${trigger_name}`}
       >
         Close
       </EuiButtonEmpty>
     ),
-    body: (
-      <div>
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Trigger name</strong>
-              <p>{trigger_name}</p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Severity</strong>
-              <p>{getSeverityText(severity) || severity || '-'}</p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size={'xxl'} />
-
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Trigger start time</strong>
-              <p>{getTime(start_time)}</p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Trigger last updated</strong>
-              <p>{getTime(last_notification_time)}</p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size={'xxl'} />
-
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Monitor</strong>
-              <p>
-                <EuiLink href={`${PLUGIN_NAME}#/monitors/${monitor_id}`}>{monitor_name}</EuiLink>
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiHorizontalRule margin={'xxl'} />
-
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>{_.isArray(condition) ? 'Conditions' : 'Condition'}</strong>
-              {loadingMonitors ? (
-                'Loading conditions...'
-              ) : _.isArray(condition) ? (
-                condition
-              ) : (
-                <p>{condition}</p>
-              )}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Time range for the last</strong>
-              <p>{timeRangeForLast}</p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size={'xxl'} />
-
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Filters</strong>
-              <p>{loadingMonitors ? 'Loading filters...' : filters}</p>
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size={'m'}>
-              <strong>Group by</strong>
-              <p>
-                {loadingMonitors
-                  ? 'Loading groups...'
-                  : !_.isEmpty(groupBy)
-                  ? _.join(_.orderBy(groupBy), ', ')
-                  : '-'}
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiHorizontalRule margin={'xxl'} />
-
-        <EuiFlexGroup>
-          <EuiFlexItem>
-            <Dashboard
-              isAlertsFlyout={true}
-              monitorIds={[monitor_id]}
-              detectorIds={detectorId ? [detectorId] : []}
-              httpClient={httpClient}
-              location={location}
-              history={history}
-              notifications={notifications}
-              monitorType={monitorType}
-              perAlertView={true}
-              groupBy={groupBy}
-              flyoutAlerts={alerts}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size={'l'} />
-      </div>
-    ),
+    body: <AlertsDashboardFlyoutComponent {...payload} />,
   };
 };
 

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -1,0 +1,583 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import _ from 'lodash';
+import {
+  EuiBasicTable,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiLink,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { getTime } from '../../../../pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats';
+import { PLUGIN_NAME } from '../../../../../utils/constants';
+import {
+  ALERT_STATE,
+  MONITOR_GROUP_BY,
+  MONITOR_INPUT_DETECTOR_ID,
+  MONITOR_TYPE,
+  OPENSEARCH_DASHBOARDS_AD_PLUGIN,
+  SEARCH_TYPE,
+} from '../../../../utils/constants';
+import { TRIGGER_TYPE } from '../../../../pages/CreateTrigger/containers/CreateTrigger/utils/constants';
+import { SEVERITY_OPTIONS } from '../../../../pages/CreateTrigger/containers/DefineTrigger/DefineTrigger';
+import { UNITS_OF_TIME } from '../../../../pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants';
+import { DEFAULT_WHERE_EXPRESSION_TEXT } from '../../../../pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers';
+import { backendErrorNotification } from '../../../../utils/helpers';
+import {
+  displayAcknowledgedAlertsToast,
+  filterActiveAlerts,
+  getQueryObjectFromState,
+  getURLQueryParams,
+  insertGroupByColumn,
+  removeColumns,
+} from '../../../../pages/Dashboard/utils/helpers';
+import DashboardControls from '../../../../pages/Dashboard/components/DashboardControls';
+import ContentPanel from '../../../ContentPanel';
+import { queryColumns } from '../../../../pages/Dashboard/utils/tableUtils';
+import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../../../pages/Monitors/containers/Monitors/utils/constants';
+import queryString from 'query-string';
+import { MAX_ALERT_COUNT } from '../../../../pages/Dashboard/utils/constants';
+
+export const DEFAULT_NUM_FLYOUT_ROWS = 10;
+
+export default class AlertsDashboardFlyoutComponent extends Component {
+  constructor(props) {
+    super(props);
+    const { location, monitor_id } = this.props;
+
+    const {
+      alertState,
+      from,
+      search,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+    } = getURLQueryParams(location);
+
+    this.state = {
+      alerts: [],
+      alertState: alertState,
+      loading: true,
+      monitors: [],
+      monitorIds: [monitor_id],
+      page: Math.floor(from / size),
+      search: search,
+      selectable: true,
+      selectedItems: [],
+      severityLevel: severityLevel,
+      size: DEFAULT_NUM_FLYOUT_ROWS,
+      sortDirection: sortDirection,
+      sortField: sortField,
+      totalAlerts: 0,
+    };
+  }
+
+  componentDidMount() {
+    const {
+      alertState,
+      page,
+      search,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+      monitorIds,
+    } = this.state;
+    this.getAlerts(
+      page * size,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds
+    );
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const prevQuery = getQueryObjectFromState(prevState);
+    const currQuery = getQueryObjectFromState(this.state);
+    if (!_.isEqual(prevQuery, currQuery)) {
+      const {
+        page,
+        size,
+        search,
+        sortField,
+        sortDirection,
+        severityLevel,
+        alertState,
+        monitorIds,
+      } = this.state;
+      this.getAlerts(
+        page * size,
+        size,
+        search,
+        sortField,
+        sortDirection,
+        severityLevel,
+        alertState,
+        monitorIds
+      );
+    }
+  }
+
+  getBucketLevelGraphConditions = (trigger) => {
+    let conditions = _.get(trigger, 'condition.script.source', '-');
+    conditions = _.replace(conditions, ' && ', '&AND&');
+    conditions = _.replace(conditions, ' || ', '&OR&');
+    conditions = conditions.split(/&/);
+    return conditions.join('\n');
+  };
+
+  getSeverityText = (severity) => {
+    return _.get(_.find(SEVERITY_OPTIONS, { value: severity }), 'text');
+  };
+
+  getBucketLevelGraphFilter = (trigger) => {
+    const compositeAggFilter = _.get(trigger, 'condition.composite_agg_filter');
+    if (_.isEmpty(compositeAggFilter)) return DEFAULT_WHERE_EXPRESSION_TEXT;
+    const keyword = _.keys(compositeAggFilter)[0];
+    const operator = _.keys(compositeAggFilter[keyword])[0];
+    const value = _.get(compositeAggFilter, `${keyword}.${operator}`);
+    return `${keyword} ${_.upperCase(operator)}S ${value}`;
+  };
+
+  getAlerts = async () => {
+    this.setState({ ...this.state, loading: true });
+    const {
+      from,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    } = this.state;
+
+    const { httpClient, history, notifications, triggerID } = this.props;
+
+    const params = {
+      from,
+      size: MAX_ALERT_COUNT,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    };
+
+    const queryParamsString = queryString.stringify(params);
+    history.replace({ ...this.props.location, search: queryParamsString });
+
+    httpClient.get('../api/alerting/alerts', { query: params }).then((resp) => {
+      if (resp.ok) {
+        const { alerts } = resp;
+        const filteredAlerts = _.filter(alerts, { trigger_id: triggerID });
+        this.setState({
+          ...this.state,
+          alerts: filteredAlerts,
+          totalAlerts: filteredAlerts.length,
+        });
+      } else {
+        console.log('error getting alerts:', resp);
+        backendErrorNotification(notifications, 'get', 'alerts', resp.err);
+      }
+    });
+
+    this.setState({ ...this.state, loading: false });
+  };
+
+  acknowledgeAlerts = async () => {
+    const { selectedItems } = this.state;
+    const { httpClient, notifications } = this.props;
+
+    if (!selectedItems.length) return;
+
+    const selectedAlerts = filterActiveAlerts(selectedItems);
+
+    const monitorAlerts = selectedAlerts.reduce((monitorAlerts, alert) => {
+      const { id, monitor_id: monitorId } = alert;
+      if (monitorAlerts[monitorId]) monitorAlerts[monitorId].push(id);
+      else monitorAlerts[monitorId] = [id];
+      return monitorAlerts;
+    }, {});
+
+    Object.entries(monitorAlerts).map(([monitorId, alerts]) =>
+      httpClient
+        .post(`../api/alerting/monitors/${monitorId}/_acknowledge/alerts`, {
+          body: JSON.stringify({ alerts }),
+        })
+        .then((resp) => {
+          if (!resp.ok) {
+            backendErrorNotification(notifications, 'acknowledge', 'alert', resp.resp);
+          } else {
+            const successfulCount = _.get(resp, 'resp.success', []).length;
+            displayAcknowledgedAlertsToast(notifications, successfulCount);
+          }
+        })
+        .catch((error) => error)
+    );
+
+    const {
+      page,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    } = this.state;
+    await this.getAlerts(
+      page * size,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds
+    );
+    this.setState({ ...this.state, selectedItems: [] });
+    this.props.refreshDashboard();
+  };
+
+  onAlertStateChange = (e) => {
+    this.setState({ page: 0, alertState: e.target.value });
+  };
+
+  onPageClick = (page) => {
+    this.setState({ page });
+  };
+
+  onSearchChange = (e) => {
+    this.setState({ page: 0, search: e.target.value });
+  };
+
+  onSelectionChange = (selectedItems) => {
+    this.setState({ selectedItems });
+  };
+
+  onTableChange = ({ page: tablePage = {}, sort = {} }) => {
+    const { index: page, size } = tablePage;
+
+    const { field: sortField, direction: sortDirection } = sort;
+    this.setState({
+      page,
+      size,
+      sortField,
+      sortDirection,
+    });
+
+    const { alerts } = this.props;
+    this.setState({ alerts });
+  };
+
+  render() {
+    const {
+      last_notification_time,
+      loadingMonitors,
+      monitors,
+      monitor_id,
+      monitor_name,
+      start_time,
+      triggerID,
+      trigger_name,
+    } = this.props;
+    const monitor = _.get(_.find(monitors, { _id: monitor_id }), '_source');
+    const monitorType = _.get(monitor, 'monitor_type', MONITOR_TYPE.QUERY_LEVEL);
+    const searchType = _.get(monitor, 'ui_metadata.search.searchType', SEARCH_TYPE.GRAPH);
+    const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
+
+    const triggerType =
+      monitorType === MONITOR_TYPE.QUERY_LEVEL
+        ? TRIGGER_TYPE.QUERY_LEVEL
+        : TRIGGER_TYPE.BUCKET_LEVEL;
+
+    let trigger = _.get(monitor, 'triggers', []).find((trigger) => {
+      return trigger[triggerType].id === triggerID;
+    });
+    trigger = _.get(trigger, triggerType);
+
+    const severity = _.get(trigger, 'severity');
+    const groupBy = _.get(monitor, MONITOR_GROUP_BY);
+
+    const condition =
+      monitorType === MONITOR_TYPE.BUCKET_LEVEL && searchType === SEARCH_TYPE.GRAPH
+        ? this.getBucketLevelGraphConditions(trigger)
+        : _.get(trigger, 'condition.script.source', '-');
+
+    const filters =
+      monitorType === MONITOR_TYPE.BUCKET_LEVEL && searchType === SEARCH_TYPE.GRAPH
+        ? this.getBucketLevelGraphFilter(trigger)
+        : '-';
+
+    const bucketValue = _.get(monitor, 'ui_metadata.search.bucketValue');
+    let bucketUnitOfTime = _.get(monitor, 'ui_metadata.search.bucketUnitOfTime');
+    UNITS_OF_TIME.map((entry) => {
+      if (entry.value === bucketUnitOfTime) bucketUnitOfTime = entry.text;
+    });
+    const timeRangeForLast =
+      bucketValue !== undefined && !_.isEmpty(bucketUnitOfTime)
+        ? `${bucketValue} ${bucketUnitOfTime}`
+        : '-';
+
+    const actions = () => {
+      const { selectedItems } = this.state;
+      const actions = [
+        <EuiButton
+          onClick={this.acknowledgeAlerts}
+          disabled={!selectedItems.length}
+          data-test-subj={'flyoutAcknowledgeAlertsButton'}
+        >
+          Acknowledge
+        </EuiButton>,
+      ];
+      if (!_.isEmpty(detectorId)) {
+        actions.unshift(
+          <EuiButton
+            href={`${OPENSEARCH_DASHBOARDS_AD_PLUGIN}#/detectors/${detectorId}`}
+            target="_blank"
+          >
+            View detector <EuiIcon type="popout" />
+          </EuiButton>
+        );
+      }
+      return actions;
+    };
+
+    const getItemId = (item) => {
+      switch (monitorType) {
+        case MONITOR_TYPE.QUERY_LEVEL:
+          return `${item.id}-${item.version}`;
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          return item.id;
+      }
+    };
+
+    const {
+      alerts,
+      alertState,
+      loading,
+      page,
+      search,
+      selectable,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+      totalAlerts,
+    } = this.state;
+
+    const columnType = () => {
+      let columns = [];
+      switch (monitorType) {
+        case MONITOR_TYPE.QUERY_LEVEL:
+          columns = queryColumns;
+          break;
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          columns = insertGroupByColumn(groupBy);
+          break;
+      }
+      return removeColumns(['severity', 'trigger_name'], columns);
+    };
+
+    const pagination = {
+      pageIndex: page,
+      pageSize: size,
+      totalItemCount: totalAlerts,
+      pageSizeOptions: DEFAULT_PAGE_SIZE_OPTIONS,
+    };
+
+    const selection = {
+      onSelectionChange: this.onSelectionChange,
+      selectable: (item) => item.state === ALERT_STATE.ACTIVE,
+      selectableMessage: (selectable) =>
+        selectable ? undefined : 'Only active alerts can be acknowledged.',
+    };
+
+    const sorting = {
+      sort: {
+        direction: sortDirection,
+        field: sortField,
+      },
+    };
+
+    const trimmedAlerts = alerts.slice(page * size, page * size + size);
+
+    return (
+      <div>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText
+              size={'m'}
+              data-test-subj={`alertsDashboardFlyout_triggerName_${trigger_name}`}
+            >
+              <strong>Trigger name</strong>
+              <p>{trigger_name}</p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_severity_${trigger_name}`}>
+              <strong>Severity</strong>
+              <p>{this.getSeverityText(severity) || severity || '-'}</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size={'xxl'} />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText size={'m'}>
+              <strong>Trigger start time</strong>
+              <p>{getTime(start_time)}</p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size={'m'}>
+              <strong>Trigger last updated</strong>
+              <p>{getTime(last_notification_time)}</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size={'xxl'} />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_monitor_${trigger_name}`}>
+              <strong>Monitor</strong>
+              <p>
+                <EuiLink href={`${PLUGIN_NAME}#/monitors/${monitor_id}`}>{monitor_name}</EuiLink>
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiHorizontalRule margin={'xxl'} />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_conditions_${trigger_name}`}>
+              <strong>
+                {monitorType === MONITOR_TYPE.BUCKET_LEVEL ? 'Conditions' : 'Condition'}
+              </strong>
+              <p style={{ whiteSpace: 'pre-wrap' }}>
+                {loadingMonitors || loading ? 'Loading conditions...' : condition}
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_timeRange_${trigger_name}`}>
+              <strong>Time range for the last</strong>
+              <p>{timeRangeForLast}</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size={'xxl'} />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_filters_${trigger_name}`}>
+              <strong>Filters</strong>
+              <p>{loadingMonitors || loading ? 'Loading filters...' : filters}</p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_groupBy_${trigger_name}`}>
+              <strong>Group by</strong>
+              <p>
+                {loadingMonitors || loading
+                  ? 'Loading groups...'
+                  : !_.isEmpty(groupBy)
+                  ? _.join(_.orderBy(groupBy), ', ')
+                  : '-'}
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiHorizontalRule margin={'xxl'} />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <ContentPanel
+              title={'Alerts'}
+              titleSize={'s'}
+              bodyStyles={{ padding: 'initial' }}
+              actions={actions()}
+            >
+              <DashboardControls
+                activePage={page}
+                pageCount={Math.ceil(totalAlerts / size) || 1}
+                search={search}
+                severity={severityLevel}
+                state={alertState}
+                onSearchChange={this.onSearchChange}
+                onStateChange={this.onAlertStateChange}
+                onPageChange={this.onPageClick}
+                isAlertsFlyout={true}
+              />
+
+              <EuiHorizontalRule margin="xs" />
+
+              <EuiBasicTable
+                items={loading ? [] : trimmedAlerts}
+                /*
+                 * If using just ID, doesn't update selectedItems when doing acknowledge
+                 * because the next getAlerts have the same id
+                 * $id-$version will correctly remove selected items
+                 * */
+                itemId={getItemId}
+                columns={columnType()}
+                loading={loading}
+                pagination={pagination}
+                sorting={sorting}
+                isSelectable={selectable}
+                selection={selection}
+                onChange={this.onTableChange}
+                noItemsMessage={loading ? 'Loading alerts...' : 'No alerts.'}
+                data-test-subj={`alertsDashboardFlyout_table_${trigger_name}`}
+              />
+            </ContentPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size={'l'} />
+      </div>
+    );
+  }
+}

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.test.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.test.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AlertsDashboardFlyoutComponent from './AlertsDashboardFlyoutComponent';
+
+describe('AlertsDashboardFlyoutComponent', () => {
+  test('renders', () => {
+    const wrapper = shallow(
+      <AlertsDashboardFlyoutComponent
+        location={{ pathname: '/dashboard', search: '' }}
+        flyout={{ type: 'message', payload: null }}
+        onClose={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
+++ b/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
@@ -1,0 +1,268 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertsDashboardFlyoutComponent renders 1`] = `
+<div>
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_triggerName_undefined"
+        size="m"
+      >
+        <strong>
+          Trigger name
+        </strong>
+        <p />
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_severity_undefined"
+        size="m"
+      >
+        <strong>
+          Severity
+        </strong>
+        <p>
+          -
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="xxl"
+  />
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText
+        size="m"
+      >
+        <strong>
+          Trigger start time
+        </strong>
+        <p>
+          -
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiText
+        size="m"
+      >
+        <strong>
+          Trigger last updated
+        </strong>
+        <p>
+          -
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="xxl"
+  />
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_monitor_undefined"
+        size="m"
+      >
+        <strong>
+          Monitor
+        </strong>
+        <p>
+          <EuiLink
+            href="alerting#/monitors/undefined"
+          />
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiHorizontalRule
+    margin="xxl"
+  />
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_conditions_undefined"
+        size="m"
+      >
+        <strong>
+          Condition
+        </strong>
+        <p
+          style={
+            Object {
+              "whiteSpace": "pre-wrap",
+            }
+          }
+        >
+          Loading conditions...
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_timeRange_undefined"
+        size="m"
+      >
+        <strong>
+          Time range for the last
+        </strong>
+        <p>
+          -
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="xxl"
+  />
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_filters_undefined"
+        size="m"
+      >
+        <strong>
+          Filters
+        </strong>
+        <p>
+          Loading filters...
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiText
+        data-test-subj="alertsDashboardFlyout_groupBy_undefined"
+        size="m"
+      >
+        <strong>
+          Group by
+        </strong>
+        <p>
+          Loading groups...
+        </p>
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiHorizontalRule
+    margin="xxl"
+  />
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <ContentPanel
+        actions={
+          Array [
+            <EuiButton
+              data-test-subj="flyoutAcknowledgeAlertsButton"
+              disabled={true}
+              onClick={[Function]}
+            >
+              Acknowledge
+            </EuiButton>,
+          ]
+        }
+        bodyStyles={
+          Object {
+            "padding": "initial",
+          }
+        }
+        title="Alerts"
+        titleSize="s"
+      >
+        <DashboardControls
+          activePage={0}
+          isAlertsFlyout={true}
+          onPageChange={[Function]}
+          onSearchChange={[Function]}
+          onStateChange={[Function]}
+          pageCount={1}
+          search=""
+          severity="ALL"
+          state="ALL"
+        />
+        <EuiHorizontalRule
+          margin="xs"
+        />
+        <EuiBasicTable
+          columns={
+            Array [
+              Object {
+                "dataType": "date",
+                "field": "start_time",
+                "name": "Alert start time",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": false,
+              },
+              Object {
+                "dataType": "date",
+                "field": "end_time",
+                "name": "Alert end time",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": false,
+              },
+              Object {
+                "field": "state",
+                "name": "State",
+                "render": [Function],
+                "sortable": false,
+                "truncateText": false,
+              },
+              Object {
+                "dataType": "date",
+                "field": "acknowledged_time",
+                "name": "Time acknowledged",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": false,
+              },
+            ]
+          }
+          data-test-subj="alertsDashboardFlyout_table_undefined"
+          isSelectable={true}
+          itemId={[Function]}
+          items={Array []}
+          loading={true}
+          noItemsMessage="Loading alerts..."
+          onChange={[Function]}
+          pagination={
+            Object {
+              "pageIndex": 0,
+              "pageSize": 10,
+              "pageSizeOptions": Array [
+                5,
+                10,
+                20,
+                50,
+              ],
+              "totalItemCount": 0,
+            }
+          }
+          responsive={true}
+          selection={
+            Object {
+              "onSelectionChange": [Function],
+              "selectable": [Function],
+              "selectableMessage": [Function],
+            }
+          }
+          sorting={
+            Object {
+              "sort": Object {
+                "direction": "desc",
+                "field": "start_time",
+              },
+            }
+          }
+          tableLayout="fixed"
+        />
+      </ContentPanel>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="l"
+  />
+</div>
+`;

--- a/public/components/Flyout/flyouts/flyouts.test.js
+++ b/public/components/Flyout/flyouts/flyouts.test.js
@@ -47,3 +47,10 @@ describe('Flyouts.triggerCondition', () => {
     expect(json).toMatchSnapshot();
   });
 });
+
+describe('Flyouts.alertsDashboard', () => {
+  test('generates message JSON', () => {
+    const json = Flyouts.alertsDashboard({});
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/public/components/Flyout/flyouts/flyouts.test.js
+++ b/public/components/Flyout/flyouts/flyouts.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/flyouts/index.js
+++ b/public/components/Flyout/flyouts/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import message from './message';

--- a/public/components/Flyout/flyouts/message.js
+++ b/public/components/Flyout/flyouts/message.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/flyouts/messageFrequency.js
+++ b/public/components/Flyout/flyouts/messageFrequency.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/flyouts/triggerCondition.js
+++ b/public/components/Flyout/flyouts/triggerCondition.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/Flyout/index.js
+++ b/public/components/Flyout/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Flyout from './Flyout';

--- a/public/components/FormControls/FormikCheckableCard/FormikCheckableCard.js
+++ b/public/components/FormControls/FormikCheckableCard/FormikCheckableCard.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCheckableCard/FormikCheckableCard.test.js
+++ b/public/components/FormControls/FormikCheckableCard/FormikCheckableCard.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCheckableCard/index.js
+++ b/public/components/FormControls/FormikCheckableCard/index.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import FormikCheckableCard from './FormikCheckableCard';

--- a/public/components/FormControls/FormikCheckbox/FormikCheckbox.js
+++ b/public/components/FormControls/FormikCheckbox/FormikCheckbox.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCheckbox/FormikCheckbox.test.js
+++ b/public/components/FormControls/FormikCheckbox/FormikCheckbox.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCheckbox/index.js
+++ b/public/components/FormControls/FormikCheckbox/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikCheckbox from './FormikCheckbox';

--- a/public/components/FormControls/FormikCodeEditor/FormikCodeEditor.js
+++ b/public/components/FormControls/FormikCodeEditor/FormikCodeEditor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCodeEditor/FormikCodeEditor.test.js
+++ b/public/components/FormControls/FormikCodeEditor/FormikCodeEditor.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikCodeEditor/index.js
+++ b/public/components/FormControls/FormikCodeEditor/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikCodeEditor from './FormikCodeEditor';

--- a/public/components/FormControls/FormikComboBox/FormikComboBox.js
+++ b/public/components/FormControls/FormikComboBox/FormikComboBox.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikComboBox/FormikComboBox.test.js
+++ b/public/components/FormControls/FormikComboBox/FormikComboBox.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikComboBox/index.js
+++ b/public/components/FormControls/FormikComboBox/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikComboBox from './FormikComboBox';

--- a/public/components/FormControls/FormikFieldNumber/FormikFieldNumber.js
+++ b/public/components/FormControls/FormikFieldNumber/FormikFieldNumber.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldNumber/FormikFieldNumber.test.js
+++ b/public/components/FormControls/FormikFieldNumber/FormikFieldNumber.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldNumber/index.js
+++ b/public/components/FormControls/FormikFieldNumber/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFieldNumber from './FormikFieldNumber';

--- a/public/components/FormControls/FormikFieldPassword/FormikFieldPassword.js
+++ b/public/components/FormControls/FormikFieldPassword/FormikFieldPassword.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldPassword/FormikFieldPassword.test.js
+++ b/public/components/FormControls/FormikFieldPassword/FormikFieldPassword.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldPassword/index.js
+++ b/public/components/FormControls/FormikFieldPassword/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFieldPassword from './FormikFieldPassword';

--- a/public/components/FormControls/FormikFieldRadio/FormikFieldRadio.js
+++ b/public/components/FormControls/FormikFieldRadio/FormikFieldRadio.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldRadio/index.js
+++ b/public/components/FormControls/FormikFieldRadio/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFieldRadio from './FormikFieldRadio';

--- a/public/components/FormControls/FormikFieldText/FormikFieldText.js
+++ b/public/components/FormControls/FormikFieldText/FormikFieldText.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldText/FormikFieldText.test.js
+++ b/public/components/FormControls/FormikFieldText/FormikFieldText.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFieldText/index.js
+++ b/public/components/FormControls/FormikFieldText/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFieldText from './FormikFieldText';

--- a/public/components/FormControls/FormikFormRow/FormikFormRow.js
+++ b/public/components/FormControls/FormikFormRow/FormikFormRow.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFormRow/FormikFormRow.test.js
+++ b/public/components/FormControls/FormikFormRow/FormikFormRow.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikFormRow/index.js
+++ b/public/components/FormControls/FormikFormRow/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFormRow from './FormikFormRow';

--- a/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.js
+++ b/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.test.js
+++ b/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikInputWrapper/index.js
+++ b/public/components/FormControls/FormikInputWrapper/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikInputWrapper from './FormikInputWrapper';

--- a/public/components/FormControls/FormikSelect/FormikSelect.js
+++ b/public/components/FormControls/FormikSelect/FormikSelect.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikSelect/FormikSelect.test.js
+++ b/public/components/FormControls/FormikSelect/FormikSelect.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikSelect/index.js
+++ b/public/components/FormControls/FormikSelect/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikSelect from './FormikSelect';

--- a/public/components/FormControls/FormikSwitch/FormikSwitch.js
+++ b/public/components/FormControls/FormikSwitch/FormikSwitch.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikSwitch/FormikSwitch.test.js
+++ b/public/components/FormControls/FormikSwitch/FormikSwitch.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikSwitch/index.js
+++ b/public/components/FormControls/FormikSwitch/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikSwitch from './FormikSwitch';

--- a/public/components/FormControls/FormikTextArea/FormikTextArea.js
+++ b/public/components/FormControls/FormikTextArea/FormikTextArea.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikTextArea/FormikTextArea.test.js
+++ b/public/components/FormControls/FormikTextArea/FormikTextArea.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/FormControls/FormikTextArea/index.js
+++ b/public/components/FormControls/FormikTextArea/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikTextArea from './FormikTextArea';

--- a/public/components/FormControls/index.js
+++ b/public/components/FormControls/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import FormikFieldText from './FormikFieldText';

--- a/public/components/IconToolTip/IconToolTip.js
+++ b/public/components/IconToolTip/IconToolTip.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/components/IconToolTip/IconToolTip.test.js
+++ b/public/components/IconToolTip/IconToolTip.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/components/IconToolTip/index.js
+++ b/public/components/IconToolTip/index.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import IconToolTip from './IconToolTip';

--- a/public/components/SubHeader/SubHeader.js
+++ b/public/components/SubHeader/SubHeader.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/components/SubHeader/SubHeader.test.js
+++ b/public/components/SubHeader/SubHeader.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/components/SubHeader/index.js
+++ b/public/components/SubHeader/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import SubHeader from './SubHeader';

--- a/public/index.js
+++ b/public/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { AlertingPlugin } from './plugin';

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 .container {

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.test.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/AnomaliesChart.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/index.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export { AnomaliesChart } from './AnomaliesChart';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyDetectorMessage/EmptyDetectorMessage.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyDetectorMessage/EmptyDetectorMessage.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/EmptyFeaturesMessage.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/EmptyFeaturesMessage.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/EmptyFeaturesMessage.test.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/EmptyFeaturesMessage.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.test.js
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/FeatureChart.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.js
+++ b/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.test.js
+++ b/public/pages/CreateMonitor/components/ExtractionQuery/ExtractionQuery.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/ExtractionQuery/index.js
+++ b/public/pages/CreateMonitor/components/ExtractionQuery/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ExtractionQuery from './ExtractionQuery';

--- a/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.test.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/MonitorDefinition.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorDefinition/index.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorDefinition from './MonitorDefinition';

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.test.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/index.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/index.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import MonitorDefinitionCard from './MonitorDefinitionCard';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/MonitorExpressions.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/ForExpression.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByItem.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByItem.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React, { useState } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/GroupByPopover.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricItem.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricItem.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React, { useState } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/MetricPopover.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OfExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OfExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OfExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OfExpression.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OverExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OverExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OverExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/OverExpression.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhenExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhenExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhenExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhenExpression.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/index.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ForExpression from './ForExpression';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 export const POPOVER_STYLE = { zIndex: '200' };

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/dataTypes.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/dataTypes.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { NUMBER_TYPES } from './constants';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export function selectOptionValueToText(optionValue, options) {

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import {

--- a/public/pages/CreateMonitor/components/MonitorExpressions/index.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorExpressions from './MonitorExpressions';

--- a/public/pages/CreateMonitor/components/MonitorState/MonitorState.js
+++ b/public/pages/CreateMonitor/components/MonitorState/MonitorState.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/CreateMonitor/components/MonitorState/MonitorState.test.js
+++ b/public/pages/CreateMonitor/components/MonitorState/MonitorState.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorState/index.js
+++ b/public/pages/CreateMonitor/components/MonitorState/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorState from './MonitorState';

--- a/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.test.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorTimeField/index.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorTimeField from './MonitorTimeField';

--- a/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const validateTimeField = (dateFields) => (value) => {

--- a/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// dateFields is a string array of available time field names
 export const validateTimeField = (dateFields) => (value) => {
-  if (!value) return 'Select a time field';
+  if (!value) return 'Select a time field.';
   if (!dateFields.filter((opt) => opt === value).length)
-    return `The field "${value}" does not exist in the selected index mappings, please choose a new time field`;
+    return `The field "${value}" does not exist in the selected index mappings, please choose a new time field.`;
 };

--- a/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.test.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/utils/validation.test.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+import { validateTimeField } from './validation';
+
+describe('validation', () => {
+  test('prompts user to select time field when no value is selected', () => {
+    const dateFields = ['customer_birth_date', 'order_date', 'products.created_on'];
+    const value = undefined;
+    expect(validateTimeField(dateFields)(value)).toBe('Select a time field.');
+  });
+
+  test('shows error message if the option is not in dateFields', () => {
+    const dateFields = ['customer_birth_date', 'order_date', 'products.created_on'];
+    const value = 'invalidValue';
+    expect(validateTimeField(dateFields)(value)).toBe(
+      `The field "${value}" does not exist in the selected index mappings, please choose a new time field.`
+    );
+  });
+});

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.test.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/MonitorType/index.js
+++ b/public/pages/CreateMonitor/components/MonitorType/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorType from './MonitorType';

--- a/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.test.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/QueryPerformance/index.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import QueryPerformance from './QueryPerformance';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/CustomCron.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/CustomCron.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Daily.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Daily.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Daily.test.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Daily.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequencies.test.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequencies.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequency.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Frequency.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/FrequencyPicker.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/FrequencyPicker.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Interval.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Monthly.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Monthly.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/TimezoneComboBox.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/TimezoneComboBox.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/Weekly.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/Weekly.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/index.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Frequency from './Frequency';

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/utils/constants.js
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const monthlyTypes = [{ value: 'day', text: 'Day' }];

--- a/public/pages/CreateMonitor/components/Schedule/Schedule.js
+++ b/public/pages/CreateMonitor/components/Schedule/Schedule.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/Schedule.test.js
+++ b/public/pages/CreateMonitor/components/Schedule/Schedule.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/Schedule/index.js
+++ b/public/pages/CreateMonitor/components/Schedule/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Schedule from './Schedule';

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
@@ -208,18 +208,11 @@ export default class VisualGraph extends Component {
       ? null
       : getMapDataFromResponse(response, aggTypeFieldName, values.groupBy);
     // Show empty graph view when data is empty or aggregation monitor does not have group by defined.
-    const showEmpty =
-      !data.length || (monitorType == MONITOR_TYPE.BUCKET_LEVEL && !values.groupBy.length);
+    const showEmpty = !data.length || (!isQueryMonitor && !values.groupBy.length);
 
-    return (
-      <>
-        {showEmpty
-          ? this.renderEmptyData()
-          : isQueryMonitor
-          ? this.renderXYPlot(data)
-          : this.renderAggregationXYPlot(data, groupedData)}
-      </>
-    );
+    if (showEmpty) return <>{this.renderEmptyData()}</>;
+    else if (isQueryMonitor) return <>{this.renderXYPlot(data)}</>;
+    else return <>{this.renderAggregationXYPlot(data, groupedData)}</>;
   }
 }
 

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
@@ -29,10 +29,99 @@ import { render } from 'enzyme';
 
 import VisualGraph from './VisualGraph';
 import { FORMIK_INITIAL_VALUES } from '../../containers/CreateMonitor/utils/constants';
+import { MONITOR_TYPE } from '../../../../utils/constants';
+
+const queryGraphResponse = {
+  _shards: { total: 1, failed: 0, successful: 1, skipped: 0 },
+  hits: { hits: [], total: { value: 28, relation: 'eq' }, max_score: null },
+  took: 5,
+  timed_out: false,
+  aggregations: {
+    over: {
+      buckets: [
+        { key_as_string: '2021-11-19T07:00:00.000-08:00', doc_count: 0, key: 1637334000000 },
+        { key_as_string: '2021-11-19T08:00:00.000-08:00', doc_count: 6, key: 1637337600000 },
+        { key_as_string: '2021-11-19T09:00:00.000-08:00', doc_count: 5, key: 1637341200000 },
+        { key_as_string: '2021-11-19T10:00:00.000-08:00', doc_count: 4, key: 1637344800000 },
+        { key_as_string: '2021-11-19T11:00:00.000-08:00', doc_count: 8, key: 1637348400000 },
+        { key_as_string: '2021-11-19T12:00:00.000-08:00', doc_count: 5, key: 1637352000000 },
+      ],
+    },
+  },
+};
+const bucketMonitorValues = {
+  name: '',
+  disabled: false,
+  frequency: 'interval',
+  timezone: [],
+  daily: 0,
+  period: { interval: 1, unit: 'MINUTES' },
+  weekly: { mon: false, tue: false, wed: false, thur: false, fri: false, sat: false, sun: false },
+  monthly: { type: 'day', day: 1 },
+  cronExpression: '0 */1 * * *',
+  monitor_type: 'bucket_level_monitor',
+  searchType: 'graph',
+  index: [
+    { label: 'opensearch_dashboards_sample_data_ecommerce', health: 'green', status: 'open' },
+  ],
+  timeField: 'order_date',
+  query: '{\n    "size": 0,\n    "query": {\n        "match_all": {}\n    }\n}',
+  aggregationType: 'count',
+  fieldName: [],
+  aggregations: [],
+  groupBy: ['customer_gender'],
+  groupByField: [{ label: '' }],
+  overDocuments: 'all documents',
+  groupedOverTop: 5,
+  groupedOverFieldName: 'bytes',
+  bucketValue: 1,
+  bucketUnitOfTime: 'h',
+  where: { fieldName: [], operator: 'is', fieldValue: '', fieldRangeStart: 0, fieldRangeEnd: 0 },
+  detectorId: '',
+  triggerDefinitions: [],
+};
+
+const bucketGraphResponse = {
+  _shards: { total: 1, failed: 0, successful: 1, skipped: 0 },
+  hits: { hits: [], total: { value: 28, relation: 'eq' }, max_score: null },
+  took: 19,
+  timed_out: false,
+  aggregations: {
+    composite_agg: {
+      buckets: [
+        { doc_count: 6, key: { date: 1637337600000 } },
+        { doc_count: 5, key: { date: 1637341200000 } },
+        { doc_count: 4, key: { date: 1637344800000 } },
+        { doc_count: 8, key: { date: 1637348400000 } },
+        { doc_count: 5, key: { date: 1637352000000 } },
+      ],
+      after_key: { date: 1637352000000 },
+    },
+  },
+};
 
 describe('VisualGraph', () => {
   test('renders', () => {
-    const component = <VisualGraph values={FORMIK_INITIAL_VALUES} />;
+    const component = (
+      <VisualGraph
+        values={FORMIK_INITIAL_VALUES}
+        fieldName="doc_count"
+        response={queryGraphResponse}
+      />
+    );
+    expect(render(component)).toMatchSnapshot();
+  });
+
+  test('renders with bucket level monitor', () => {
+    const values = FORMIK_INITIAL_VALUES;
+    values.monitor_type = MONITOR_TYPE.BUCKET_LEVEL;
+    const component = (
+      <VisualGraph
+        values={bucketMonitorValues}
+        fieldName="doc_count"
+        response={bucketGraphResponse}
+      />
+    );
     expect(render(component)).toMatchSnapshot();
   });
 });

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
+++ b/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
@@ -2,10 +2,1091 @@
 
 exports[`VisualGraph renders 1`] = `
 <div
-  style="display:flex;align-items:center;justify-content:center;height:450px"
+  class="euiPanel euiPanel--paddingMedium"
+  style="padding-left:10px;padding-right:0px"
 >
-  <div>
-    There is no data for the current selections.
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding:0px 10px"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <h3
+        class="euiTitle euiTitle--small"
+      >
+        COUNT of documents
+      </h3>
+    </div>
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiFlexItem"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiText euiText--extraSmall"
+    style="padding:0px 10px"
+  >
+    <div
+      class="euiTextColor euiTextColor--subdued"
+    >
+      FOR THE LAST 1 hour(s)
+    </div>
+  </div>
+  <hr
+    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+  />
+  <div
+    style="padding:0px 10px"
+  >
+    <div
+      style="width:100%;height:100%"
+    >
+      <div
+        class="rv-xy-plot "
+        style="width:0px;height:400px"
+      >
+        <svg
+          class="rv-xy-plot__inner"
+          height="400"
+          width="0"
+        >
+          <g
+            class="rv-xy-plot__axis rv-xy-plot__axis--horizontal "
+            transform="translate(80,330)"
+          >
+            <line
+              class="rv-xy-plot__axis__line"
+              x1="0"
+              x2="-100"
+              y1="0"
+              y2="0"
+            />
+            <g
+              class="rv-xy-plot__axis__ticks"
+              transform="translate(0, 0)"
+            >
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  03 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-20, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  04 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-40, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  05 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-60, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  06 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-80, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  07 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-100, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  08 PM
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="rv-xy-plot__axis rv-xy-plot__axis--vertical "
+            transform="translate(0,20)"
+          >
+            <line
+              class="rv-xy-plot__axis__line"
+              x1="80"
+              x2="80"
+              y1="0"
+              y2="310"
+            />
+            <g
+              class="rv-xy-plot__axis__ticks"
+              transform="translate(80, 0)"
+            >
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 310)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  0
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 284.16666666666663)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  1
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 258.33333333333337)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  2
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 232.5)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  3
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 206.66666666666669)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  4
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 180.83333333333331)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  5
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 155)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  6
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 129.16666666666666)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  7
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 103.33333333333334)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  8
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 77.5)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  9
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 51.66666666666666)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  10
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 25.833333333333346)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  11
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  12
+                </text>
+              </g>
+            </g>
+            <g
+              class="rv-xy-plot__axis__title"
+              transform="translate(80, 0)"
+            >
+              <g
+                style="text-anchor:end"
+                transform="translate(16, 6) rotate(-90)"
+              >
+                <text>
+                  doc_count
+                </text>
+              </g>
+            </g>
+          </g>
+          <path
+            class="rv-xy-plot__series rv-xy-plot__series--line "
+            d="M0,310L-20,155L-40,180.83333333333331L-60,206.66666666666669L-80,103.33333333333334L-100,180.83333333333331"
+            style="opacity:1;stroke-width:1;stroke:#12939A"
+            transform="translate(80,20)"
+          />
+          <g
+            class="rv-xy-plot__series rv-xy-plot__series--mark undefined"
+            transform="translate(80,20)"
+          >
+            <circle
+              cx="0"
+              cy="310"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+            <circle
+              cx="-20"
+              cy="155"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+            <circle
+              cx="-40"
+              cy="180.83333333333331"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+            <circle
+              cx="-60"
+              cy="206.66666666666669"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+            <circle
+              cx="-80"
+              cy="103.33333333333334"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+            <circle
+              cx="-100"
+              cy="180.83333333333331"
+              r="3"
+              style="opacity:1;stroke:#79C7E3;fill:#79C7E3;stroke-width:1"
+            />
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`VisualGraph renders with bucket level monitor 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium"
+  style="padding-left:10px;padding-right:0px"
+>
+  <div
+    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+    style="padding:0px 10px"
+  >
+    <div
+      class="euiFlexItem"
+    >
+      <h3
+        class="euiTitle euiTitle--small"
+      >
+        COUNT of documents
+      </h3>
+    </div>
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      >
+        <div
+          class="euiFlexItem"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiText euiText--extraSmall"
+    style="padding:0px 10px"
+  >
+    <div
+      class="euiTextColor euiTextColor--subdued"
+    >
+      <span>
+        FOR THE LAST 1 hour(s), GROUP BY customer_gender, Showing top 3 buckets.
+      </span>
+    </div>
+  </div>
+  <hr
+    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+  />
+  <div
+    style="padding:0px 10px"
+  >
+    <div
+      style="width:100%;height:100%"
+    >
+      <div
+        class="rv-xy-plot "
+        style="width:0px;height:400px"
+      >
+        <svg
+          class="rv-xy-plot__inner"
+          height="400"
+          width="0"
+        >
+          <g
+            class="rv-xy-plot__axis rv-xy-plot__axis--horizontal "
+            transform="translate(80,330)"
+          >
+            <line
+              class="rv-xy-plot__axis__line"
+              x1="0"
+              x2="-100"
+              y1="0"
+              y2="0"
+            />
+            <g
+              class="rv-xy-plot__axis__ticks"
+              transform="translate(0, 0)"
+            >
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-14.285714285714285, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  04 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-32.142857142857146, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  05 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-50, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  06 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-67.85714285714286, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  07 PM
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(-85.71428571428571, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="0"
+                  x2="0"
+                  y1="-6"
+                  y2="6"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.72em"
+                  text-anchor="middle"
+                  transform="translate(0, 14)"
+                >
+                  08 PM
+                </text>
+              </g>
+            </g>
+            <g
+              class="rv-xy-plot__axis__title"
+              transform="translate(0, 0)"
+            >
+              <g
+                style="text-anchor:end"
+                transform="translate(-106, -6) rotate(0)"
+              >
+                <text>
+                  order_date
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="rv-xy-plot__axis rv-xy-plot__axis--vertical "
+            transform="translate(0,20)"
+          >
+            <line
+              class="rv-xy-plot__axis__line"
+              x1="80"
+              x2="80"
+              y1="0"
+              y2="310"
+            />
+            <g
+              class="rv-xy-plot__axis__ticks"
+              transform="translate(80, 0)"
+            >
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 310)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  0
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 284.16666666666663)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  1
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 258.33333333333337)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  2
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 232.5)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  3
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 206.66666666666669)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  4
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 180.83333333333331)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  5
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 155)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  6
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 129.16666666666666)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  7
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 103.33333333333334)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  8
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 77.5)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  9
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 51.66666666666666)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  10
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 25.833333333333346)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  11
+                </text>
+              </g>
+              <g
+                class="rv-xy-plot__axis__tick"
+                transform="translate(0, 0)"
+              >
+                <line
+                  class="rv-xy-plot__axis__tick__line"
+                  x1="6"
+                  x2="-6"
+                  y1="0"
+                  y2="0"
+                />
+                <text
+                  class="rv-xy-plot__axis__tick__text"
+                  dy="0.32em"
+                  text-anchor="end"
+                  transform="translate(-14, 0)"
+                >
+                  12
+                </text>
+              </g>
+            </g>
+            <g
+              class="rv-xy-plot__axis__title"
+              transform="translate(80, 0)"
+            >
+              <g
+                style="text-anchor:end"
+                transform="translate(16, 6) rotate(-90)"
+              >
+                <text>
+                  doc_count
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="rv-xy-plot__series rv-xy-plot__series--rect -"
+            transform="translate(80,20)"
+          >
+            <rect
+              height="129.16666666666669"
+              style="opacity:1;stroke:#12939A;fill:#12939A"
+              width="1.5"
+              x="-83.46428571428571"
+              y="180.83333333333331"
+            />
+            <rect
+              height="206.66666666666666"
+              style="opacity:1;stroke:#12939A;fill:#12939A"
+              width="1.5000000000000142"
+              x="-65.60714285714285"
+              y="103.33333333333334"
+            />
+            <rect
+              height="103.33333333333331"
+              style="opacity:1;stroke:#12939A;fill:#12939A"
+              width="1.5"
+              x="-47.75"
+              y="206.66666666666669"
+            />
+            <rect
+              height="129.16666666666669"
+              style="opacity:1;stroke:#12939A;fill:#12939A"
+              width="1.5000000000000036"
+              x="-29.892857142857142"
+              y="180.83333333333331"
+            />
+            <rect
+              height="155"
+              style="opacity:1;stroke:#12939A;fill:#12939A"
+              width="1.5"
+              x="-12.035714285714286"
+              y="155"
+            />
+          </g>
+        </svg>
+        <div
+          class="rv-discrete-color-legend vertical "
+          style="position:absolute;right:50px;top:10px"
+        >
+          <div
+            class="rv-discrete-color-legend-item vertical"
+          >
+            <svg
+              class="rv-discrete-color-legend-item__color"
+              height="2"
+              width="14"
+            >
+              <path
+                class="rv-discrete-color-legend-item__color__path"
+                d="M 0, 1 L 14, 1"
+                style="stroke:#12939A"
+              />
+            </svg>
+            <span
+              class="rv-discrete-color-legend-item__title"
+            >
+              -
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/public/pages/CreateMonitor/components/VisualGraph/index.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import VisualGraph from './VisualGraph';

--- a/public/pages/CreateMonitor/components/VisualGraph/utils/constants.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const SIZE_RANGE = [3, 3];

--- a/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.test.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectorData.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectorData.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetector.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetectorPreviewData.test.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/AnomalyDetectorPreviewData.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/index.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import AnomalyDetectors from './AnomalyDetectors';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component, Fragment } from 'react';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/index.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CreateMonitor from './CreateMonitor';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import { OPERATORS_MAP } from '../../../components/MonitorExpressions/expressions/utils/constants';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorQueryParams.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorQueryParams.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { SEARCH_TYPE } from '../../../../../utils/constants';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/whereFilters.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/whereFilters.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { OPERATORS_MAP } from '../../../components/MonitorExpressions/expressions/utils/constants';

--- a/public/pages/CreateMonitor/containers/DataSource/DataSource.js
+++ b/public/pages/CreateMonitor/containers/DataSource/DataSource.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateMonitor/containers/DataSource/DataSource.test.js
+++ b/public/pages/CreateMonitor/containers/DataSource/DataSource.test.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/DataSource/DataSource.test.js
+++ b/public/pages/CreateMonitor/containers/DataSource/DataSource.test.js
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { httpClientMock } from '../../../../../test/mocks';
+import DataSource from './DataSource';
+import { FORMIK_INITIAL_VALUES } from '../CreateMonitor/utils/constants';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DataSource', () => {
+  test('renders', () => {
+    const wrapper = shallow(
+      <DataSource values={FORMIK_INITIAL_VALUES} httpClient={httpClientMock} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataSource renders 1`] = `
+<ContentPanel
+  bodyStyles={
+    Object {
+      "padding": "initial",
+    }
+  }
+  panelStyles={
+    Object {
+      "paddingLeft": "10px",
+      "paddingRight": "10px",
+    }
+  }
+  title="Data source"
+  titleSize="s"
+>
+  <MonitorIndex
+    httpClient={[MockFunction]}
+  />
+  <EuiSpacer
+    size="s"
+  />
+  <MonitorTimeField />
+</ContentPanel>
+`;

--- a/public/pages/CreateMonitor/containers/DataSource/index.js
+++ b/public/pages/CreateMonitor/containers/DataSource/index.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import DataSource from './DataSource';

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -402,7 +402,7 @@ class DefineMonitor extends Component {
   showPluginWarning() {
     const { values } = this.props;
     const { plugins } = this.state;
-    return values.searchType == SEARCH_TYPE.AD && plugins.indexOf(OS_AD_PLUGIN) == -1;
+    return values.searchType === SEARCH_TYPE.AD && plugins.indexOf(OS_AD_PLUGIN) === -1;
   }
 
   render() {

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component, Fragment } from 'react';

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/DefineMonitor/index.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DefineMonitor from './DefineMonitor';

--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export function shouldSkip(mapping) {

--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.test.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { getPathsPerDataType } from './mappings';

--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/searchRequests.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/searchRequests.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import {

--- a/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/MonitorDetails/index.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/index.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import MonitorDetails from './MonitorDetails';

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateMonitor/containers/MonitorIndex/index.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorIndex from './MonitorIndex';

--- a/public/pages/CreateMonitor/containers/MonitorIndex/utils/helpers.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export function canAppendWildcard(keyPressed) {

--- a/public/pages/CreateMonitor/index.js
+++ b/public/pages/CreateMonitor/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CreateMonitor from './containers/CreateMonitor';

--- a/public/pages/CreateTrigger/components/Action/Action.js
+++ b/public/pages/CreateTrigger/components/Action/Action.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { useState } from 'react';

--- a/public/pages/CreateTrigger/components/Action/actions/Message.test.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/Action/actions/index.js
+++ b/public/pages/CreateTrigger/components/Action/actions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Message from './Message';

--- a/public/pages/CreateTrigger/components/Action/index.js
+++ b/public/pages/CreateTrigger/components/Action/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Action from './Action';

--- a/public/pages/CreateTrigger/components/Action/utils/constants.js
+++ b/public/pages/CreateTrigger/components/Action/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/Action/utils/validate.js
+++ b/public/pages/CreateTrigger/components/Action/utils/validate.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 export const validateDestination = (destinations) => (value) => {

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.test.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import ActionEmptyPrompt from './ActionEmptyPrompt';
+
+describe('ActionEmptyPrompt', () => {
+  test('renders', () => {
+    const wrapper = shallow(<ActionEmptyPrompt />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionEmptyPrompt renders 1`] = `
+<EuiEmptyPrompt
+  actions={
+    <EuiButton
+      fill={true}
+      href="alerting#/create-destination"
+    >
+      Add destination
+    </EuiButton>
+  }
+  body={
+    <EuiText>
+      <p>
+        There are no existing destinations. Add a destinations to create an action.
+      </p>
+    </EuiText>
+  }
+  style={
+    Object {
+      "maxWidth": "45em",
+    }
+  }
+/>
+`;

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/index.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ActionEmptyPrompt from './ActionEmptyPrompt';

--- a/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.test.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AddActionButton from './AddActionButton';
+
+describe('AddActionButton', () => {
+  test('renders', () => {
+    const wrapper = shallow(<AddActionButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/AddActionButton/__snapshots__/AddActionButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddActionButton/__snapshots__/AddActionButton.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddActionButton renders 1`] = `
+<EuiButton
+  fill={false}
+  onClick={[Function]}
+  size="s"
+>
+  Add action
+</EuiButton>
+`;

--- a/public/pages/CreateTrigger/components/AddActionButton/index.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import AddActionButton from './AddActionButton';

--- a/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.test.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AddTriggerButton from './AddTriggerButton';
+
+describe('AddTriggerButton', () => {
+  test('renders', () => {
+    const wrapper = shallow(<AddTriggerButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/AddTriggerButton/__snapshots__/AddTriggerButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/__snapshots__/AddTriggerButton.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddTriggerButton renders 1`] = `
+<EuiButton
+  fill={false}
+  onClick={[Function]}
+  size="s"
+>
+  Add trigger
+</EuiButton>
+`;

--- a/public/pages/CreateTrigger/components/AddTriggerButton/index.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import AddTriggerButton from './AddTriggerButton';

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.js
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.test.js
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/AddTriggerConditionButton.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import AddTriggerConditionButton from './AddTriggerConditionButton';
+
+describe('AddTriggerConditionButton', () => {
+  test('renders', () => {
+    const wrapper = shallow(<AddTriggerConditionButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/__snapshots__/AddTriggerConditionButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/__snapshots__/AddTriggerConditionButton.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddTriggerConditionButton renders 1`] = `
+<EuiButtonEmpty
+  data-test-subj="addTriggerConditionButton"
+  onClick={[Function]}
+  size="xs"
+>
+  + Add condition
+</EuiButtonEmpty>
+`;

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/index.js
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import AddTriggerConditionButton from './AddTriggerConditionButton';

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.test.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/BucketLevelTriggerExpression.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import BucketLevelTriggerExpression from './BucketLevelTriggerExpression';
+
+describe('BucketLevelTriggerExpression', () => {
+  test('renders', () => {
+    const wrapper = shallow(<BucketLevelTriggerExpression />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/__snapshots__/BucketLevelTriggerExpression.test.js.snap
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/__snapshots__/BucketLevelTriggerExpression.test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BucketLevelTriggerExpression renders 1`] = `
+<EuiFlexGroup
+  alignItems="flexStart"
+  gutterSize="m"
+  style={
+    Object {
+      "maxWidth": 1200,
+      "paddingLeft": "10px",
+      "paddingTop": "10px",
+      "whiteSpace": "nowrap",
+    }
+  }
+>
+  <EuiFlexItem
+    grow={false}
+    style={
+      Object {
+        "width": "90px",
+      }
+    }
+  >
+    <Field>
+      <Component />
+    </Field>
+  </EuiFlexItem>
+  <EuiFlexItem
+    grow={false}
+    style={
+      Object {
+        "minWidth": "300px",
+      }
+    }
+  >
+    <Field
+      fullWidth={true}
+    >
+      <Component />
+    </Field>
+  </EuiFlexItem>
+  <EuiFlexItem
+    grow={false}
+    style={
+      Object {
+        "width": "200px",
+      }
+    }
+  >
+    <Field
+      fullWidth={true}
+    >
+      <Component />
+    </Field>
+  </EuiFlexItem>
+  <EuiFlexItem
+    grow={false}
+    style={
+      Object {
+        "width": "200px",
+      }
+    }
+  >
+    <Field>
+      <Component />
+    </Field>
+  </EuiFlexItem>
+  <EuiFlexItem
+    grow={false}
+  >
+    <EuiButton
+      color="danger"
+      onClick={[Function]}
+    >
+      Remove condition
+    </EuiButton>
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/index.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import BucketLevelTriggerExpression from './BucketLevelTriggerExpression';

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.test.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerGraph.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import BucketLevelTriggerGraph from './BucketLevelTriggerGraph';
+
+describe('BucketLevelTriggerGraph', () => {
+  test('renders', () => {
+    const wrapper = shallow(<BucketLevelTriggerGraph />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/BucketLevelTriggerQuery.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/BucketLevelTriggerQuery.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/index.js
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerQuery/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import BucketLevelTriggerQuery from './BucketLevelTriggerQuery';

--- a/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/TriggerEmptyPrompt/index.js
+++ b/public/pages/CreateTrigger/components/TriggerEmptyPrompt/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import TriggerEmptyPrompt from './TriggerEmptyPrompt';

--- a/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.test.js
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/TriggerExpressions/index.js
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import TriggerExpressions from './TriggerExpressions';

--- a/public/pages/CreateTrigger/components/TriggerGraph.js
+++ b/public/pages/CreateTrigger/components/TriggerGraph.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/TriggerGraph.test.js
+++ b/public/pages/CreateTrigger/components/TriggerGraph.test.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import TriggerGraph from './TriggerGraph';
+
+describe('TriggerGraph', () => {
+  test('renders', () => {
+    const wrapper = shallow(<TriggerGraph />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.test.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/TriggerQuery.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/components/TriggerQuery/index.js
+++ b/public/pages/CreateTrigger/components/TriggerQuery/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import TriggerQuery from './TriggerQuery';

--- a/public/pages/CreateTrigger/components/__snapshots__/BucketLevelTriggerGraph.test.js.snap
+++ b/public/pages/CreateTrigger/components/__snapshots__/BucketLevelTriggerGraph.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BucketLevelTriggerGraph renders 1`] = `
+<div
+  style={
+    Object {
+      "padding": "0px 10px",
+    }
+  }
+>
+  <BucketLevelTriggerExpression
+    andOrConditionFieldName="undefinedtriggerConditions[undefined].andOrCondition"
+    enumFieldName="undefinedtriggerConditions[undefined].thresholdEnum"
+    label="Trigger conditions"
+    queryMetric="_count"
+    queryMetricFieldName="undefinedtriggerConditions[undefined].queryMetric"
+    valueFieldName="undefinedtriggerConditions[undefined].thresholdValue"
+  />
+</div>
+`;

--- a/public/pages/CreateTrigger/components/__snapshots__/TriggerGraph.test.js.snap
+++ b/public/pages/CreateTrigger/components/__snapshots__/TriggerGraph.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TriggerGraph renders 1`] = `
+<div
+  style={
+    Object {
+      "padding": "0px 10px",
+    }
+  }
+>
+  <TriggerExpressions
+    keyFieldName="undefinedthresholdEnum"
+    label="Trigger condition"
+    valueFieldName="undefinedthresholdValue"
+  />
+  <EuiSpacer
+    size="m"
+  />
+  <VisualGraph
+    annotation={true}
+  />
+</div>
+`;

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.test.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { checkForError } from './ConfigureActions';

--- a/public/pages/CreateTrigger/containers/ConfigureActions/index.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ConfigureActions from './ConfigureActions';

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/index.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import ConfigureTriggers from './ConfigureTriggers';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import React, { Component, Fragment } from 'react';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/index.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CreateTrigger from './CreateTrigger';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 export const TRIGGER_TYPE = {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/index.js
+++ b/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/index.js
@@ -1,16 +1,6 @@
 /*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import DefineBucketLevelTrigger from './DefineBucketLevelTrigger';

--- a/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/AnomalyDetectorTrigger.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/CreateTrigger/containers/DefineTrigger/index.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DefineTrigger from './DefineTrigger';

--- a/public/pages/CreateTrigger/containers/DefineTrigger/utils/validation.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/utils/validation.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 import _ from 'lodash';
 

--- a/public/pages/CreateTrigger/containers/DefineTrigger/utils/validation.test.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/utils/validation.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { validateTriggerName } from './validation';

--- a/public/pages/CreateTrigger/index.js
+++ b/public/pages/CreateTrigger/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CreateMultipleTriggers from './containers/CreateTrigger/CreateMultipleTriggers';

--- a/public/pages/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 export const DEFAULT_MESSAGE_SOURCE = {

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -1,0 +1,454 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { Component } from 'react';
+import _ from 'lodash';
+import queryString from 'query-string';
+import PropTypes from 'prop-types';
+import {
+  EuiBasicTable,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+} from '@elastic/eui';
+import {
+  ALERT_STATE,
+  MONITOR_ACTIONS,
+  MONITOR_GROUP_BY,
+  MONITOR_INPUT_DETECTOR_ID,
+  MONITOR_TYPE,
+  OPENSEARCH_DASHBOARDS_AD_PLUGIN,
+} from '../../../../utils/constants';
+import {
+  displayAcknowledgedAlertsToast,
+  filterActiveAlerts,
+  getQueryObjectFromState,
+  getURLQueryParams,
+  insertGroupByColumn,
+  removeColumns,
+} from '../../utils/helpers';
+import { backendErrorNotification } from '../../../../utils/helpers';
+import { MAX_ALERT_COUNT } from '../../utils/constants';
+import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../../Monitors/containers/Monitors/utils/constants';
+import DashboardControls from '../DashboardControls';
+import ContentPanel from '../../../../components/ContentPanel';
+import { queryColumns } from '../../utils/tableUtils';
+import DashboardEmptyPrompt from '../DashboardEmptyPrompt';
+
+export const DEFAULT_NUM_MODAL_ROWS = 10;
+
+export default class AcknowledgeAlertsModal extends Component {
+  constructor(props) {
+    super(props);
+    const { location, monitor_id } = this.props;
+
+    const {
+      alertState,
+      from,
+      search,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+    } = getURLQueryParams(location);
+
+    this.state = {
+      alerts: [],
+      alertState: alertState,
+      loading: true,
+      monitors: [],
+      monitorIds: [monitor_id],
+      page: Math.floor(from / size),
+      search: search,
+      selectedItems: [],
+      severityLevel: severityLevel,
+      size: DEFAULT_NUM_MODAL_ROWS,
+      sortDirection: sortDirection,
+      sortField: sortField,
+      totalAlerts: 0,
+    };
+  }
+
+  componentDidMount() {
+    const {
+      alertState,
+      page,
+      search,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+      monitorIds,
+    } = this.state;
+    this.getAlerts(
+      page * size,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds
+    );
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const prevQuery = getQueryObjectFromState(prevState);
+    const currQuery = getQueryObjectFromState(this.state);
+    if (!_.isEqual(prevQuery, currQuery)) {
+      const {
+        page,
+        size,
+        search,
+        sortField,
+        sortDirection,
+        severityLevel,
+        alertState,
+        monitorIds,
+      } = this.state;
+      this.getAlerts(
+        page * size,
+        size,
+        search,
+        sortField,
+        sortDirection,
+        severityLevel,
+        alertState,
+        monitorIds
+      );
+    }
+  }
+
+  getAlerts = async () => {
+    this.setState({ ...this.state, loading: true });
+    const {
+      from,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    } = this.state;
+
+    const { httpClient, history, notifications, triggerId } = this.props;
+
+    const params = {
+      from,
+      size: MAX_ALERT_COUNT,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    };
+
+    const queryParamsString = queryString.stringify(params);
+    history.replace({ ...this.props.location, search: queryParamsString });
+
+    httpClient.get('../api/alerting/alerts', { query: params }).then((resp) => {
+      if (resp.ok) {
+        const { alerts } = resp;
+        const filteredAlerts = _.filter(alerts, { trigger_id: triggerId });
+        this.setState({
+          ...this.state,
+          alerts: filteredAlerts,
+          totalAlerts: filteredAlerts.length,
+        });
+      } else {
+        console.log('error getting alerts:', resp);
+        backendErrorNotification(notifications, 'get', 'alerts', resp.err);
+      }
+    });
+
+    this.setState({ ...this.state, loading: false });
+  };
+
+  acknowledgeAlerts = async () => {
+    const { selectedItems } = this.state;
+    const { httpClient, notifications } = this.props;
+
+    if (!selectedItems.length) return;
+
+    const selectedAlerts = filterActiveAlerts(selectedItems);
+
+    const monitorAlerts = selectedAlerts.reduce((monitorAlerts, alert) => {
+      const { id, monitor_id: monitorId } = alert;
+      if (monitorAlerts[monitorId]) monitorAlerts[monitorId].push(id);
+      else monitorAlerts[monitorId] = [id];
+      return monitorAlerts;
+    }, {});
+
+    Object.entries(monitorAlerts).map(([monitorId, alerts]) =>
+      httpClient
+        .post(`../api/alerting/monitors/${monitorId}/_acknowledge/alerts`, {
+          body: JSON.stringify({ alerts }),
+        })
+        .then((resp) => {
+          if (!resp.ok) {
+            backendErrorNotification(notifications, 'acknowledge', 'alert', resp.resp);
+          } else {
+            const successfulCount = _.get(resp, 'resp.success', []).length;
+            displayAcknowledgedAlertsToast(notifications, successfulCount);
+          }
+        })
+        .catch((error) => error)
+    );
+
+    const {
+      page,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    } = this.state;
+    await this.getAlerts(
+      page * size,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds
+    );
+    this.setState({ ...this.state, selectedItems: [] });
+  };
+
+  onSeverityLevelChange = (e) => {
+    this.setState({ page: 0, severityLevel: e.target.value });
+  };
+
+  onAlertStateChange = (e) => {
+    this.setState({ page: 0, alertState: e.target.value });
+  };
+
+  onPageClick = (page) => {
+    this.setState({ page });
+  };
+
+  onSearchChange = (e) => {
+    this.setState({ page: 0, search: e.target.value });
+  };
+
+  onSelectionChange = (selectedItems) => {
+    this.setState({ selectedItems });
+  };
+
+  onTableChange = ({ page: tablePage = {}, sort = {} }) => {
+    const { index: page, size } = tablePage;
+
+    const { field: sortField, direction: sortDirection } = sort;
+    this.setState({
+      page,
+      size,
+      sortField,
+      sortDirection,
+    });
+
+    const { alerts } = this.props;
+    this.setState({ alerts });
+  };
+
+  onCreateTrigger = () => {
+    const { history, monitorId, onClose } = this.props;
+    onClose();
+    history.push(`/monitors/${monitorId}?action=${MONITOR_ACTIONS.UPDATE_MONITOR}`);
+  };
+
+  render() {
+    const { monitor, onClose, triggerName } = this.props;
+    const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
+    const groupBy = _.get(monitor, MONITOR_GROUP_BY);
+    const monitorType = _.get(monitor, 'monitor_type', MONITOR_TYPE.QUERY_LEVEL);
+
+    const actions = () => {
+      const { selectedItems } = this.state;
+      const actions = [
+        <EuiButton
+          onClick={this.acknowledgeAlerts}
+          disabled={!selectedItems.length}
+          data-test-subj={'alertsDashboardModal_acknowledgeAlertsButton'}
+        >
+          Acknowledge
+        </EuiButton>,
+      ];
+      if (!_.isEmpty(detectorId)) {
+        actions.unshift(
+          <EuiButton
+            href={`${OPENSEARCH_DASHBOARDS_AD_PLUGIN}#/detectors/${detectorId}`}
+            target="_blank"
+          >
+            View detector <EuiIcon type="popout" />
+          </EuiButton>
+        );
+      }
+      return actions;
+    };
+
+    const getItemId = (item) => {
+      switch (monitorType) {
+        case MONITOR_TYPE.QUERY_LEVEL:
+          return `${item.id}-${item.version}`;
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          return item.id;
+      }
+    };
+
+    const {
+      alerts = [],
+      alertState,
+      loading,
+      page,
+      search,
+      selectable,
+      selectedItems,
+      severityLevel,
+      size,
+      sortDirection,
+      sortField,
+      totalAlerts,
+    } = this.state;
+
+    const columnType = () => {
+      let columns = [];
+      switch (monitorType) {
+        case MONITOR_TYPE.QUERY_LEVEL:
+          columns = queryColumns;
+          break;
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          columns = insertGroupByColumn(groupBy);
+          break;
+      }
+      return removeColumns(['trigger_name'], columns);
+    };
+
+    const pagination = {
+      pageIndex: page,
+      pageSize: size,
+      totalItemCount: totalAlerts,
+      pageSizeOptions: DEFAULT_PAGE_SIZE_OPTIONS,
+    };
+
+    const selection = {
+      onSelectionChange: this.onSelectionChange,
+      selectable: (item) => item.state === ALERT_STATE.ACTIVE,
+      selectableMessage: (selectable) =>
+        selectable ? undefined : 'Only active alerts can be acknowledged.',
+    };
+
+    const sorting = {
+      sort: {
+        direction: sortDirection,
+        field: sortField,
+      },
+    };
+
+    const trimmedAlerts = alerts.slice(page * size, page * size + size);
+
+    return (
+      <EuiOverlayMask>
+        <EuiModal
+          onClose={onClose}
+          maxWidth={false}
+          data-test-subj={`alertsDashboardModal_${triggerName}`}
+        >
+          <EuiModalHeader data-test-subj={`alertsDashboardModal_header_${triggerName}`}>
+            <EuiModalHeaderTitle>
+              {`Select which alerts to acknowledge for ${triggerName}`}
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <ContentPanel
+                  title={`Alerts (${selectedItems.length}/${totalAlerts})`}
+                  titleSize={'s'}
+                  bodyStyles={{ padding: 'initial' }}
+                  actions={actions()}
+                >
+                  <DashboardControls
+                    activePage={page}
+                    pageCount={Math.ceil(totalAlerts / size) || 1}
+                    search={search}
+                    severity={severityLevel}
+                    state={alertState}
+                    onSearchChange={this.onSearchChange}
+                    onSeverityChange={this.onSeverityLevelChange}
+                    onStateChange={this.onAlertStateChange}
+                    onPageChange={this.onPageClick}
+                  />
+
+                  <EuiHorizontalRule margin="xs" />
+
+                  <EuiBasicTable
+                    items={loading ? [] : trimmedAlerts}
+                    /*
+                     * If using just ID, doesn't update selectedItems when doing acknowledge
+                     * because the next getAlerts have the same id
+                     * $id-$version will correctly remove selected items
+                     * */
+                    itemId={getItemId}
+                    columns={columnType()}
+                    loading={loading}
+                    pagination={pagination}
+                    sorting={sorting}
+                    isSelectable={selectable}
+                    selection={selection}
+                    onChange={this.onTableChange}
+                    noItemsMessage={
+                      loading ? (
+                        'Loading alerts...'
+                      ) : (
+                        <DashboardEmptyPrompt
+                          onCreateTrigger={this.onCreateTrigger}
+                          isModal={true}
+                        />
+                      )
+                    }
+                    data-test-subj={`alertsDashboardModal_table_${triggerName}`}
+                  />
+                </ContentPanel>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButton
+              onClick={onClose}
+              fill
+              data-test-subj={`alertsDashboardModal_closeButton_${triggerName}`}
+            >
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      </EuiOverlayMask>
+    );
+  }
+}
+
+AcknowledgeAlertsModal.propTypes = {
+  httpClient: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  monitor: PropTypes.object.isRequired,
+  monitorId: PropTypes.string.isRequired,
+  notifications: PropTypes.object.isRequired,
+  triggerId: PropTypes.string.isRequired,
+  triggerName: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.test.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.test.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import _ from 'lodash';
+import { historyMock, httpClientMock } from '../../../../../test/mocks';
+import AcknowledgeAlertsModal from './AcknowledgeAlertsModal';
+import { FORMIK_INITIAL_VALUES } from '../../../CreateMonitor/containers/CreateMonitor/utils/constants';
+import coreMock from '../../../../../test/mocks/CoreMock';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AcknowledgeAlertsModal', () => {
+  test('renders', () => {
+    const location = {
+      hash: '',
+      pathname: '/dashboard',
+      search: '',
+      state: undefined,
+    };
+    const notifications = _.cloneDeep(coreMock.notifications);
+    const component = (
+      <AcknowledgeAlertsModal
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        monitor={FORMIK_INITIAL_VALUES}
+        monitorId={'fake_monitor_id'}
+        notifications={notifications}
+        triggerId={'fake_trigger_id'}
+        triggerName={'fake_trigger_name'}
+        onClose={() => {}}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AcknowledgeAlertsModal renders 1`] = `
+<AcknowledgeAlertsModal
+  history={
+    Object {
+      "action": "REPLACE",
+      "block": [MockFunction],
+      "createHref": [MockFunction],
+      "go": [MockFunction],
+      "goBack": [MockFunction],
+      "goForward": [MockFunction],
+      "length": 0,
+      "listen": [MockFunction],
+      "location": Object {
+        "hash": "",
+        "pathname": "",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [MockFunction],
+      "replace": [MockFunction],
+    }
+  }
+  httpClient={[MockFunction]}
+  location={
+    Object {
+      "hash": "",
+      "pathname": "/dashboard",
+      "search": "",
+      "state": undefined,
+    }
+  }
+  monitor={
+    Object {
+      "aggregationType": "count",
+      "aggregations": Array [],
+      "bucketUnitOfTime": "h",
+      "bucketValue": 1,
+      "cronExpression": "0 */1 * * *",
+      "daily": 0,
+      "detectorId": "",
+      "disabled": false,
+      "fieldName": Array [],
+      "frequency": "interval",
+      "groupBy": Array [],
+      "groupByField": Array [
+        Object {
+          "label": "",
+        },
+      ],
+      "groupedOverFieldName": "bytes",
+      "groupedOverTop": 5,
+      "index": Array [],
+      "monitor_type": "query_level_monitor",
+      "monthly": Object {
+        "day": 1,
+        "type": "day",
+      },
+      "name": "",
+      "overDocuments": "all documents",
+      "period": Object {
+        "interval": 1,
+        "unit": "MINUTES",
+      },
+      "query": "{
+    \\"size\\": 0,
+    \\"query\\": {
+        \\"match_all\\": {}
+    }
+}",
+      "searchType": "graph",
+      "timeField": "",
+      "timezone": Array [],
+      "weekly": Object {
+        "fri": false,
+        "mon": false,
+        "sat": false,
+        "sun": false,
+        "thur": false,
+        "tue": false,
+        "wed": false,
+      },
+      "where": Object {
+        "fieldName": Array [],
+        "fieldRangeEnd": 0,
+        "fieldRangeStart": 0,
+        "fieldValue": "",
+        "operator": "is",
+      },
+    }
+  }
+  monitorId="fake_monitor_id"
+  notifications={
+    Object {
+      "toasts": Object {
+        "addDanger": [MockFunction addDanger],
+        "addSuccess": [MockFunction addSuccess],
+      },
+    }
+  }
+  onClose={[Function]}
+  triggerId="fake_trigger_id"
+  triggerName="fake_trigger_name"
+/>
+`;

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/index.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/index.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import AcknowledgeAlertsModal from './AcknowledgeAlertsModal';
+
+export default AcknowledgeAlertsModal;

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -75,7 +75,12 @@ const DashboardControls = ({
     )}
 
     <EuiFlexItem grow={false}>
-      <EuiSelect options={stateOptions} value={state} onChange={onStateChange} />
+      <EuiSelect
+        options={stateOptions}
+        value={state}
+        onChange={onStateChange}
+        data-test-subj={'dashboardAlertStateFilter'}
+      />
     </EuiFlexItem>
     <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
       <EuiPagination pageCount={pageCount} activePage={activePage} onPageClick={onPageChange} />

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.test.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
@@ -103,6 +103,7 @@ exports[`DashboardControls renders 1`] = `
       >
         <select
           class="euiSelect"
+          data-test-subj="dashboardAlertStateFilter"
         >
           <option
             selected=""

--- a/public/pages/Dashboard/components/DashboardControls/index.js
+++ b/public/pages/Dashboard/components/DashboardControls/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DashboardControls from './DashboardControls';

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
@@ -14,6 +14,9 @@ const createMonitorText =
   'There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.';
 const createTriggerText =
   'There are no existing alerts. Create a trigger to start alerting. Once an alarm is triggered, the state will show in this table.';
+const editTriggerConditionsText =
+  'There are no existing alerts. Adjust trigger conditions to start alerting. Once an alarm is triggered, the state will show in this table.';
+
 const createMonitorButton = (
   <EuiButton fill href={`${PLUGIN_NAME}#${APP_PATH.CREATE_MONITOR}`}>
     Create monitor
@@ -25,17 +28,24 @@ const editMonitorButton = (onCreateTrigger) => (
   </EuiButton>
 );
 
-const DashboardEmptyPrompt = ({ onCreateTrigger }) => {
+const DashboardEmptyPrompt = ({ onCreateTrigger, isModal = false }) => {
   const inMonitorDetails = typeof onCreateTrigger === 'function';
+  const displayText = isModal
+    ? editTriggerConditionsText
+    : inMonitorDetails
+    ? createTriggerText
+    : createMonitorText;
   return (
     <EuiEmptyPrompt
       style={{ maxWidth: '45em' }}
       body={
         <EuiText>
-          <p>{inMonitorDetails ? createTriggerText : createMonitorText}</p>
+          <p>{displayText}</p>
         </EuiText>
       }
-      actions={inMonitorDetails ? editMonitorButton(onCreateTrigger) : createMonitorButton}
+      actions={
+        inMonitorDetails || isModal ? editMonitorButton(onCreateTrigger) : createMonitorButton
+      }
     />
   );
 };

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.test.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/index.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DashboardEmptyPrompt from './DashboardEmptyPrompt';

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -32,16 +32,23 @@ import ContentPanel from '../../../components/ContentPanel';
 import DashboardEmptyPrompt from '../components/DashboardEmptyPrompt';
 import DashboardControls from '../components/DashboardControls';
 import { alertColumns, queryColumns } from '../utils/tableUtils';
-import { MONITOR_TYPE, OPENSEARCH_DASHBOARDS_AD_PLUGIN } from '../../../utils/constants';
+import {
+  ALERT_STATE,
+  MONITOR_TYPE,
+  OPENSEARCH_DASHBOARDS_AD_PLUGIN,
+} from '../../../utils/constants';
 import { backendErrorNotification } from '../../../utils/helpers';
 import {
+  displayAcknowledgedAlertsToast,
+  filterActiveAlerts,
   getInitialSize,
+  getQueryObjectFromState,
+  getURLQueryParams,
   groupAlertsByTrigger,
   insertGroupByColumn,
-  removeColumns,
 } from '../utils/helpers';
 import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../Monitors/containers/Monitors/utils/constants';
-import { MAX_ALERT_COUNT, DEFAULT_GET_ALERTS_QUERY_PARAMS } from '../utils/constants';
+import { MAX_ALERT_COUNT } from '../utils/constants';
 
 // TODO: Abstract out a Table component to be used in both Dashboard and Monitors
 
@@ -49,7 +56,7 @@ export default class Dashboard extends Component {
   constructor(props) {
     super(props);
 
-    const { flyoutAlerts, isAlertsFlyout = false, perAlertView } = props;
+    const { location, perAlertView } = props;
 
     const {
       alertState,
@@ -59,12 +66,13 @@ export default class Dashboard extends Component {
       size,
       sortDirection,
       sortField,
-    } = this.getURLQueryParams();
+    } = getURLQueryParams(location);
 
     this.state = {
       alerts: [],
       alertsByTriggers: [],
       alertState,
+      flyoutIsOpen: false,
       loadingMonitors: true,
       monitors: [],
       monitorIds: this.props.monitorIds,
@@ -72,12 +80,11 @@ export default class Dashboard extends Component {
       search,
       selectedItems: [],
       severityLevel,
-      size: getInitialSize(isAlertsFlyout, perAlertView, size),
+      size: getInitialSize(perAlertView, size),
       sortDirection,
       sortField,
       totalAlerts: 0,
       totalTriggers: 0,
-      trimmedFlyoutAlerts: flyoutAlerts ? flyoutAlerts.slice(0, 10) : [],
     };
   }
 
@@ -110,8 +117,8 @@ export default class Dashboard extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const prevQuery = this.getQueryObjectFromState(prevState);
-    const currQuery = this.getQueryObjectFromState(this.state);
+    const prevQuery = getQueryObjectFromState(prevState);
+    const currQuery = getQueryObjectFromState(this.state);
     if (!_.isEqual(prevQuery, currQuery)) {
       const {
         page,
@@ -135,50 +142,6 @@ export default class Dashboard extends Component {
       );
     }
   }
-
-  getQueryObjectFromState = ({
-    page,
-    size,
-    search,
-    sortField,
-    sortDirection,
-    severityLevel,
-    alertState,
-    monitorIds,
-  }) => ({
-    page,
-    size,
-    search,
-    sortField,
-    sortDirection,
-    severityLevel,
-    alertState,
-    monitorIds,
-  });
-
-  getURLQueryParams = () => {
-    const {
-      from = DEFAULT_GET_ALERTS_QUERY_PARAMS.from,
-      size = DEFAULT_GET_ALERTS_QUERY_PARAMS.size,
-      search = DEFAULT_GET_ALERTS_QUERY_PARAMS.search,
-      sortField = DEFAULT_GET_ALERTS_QUERY_PARAMS.sortField,
-      sortDirection = DEFAULT_GET_ALERTS_QUERY_PARAMS.sortDirection,
-      severityLevel = DEFAULT_GET_ALERTS_QUERY_PARAMS.severityLevel,
-      alertState = DEFAULT_GET_ALERTS_QUERY_PARAMS.alertState,
-      monitorIds = this.props.monitorIds,
-    } = queryString.parse(this.props.location.search);
-
-    return {
-      from: isNaN(parseInt(from, 10)) ? DEFAULT_GET_ALERTS_QUERY_PARAMS.from : parseInt(from, 10),
-      size: isNaN(parseInt(size, 10)) ? DEFAULT_GET_ALERTS_QUERY_PARAMS.size : parseInt(size, 10),
-      search,
-      sortField,
-      sortDirection,
-      severityLevel,
-      alertState,
-      monitorIds,
-    };
-  };
 
   getAlerts = _.debounce(
     (from, size, search, sortField, sortDirection, severityLevel, alertState, monitorIds) => {
@@ -259,7 +222,8 @@ export default class Dashboard extends Component {
 
     if (!selectedItems.length) return;
 
-    const selectedAlerts = perAlertView ? selectedItems : _.get(selectedItems, '0.alerts', []);
+    let selectedAlerts = perAlertView ? selectedItems : _.get(selectedItems, '0.alerts', []);
+    selectedAlerts = filterActiveAlerts(selectedAlerts);
 
     const monitorAlerts = selectedAlerts.reduce((monitorAlerts, alert) => {
       const { id, monitor_id: monitorId } = alert;
@@ -268,7 +232,7 @@ export default class Dashboard extends Component {
       return monitorAlerts;
     }, {});
 
-    const promises = Object.entries(monitorAlerts).map(([monitorId, alerts]) =>
+    Object.entries(monitorAlerts).map(([monitorId, alerts]) =>
       httpClient
         .post(`../api/alerting/monitors/${monitorId}/_acknowledge/alerts`, {
           body: JSON.stringify({ alerts }),
@@ -276,14 +240,14 @@ export default class Dashboard extends Component {
         .then((resp) => {
           if (!resp.ok) {
             backendErrorNotification(notifications, 'acknowledge', 'alert', resp.resp);
+          } else {
+            const successfulCount = _.get(resp, 'resp.success', []).length;
+            displayAcknowledgedAlertsToast(notifications, successfulCount);
           }
         })
         .catch((error) => error)
     );
 
-    const values = await Promise.all(promises);
-    console.log('values:', values);
-    // // TODO: Show which values failed, succeeded, etc.
     const {
       page,
       size,
@@ -308,23 +272,9 @@ export default class Dashboard extends Component {
   };
 
   onTableChange = ({ page: tablePage = {}, sort = {} }) => {
-    const { isAlertsFlyout } = this.props;
     const { index: page, size } = tablePage;
-
     const { field: sortField, direction: sortDirection } = sort;
-    this.setState({
-      page,
-      size,
-      sortField,
-      sortDirection,
-    });
-
-    // If the table is in flyout, return the trimmed array of alerts.
-    if (isAlertsFlyout) {
-      const { flyoutAlerts } = this.props;
-      const trimmedFlyoutAlerts = flyoutAlerts.slice(page * size, page * size + size);
-      this.setState({ trimmedFlyoutAlerts });
-    }
+    this.setState({ page, size, sortField, sortDirection });
   };
 
   onSeverityLevelChange = (e) => {
@@ -347,6 +297,42 @@ export default class Dashboard extends Component {
     this.setState({ page });
   };
 
+  openFlyout = (payload) => {
+    this.setState({ ...this.state, flyoutIsOpen: true });
+    this.props.setFlyout({
+      type: 'alertsDashboard',
+      payload: { ...payload },
+    });
+  };
+
+  closeFlyout = () => {
+    this.props.setFlyout(null);
+    this.setState({ ...this.state, flyoutIsOpen: false });
+  };
+
+  refreshDashboard = () => {
+    const {
+      page,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds,
+    } = this.state;
+    this.getAlerts(
+      page * size,
+      size,
+      search,
+      sortField,
+      sortDirection,
+      severityLevel,
+      alertState,
+      monitorIds
+    );
+  };
+
   render() {
     const {
       alerts,
@@ -363,7 +349,6 @@ export default class Dashboard extends Component {
       sortField,
       totalAlerts,
       totalTriggers,
-      trimmedFlyoutAlerts,
     } = this.state;
     const {
       monitorIds,
@@ -393,13 +378,11 @@ export default class Dashboard extends Component {
           location,
           monitors,
           notifications,
-          setFlyout
+          setFlyout,
+          this.openFlyout,
+          this.closeFlyout,
+          this.refreshDashboard
         );
-
-    if (isAlertsFlyout) {
-      totalItems = this.props.flyoutAlerts.length;
-      columnType = removeColumns(['severity', 'trigger_name'], columnType);
-    }
 
     const pagination = {
       pageIndex: page,
@@ -417,11 +400,13 @@ export default class Dashboard extends Component {
 
     const selection = {
       onSelectionChange: this.onSelectionChange,
-      selectable: perAlertView ? (item) => item.state === 'ACTIVE' : (item) => item.ACTIVE > 0,
+      selectable: perAlertView
+        ? (item) => item.state === ALERT_STATE.ACTIVE
+        : (item) => item.ACTIVE > 0,
       selectableMessage: perAlertView
-        ? (selectable) => (selectable ? undefined : 'Only Active Alerts are Acknowledgeable')
+        ? (selectable) => (selectable ? undefined : 'Only active alerts can be acknowledged.')
         : (selectable) =>
-            selectable ? undefined : 'Only Triggers with Active Alerts are Acknowledgeable',
+            selectable ? undefined : 'Only triggers with active alerts can be acknowledged.',
     };
 
     const actions = () => {
@@ -430,6 +415,7 @@ export default class Dashboard extends Component {
         <EuiButton
           onClick={this.acknowledgeAlert}
           disabled={perAlertView ? !selectedItems.length : selectedItems.length !== 1}
+          data-test-subj={'acknowledgeAlertsButton'}
         >
           Acknowledge
         </EuiButton>,
@@ -440,18 +426,17 @@ export default class Dashboard extends Component {
         actions.unshift(
           <EuiButton
             onClick={() => {
-              setFlyout({
-                type: 'alertsDashboard',
-                payload: {
-                  ...alert,
-                  history,
-                  httpClient,
-                  loadingMonitors,
-                  location,
-                  monitors,
-                  notifications,
-                  setFlyout,
-                },
+              this.openFlyout({
+                ...alert,
+                history,
+                httpClient,
+                loadingMonitors,
+                location,
+                monitors,
+                notifications,
+                setFlyout,
+                closeFlyout: this.closeFlyout,
+                refreshDashboard: this.refreshDashboard,
               });
             }}
             disabled={selectedItems.length !== 1}
@@ -502,7 +487,7 @@ export default class Dashboard extends Component {
         <EuiHorizontalRule margin="xs" />
 
         <EuiBasicTable
-          items={perAlertView ? (isAlertsFlyout ? trimmedFlyoutAlerts : alerts) : alertsByTriggers}
+          items={perAlertView ? alerts : alertsByTriggers}
           /*
            * If using just ID, doesn't update selectedItems when doing acknowledge
            * because the next getAlerts have the same id

--- a/public/pages/Dashboard/containers/Dashboard.test.js
+++ b/public/pages/Dashboard/containers/Dashboard.test.js
@@ -36,6 +36,45 @@ const location = {
   state: undefined,
 };
 
+const sampleQueryAlerts = [
+  {
+    id: 'Ciw2DH0B3-v9t8HD4m3Q',
+    monitor_id: '7SwkDH0B3-v9t8HDk2zN',
+    schema_version: 3,
+    monitor_version: 2,
+    monitor_name: 'test-query-monitor',
+    trigger_id: '7CwkDH0B3-v9t8HDk2w_',
+    trigger_name: 'test-query-trigger',
+    state: 'ACTIVE',
+    error_message: null,
+    alert_history: [],
+    severity: '1',
+    action_execution_results: [],
+    start_time: 1636587463371,
+    last_notification_time: 1636587523369,
+    end_time: null,
+    acknowledged_time: null,
+  },
+  {
+    id: 'Cyw2DH0B3-v9t8HD4m3Q',
+    monitor_id: '7SwkDH0B3-v9t8HDk2zN',
+    schema_version: 3,
+    monitor_version: 2,
+    monitor_name: 'test-query-monitor',
+    trigger_id: '_iw2DH0B3-v9t8HDNWwE',
+    trigger_name: 'test-query-trigger2',
+    state: 'ACTIVE',
+    error_message: null,
+    alert_history: [],
+    severity: '1',
+    action_execution_results: [],
+    start_time: 1636587463371,
+    last_notification_time: 1636587523370,
+    end_time: null,
+    acknowledged_time: null,
+  },
+];
+
 const runAllPromises = () => new Promise(setImmediate);
 
 describe('Dashboard', () => {
@@ -43,7 +82,7 @@ describe('Dashboard', () => {
     jest.clearAllMocks();
   });
 
-  test('renders', () => {
+  test('renders with per alert view', () => {
     const resp = {
       ok: true,
       alerts: [],
@@ -53,7 +92,56 @@ describe('Dashboard', () => {
     httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
 
     const wrapper = mount(
-      <Dashboard httpClient={httpClientMock} history={historyMock} location={location} />
+      <Dashboard
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        perAlertView={true}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('renders with alert by triggers view', () => {
+    const resp = {
+      ok: true,
+      alerts: [],
+      totalAlerts: 0,
+    };
+
+    httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
+
+    const wrapper = mount(
+      <Dashboard
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        perAlertView={false}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('renders in flyout', () => {
+    const resp = {
+      ok: true,
+      alerts: [],
+      totalAlerts: 0,
+    };
+
+    httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
+
+    const wrapper = mount(
+      <Dashboard
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        isAlertsFlyout={true}
+        flyoutAlerts={sampleQueryAlerts}
+        perAlertView={true}
+      />
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -103,5 +191,32 @@ describe('Dashboard', () => {
     expect(wrapper.instance().state.alerts[0].action_execution_results).toStrictEqual([]);
     expect(wrapper.instance().state.alerts[0].alert_history).toStrictEqual([]);
     expect(wrapper.instance().state.alerts[0].error_message).toBe('');
+  });
+
+  test.skip('able to select single alert in flyout', () => {
+    const resp = {
+      ok: true,
+      alerts: [],
+      totalAlerts: 0,
+    };
+
+    httpClientMock.get = jest.fn().mockImplementation(() => Promise.resolve(resp));
+
+    const wrapper = mount(
+      <Dashboard
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        isAlertsFlyout={true}
+        flyoutAlerts={sampleQueryAlerts}
+      />
+    );
+    //TODO: Figure out how to find the 1 acknowledge button out of 3 nodes
+    expect(wrapper.find('[data-test-subj="acknowledgeButton"]').is('[disabled]')).toBe(true);
+    wrapper
+      .find('[data-test-subj="checkboxSelectRow-Ciw2DH0B3-v9t8HD4m3Q-3"]')
+      .hostNodes()
+      .simulate('change');
+    expect(wrapper.find('[data-test-subj="acknowledgeButton"]').is('[disabled]')).toBe(false);
   });
 });

--- a/public/pages/Dashboard/containers/Dashboard.test.js
+++ b/public/pages/Dashboard/containers/Dashboard.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -1,6 +1,1576 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dashboard renders 1`] = `
+exports[`Dashboard renders in flyout 1`] = `
+<Dashboard
+  detectorIds={Array []}
+  flyoutAlerts={
+    Array [
+      Object {
+        "acknowledged_time": null,
+        "action_execution_results": Array [],
+        "alert_history": Array [],
+        "end_time": null,
+        "error_message": null,
+        "id": "Ciw2DH0B3-v9t8HD4m3Q",
+        "last_notification_time": 1636587523369,
+        "monitor_id": "7SwkDH0B3-v9t8HDk2zN",
+        "monitor_name": "test-query-monitor",
+        "monitor_version": 2,
+        "schema_version": 3,
+        "severity": "1",
+        "start_time": 1636587463371,
+        "state": "ACTIVE",
+        "trigger_id": "7CwkDH0B3-v9t8HDk2w_",
+        "trigger_name": "test-query-trigger",
+      },
+      Object {
+        "acknowledged_time": null,
+        "action_execution_results": Array [],
+        "alert_history": Array [],
+        "end_time": null,
+        "error_message": null,
+        "id": "Cyw2DH0B3-v9t8HD4m3Q",
+        "last_notification_time": 1636587523370,
+        "monitor_id": "7SwkDH0B3-v9t8HDk2zN",
+        "monitor_name": "test-query-monitor",
+        "monitor_version": 2,
+        "schema_version": 3,
+        "severity": "1",
+        "start_time": 1636587463371,
+        "state": "ACTIVE",
+        "trigger_id": "_iw2DH0B3-v9t8HDNWwE",
+        "trigger_name": "test-query-trigger2",
+      },
+    ]
+  }
+  history={
+    Object {
+      "action": "REPLACE",
+      "block": [MockFunction],
+      "createHref": [MockFunction],
+      "go": [MockFunction],
+      "goBack": [MockFunction],
+      "goForward": [MockFunction],
+      "length": 0,
+      "listen": [MockFunction],
+      "location": Object {
+        "hash": "",
+        "pathname": "",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [MockFunction],
+      "replace": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "hash": "",
+              "search": "alertState=ALL&from=0&search=&severityLevel=ALL&size=20&sortDirection=desc&sortField=start_time",
+              "state": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+  httpClient={[MockFunction]}
+  isAlertsFlyout={true}
+  location={
+    Object {
+      "hash": "",
+      "search": "",
+      "state": undefined,
+    }
+  }
+  monitorIds={Array []}
+  perAlertView={true}
+>
+  <ContentPanel
+    actions={
+      Array [
+        <EuiButton
+          data-test-subj="acknowledgeAlertsButton"
+          disabled={true}
+          onClick={[Function]}
+        >
+          Acknowledge
+        </EuiButton>,
+      ]
+    }
+    bodyStyles={
+      Object {
+        "padding": "initial",
+      }
+    }
+    title="Alerts"
+    titleSize="l"
+  >
+    <EuiPanel
+      style={
+        Object {
+          "paddingLeft": "0px",
+          "paddingRight": "0px",
+        }
+      }
+    >
+      <div
+        className="euiPanel euiPanel--paddingMedium"
+        style={
+          Object {
+            "paddingLeft": "0px",
+            "paddingRight": "0px",
+          }
+        }
+      >
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiFlexItem>
+              <div
+                className="euiFlexItem"
+              >
+                <EuiTitle
+                  size="l"
+                >
+                  <h3
+                    className="euiTitle euiTitle--large"
+                  >
+                    Alerts
+                  </h3>
+                </EuiTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup
+                  alignItems="center"
+                  justifyContent="spaceBetween"
+                >
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem
+                      key="0"
+                    >
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiButton
+                          data-test-subj="acknowledgeAlertsButton"
+                          disabled={true}
+                          onClick={[Function]}
+                        >
+                          <EuiButtonDisplay
+                            data-test-subj="acknowledgeAlertsButton"
+                            disabled={true}
+                            element="button"
+                            isDisabled={true}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <button
+                              className="euiButton euiButton--primary euiButton-isDisabled"
+                              data-test-subj="acknowledgeAlertsButton"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text"
+                                  >
+                                    Acknowledge
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonDisplay>
+                        </EuiButton>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiText
+          color="subdued"
+          size="xs"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiText euiText--extraSmall"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiTextColor
+              color="subdued"
+              component="div"
+            >
+              <div
+                className="euiTextColor euiTextColor--subdued"
+              />
+            </EuiTextColor>
+          </div>
+        </EuiText>
+        <EuiHorizontalRule
+          className=""
+          margin="xs"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+        </EuiHorizontalRule>
+        <div
+          style={
+            Object {
+              "padding": "initial",
+            }
+          }
+        >
+          <DashboardControls
+            activePage={0}
+            isAlertsFlyout={true}
+            onPageChange={[Function]}
+            onSearchChange={[Function]}
+            onSeverityChange={[Function]}
+            onStateChange={[Function]}
+            pageCount={1}
+            search=""
+            severity="ALL"
+            state="ALL"
+          >
+            <EuiFlexGroup
+              style={
+                Object {
+                  "padding": "0px 5px",
+                }
+              }
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style={
+                  Object {
+                    "padding": "0px 5px",
+                  }
+                }
+              >
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={true}
+                      incremental={false}
+                      isClearable={true}
+                      isLoading={false}
+                      onChange={[Function]}
+                      placeholder="Search"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Search"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="search"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      data-test-subj="dashboardAlertStateFilter"
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All alerts",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "Active",
+                            "value": "ACTIVE",
+                          },
+                          Object {
+                            "text": "Acknowledged",
+                            "value": "ACKNOWLEDGED",
+                          },
+                          Object {
+                            "text": "Completed",
+                            "value": "COMPLETED",
+                          },
+                          Object {
+                            "text": "Error",
+                            "value": "ERROR",
+                          },
+                          Object {
+                            "text": "Deleted",
+                            "value": "DELETED",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                data-test-subj="dashboardAlertStateFilter"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All alerts
+                                </option>
+                                <option
+                                  key="1"
+                                  value="ACTIVE"
+                                >
+                                  Active
+                                </option>
+                                <option
+                                  key="2"
+                                  value="ACKNOWLEDGED"
+                                >
+                                  Acknowledged
+                                </option>
+                                <option
+                                  key="3"
+                                  value="COMPLETED"
+                                >
+                                  Completed
+                                </option>
+                                <option
+                                  key="4"
+                                  value="ERROR"
+                                >
+                                  Error
+                                </option>
+                                <option
+                                  key="5"
+                                  value="DELETED"
+                                >
+                                  Deleted
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={
+                    Object {
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    style={
+                      Object {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <EuiPagination
+                      activePage={0}
+                      onPageClick={[Function]}
+                      pageCount={1}
+                    >
+                      <nav
+                        className="euiPagination"
+                      >
+                        <EuiI18n
+                          default="Previous page, {page}"
+                          token="euiPagination.previousPage"
+                          values={
+                            Object {
+                              "page": 0,
+                            }
+                          }
+                        >
+                          <EuiI18n
+                            default="Previous page"
+                            token="euiPagination.disabledPreviousPage"
+                          >
+                            <EuiButtonIcon
+                              aria-label="Previous page"
+                              color="text"
+                              data-test-subj="pagination-button-previous"
+                              disabled={true}
+                              iconType="arrowLeft"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-label="Previous page"
+                                className="euiButtonIcon euiButtonIcon--text"
+                                data-test-subj="pagination-button-previous"
+                                disabled={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiButtonIcon__icon"
+                                  size="m"
+                                  type="arrowLeft"
+                                >
+                                  <div>
+                                    EuiIconMock
+                                  </div>
+                                </EuiIcon>
+                              </button>
+                            </EuiButtonIcon>
+                          </EuiI18n>
+                        </EuiI18n>
+                        <ul
+                          className="euiPagination__list"
+                        >
+                          <PaginationButton
+                            key="0"
+                            pageIndex={0}
+                          >
+                            <li
+                              className="euiPagination__item"
+                            >
+                              <EuiPaginationButton
+                                hideOnMobile={true}
+                                isActive={true}
+                                onClick={[Function]}
+                                pageIndex={0}
+                                totalPages={1}
+                              >
+                                <EuiI18n
+                                  default="Page {page} of {totalPages}"
+                                  token="euiPaginationButton.longPageString"
+                                  values={
+                                    Object {
+                                      "page": 1,
+                                      "totalPages": 1,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Page {page}"
+                                    token="euiPaginationButton.shortPageString"
+                                    values={
+                                      Object {
+                                        "page": 1,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonEmpty
+                                      aria-current={true}
+                                      aria-label="Page 1 of 1"
+                                      className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                      color="text"
+                                      data-test-subj="pagination-button-0"
+                                      isDisabled={true}
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <button
+                                        aria-current={true}
+                                        aria-label="Page 1 of 1"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                        data-test-subj="pagination-button-0"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="left"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonEmpty__content"
+                                          >
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              1
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </EuiI18n>
+                                </EuiI18n>
+                              </EuiPaginationButton>
+                            </li>
+                          </PaginationButton>
+                        </ul>
+                        <EuiI18n
+                          default="Next page, {page}"
+                          token="euiPagination.nextPage"
+                          values={
+                            Object {
+                              "page": 2,
+                            }
+                          }
+                        >
+                          <EuiI18n
+                            default="Next page"
+                            token="euiPagination.disabledNextPage"
+                          >
+                            <EuiButtonIcon
+                              aria-label="Next page"
+                              color="text"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              iconType="arrowRight"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-label="Next page"
+                                className="euiButtonIcon euiButtonIcon--text"
+                                data-test-subj="pagination-button-next"
+                                disabled={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiButtonIcon__icon"
+                                  size="m"
+                                  type="arrowRight"
+                                >
+                                  <div>
+                                    EuiIconMock
+                                  </div>
+                                </EuiIcon>
+                              </button>
+                            </EuiButtonIcon>
+                          </EuiI18n>
+                        </EuiI18n>
+                      </nav>
+                    </EuiPagination>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </DashboardControls>
+          <EuiHorizontalRule
+            margin="xs"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+            />
+          </EuiHorizontalRule>
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "dataType": "date",
+                  "field": "start_time",
+                  "name": "Alert start time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "end_time",
+                  "name": "Alert end time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "trigger_name",
+                  "name": "Trigger name",
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "field": "severity",
+                  "name": "Severity",
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "state",
+                  "name": "State",
+                  "render": [Function],
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "acknowledged_time",
+                  "name": "Time acknowledged",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId={[Function]}
+            items={Array []}
+            noItemsMessage={<DashboardEmptyPrompt />}
+            onChange={[Function]}
+            pagination={
+              Object {
+                "pageIndex": 0,
+                "pageSize": 20,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  20,
+                  50,
+                ],
+                "totalItemCount": 0,
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+                "selectable": [Function],
+                "selectableMessage": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "desc",
+                  "field": "start_time",
+                },
+              }
+            }
+            tableLayout="fixed"
+          >
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
+                  >
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiI18n
+                              default="Select all rows"
+                              token="euiBasicTable.selectAllRows"
+                            >
+                              <EuiCheckbox
+                                aria-label="Select all rows"
+                                checked={false}
+                                compressed={false}
+                                disabled={true}
+                                id="_selection_column-checkbox_generated-id"
+                                indeterminate={false}
+                                label="Select all rows"
+                                onChange={[Function]}
+                              >
+                                <div
+                                  className="euiCheckbox"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_generated-id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                  <label
+                                    className="euiCheckbox__label"
+                                    htmlFor="_selection_column-checkbox_generated-id"
+                                  >
+                                    Select all rows
+                                  </label>
+                                </div>
+                              </EuiCheckbox>
+                            </EuiI18n>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": false,
+                                    "isSorted": true,
+                                    "key": "_data_s_start_time_0",
+                                    "name": "Alert start time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_end_time_1",
+                                    "name": "Alert end time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_trigger_name_2",
+                                    "name": "Trigger name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_acknowledged_time_5",
+                                    "name": "Time acknowledged",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
+                            >
+                              <div
+                                className="euiTableSortMobile"
+                              >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
+                                    <EuiButtonEmpty
+                                      flush="right"
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <EuiOutsideClickDetector
+                                    isDisabled={true}
+                                    onOutsideClick={[Function]}
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                      onKeyDown={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchStart={[Function]}
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  size="m"
+                                                  type="arrowDown"
+                                                >
+                                                  <div>
+                                                    EuiIconMock
+                                                  </div>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiOutsideClickDetector>
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
+                  id="generated-id"
+                  responsive={true}
+                  tableLayout="fixed"
+                >
+                  <table
+                    className="euiTable euiTable--responsive"
+                    id="generated-id"
+                    tabIndex={-1}
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCellCheckbox
+                            key="_selection_column_h"
+                          >
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiI18n
+                                  default="Select all rows"
+                                  token="euiBasicTable.selectAllRows"
+                                >
+                                  <EuiCheckbox
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    compressed={false}
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_generated-id"
+                                    indeterminate={false}
+                                    label={null}
+                                    onChange={[Function]}
+                                    type="inList"
+                                  >
+                                    <div
+                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                    >
+                                      <input
+                                        aria-label="Select all rows"
+                                        checked={false}
+                                        className="euiCheckbox__input"
+                                        data-test-subj="checkboxSelectAll"
+                                        disabled={true}
+                                        id="_selection_column-checkbox_generated-id"
+                                        onChange={[Function]}
+                                        type="checkbox"
+                                      />
+                                      <div
+                                        className="euiCheckbox__square"
+                                      />
+                                    </div>
+                                  </EuiCheckbox>
+                                </EuiI18n>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCellCheckbox>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_start_time_0"
+                            isSortAscending={false}
+                            isSorted={true}
+                            key="_data_h_start_time_0"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="descending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_start_time_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "descending",
+                                          "innerText": "Alert start time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert start time; Sorted in descending order"
+                                      >
+                                        Alert start time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiI18n
+                                    default="Sorted in {ariaSortValue} order"
+                                    token="euiTableHeaderCell.sortedAriaLabel"
+                                    values={
+                                      Object {
+                                        "ariaSortValue": "descending",
+                                      }
+                                    }
+                                  >
+                                    <EuiIcon
+                                      aria-label="Sorted in descending order"
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </EuiI18n>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_end_time_1"
+                            isSorted={false}
+                            key="_data_h_end_time_1"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_end_time_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Alert end time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert end time"
+                                      >
+                                        Alert end time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_trigger_name_2"
+                            isSorted={false}
+                            key="_data_h_trigger_name_2"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trigger_name_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Trigger name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trigger name"
+                                      >
+                                        Trigger name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_severity_3"
+                            key="_data_h_severity_3"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_severity_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Severity"
+                                  >
+                                    Severity
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_state_4"
+                            key="_data_h_state_4"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_state_4"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="State"
+                                  >
+                                    State
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_acknowledged_time_5"
+                            isSorted={false}
+                            key="_data_h_acknowledged_time_5"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_acknowledged_time_5"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Time acknowledged",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Time acknowledged"
+                                      >
+                                        Time acknowledged
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody>
+                      <tbody>
+                        <EuiTableRow>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="center"
+                              colSpan={7}
+                              isMobileFullWidth={true}
+                            >
+                              <td
+                                className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                colSpan={7}
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    <DashboardEmptyPrompt>
+                                      <EuiEmptyPrompt
+                                        actions={
+                                          <EuiButton
+                                            fill={true}
+                                            href="alerting#/create-monitor"
+                                          >
+                                            Create monitor
+                                          </EuiButton>
+                                        }
+                                        body={
+                                          <EuiText>
+                                            <p>
+                                              There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                            </p>
+                                          </EuiText>
+                                        }
+                                        style={
+                                          Object {
+                                            "maxWidth": "45em",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="euiEmptyPrompt"
+                                          style={
+                                            Object {
+                                              "maxWidth": "45em",
+                                            }
+                                          }
+                                        >
+                                          <EuiTextColor
+                                            color="subdued"
+                                          >
+                                            <span
+                                              className="euiTextColor euiTextColor--subdued"
+                                            >
+                                              <EuiText>
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                >
+                                                  <EuiText>
+                                                    <div
+                                                      className="euiText euiText--medium"
+                                                    >
+                                                      <p>
+                                                        There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                                      </p>
+                                                    </div>
+                                                  </EuiText>
+                                                </div>
+                                              </EuiText>
+                                            </span>
+                                          </EuiTextColor>
+                                          <EuiSpacer
+                                            size="l"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--l"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiSpacer
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--s"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiButton
+                                            fill={true}
+                                            href="alerting#/create-monitor"
+                                          >
+                                            <EuiButtonDisplay
+                                              element="a"
+                                              fill={true}
+                                              href="alerting#/create-monitor"
+                                              isDisabled={false}
+                                              rel="noreferrer"
+                                            >
+                                              <a
+                                                className="euiButton euiButton--primary euiButton--fill"
+                                                href="alerting#/create-monitor"
+                                                rel="noreferrer"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButton__content"
+                                                  iconSide="left"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButton__text",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButton__content"
+                                                  >
+                                                    <span
+                                                      className="euiButton__text"
+                                                    >
+                                                      Create monitor
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </a>
+                                            </EuiButtonDisplay>
+                                          </EuiButton>
+                                        </div>
+                                      </EuiEmptyPrompt>
+                                    </DashboardEmptyPrompt>
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+            </div>
+          </EuiBasicTable>
+        </div>
+      </div>
+    </EuiPanel>
+  </ContentPanel>
+</Dashboard>
+`;
+
+exports[`Dashboard renders with alert by triggers view 1`] = `
 <Dashboard
   detectorIds={Array []}
   history={
@@ -48,6 +1618,7 @@ exports[`Dashboard renders 1`] = `
     }
   }
   monitorIds={Array []}
+  perAlertView={false}
 >
   <ContentPanel
     actions={
@@ -1836,6 +3407,1672 @@ exports[`Dashboard renders 1`] = `
                               <td
                                 className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
                                 colSpan={10}
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    <DashboardEmptyPrompt>
+                                      <EuiEmptyPrompt
+                                        actions={
+                                          <EuiButton
+                                            fill={true}
+                                            href="alerting#/create-monitor"
+                                          >
+                                            Create monitor
+                                          </EuiButton>
+                                        }
+                                        body={
+                                          <EuiText>
+                                            <p>
+                                              There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                            </p>
+                                          </EuiText>
+                                        }
+                                        style={
+                                          Object {
+                                            "maxWidth": "45em",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="euiEmptyPrompt"
+                                          style={
+                                            Object {
+                                              "maxWidth": "45em",
+                                            }
+                                          }
+                                        >
+                                          <EuiTextColor
+                                            color="subdued"
+                                          >
+                                            <span
+                                              className="euiTextColor euiTextColor--subdued"
+                                            >
+                                              <EuiText>
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                >
+                                                  <EuiText>
+                                                    <div
+                                                      className="euiText euiText--medium"
+                                                    >
+                                                      <p>
+                                                        There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
+                                                      </p>
+                                                    </div>
+                                                  </EuiText>
+                                                </div>
+                                              </EuiText>
+                                            </span>
+                                          </EuiTextColor>
+                                          <EuiSpacer
+                                            size="l"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--l"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiSpacer
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiSpacer euiSpacer--s"
+                                            />
+                                          </EuiSpacer>
+                                          <EuiButton
+                                            fill={true}
+                                            href="alerting#/create-monitor"
+                                          >
+                                            <EuiButtonDisplay
+                                              element="a"
+                                              fill={true}
+                                              href="alerting#/create-monitor"
+                                              isDisabled={false}
+                                              rel="noreferrer"
+                                            >
+                                              <a
+                                                className="euiButton euiButton--primary euiButton--fill"
+                                                href="alerting#/create-monitor"
+                                                rel="noreferrer"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButton__content"
+                                                  iconSide="left"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButton__text",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButton__content"
+                                                  >
+                                                    <span
+                                                      className="euiButton__text"
+                                                    >
+                                                      Create monitor
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </a>
+                                            </EuiButtonDisplay>
+                                          </EuiButton>
+                                        </div>
+                                      </EuiEmptyPrompt>
+                                    </DashboardEmptyPrompt>
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+            </div>
+          </EuiBasicTable>
+        </div>
+      </div>
+    </EuiPanel>
+  </ContentPanel>
+</Dashboard>
+`;
+
+exports[`Dashboard renders with per alert view 1`] = `
+<Dashboard
+  detectorIds={Array []}
+  history={
+    Object {
+      "action": "REPLACE",
+      "block": [MockFunction],
+      "createHref": [MockFunction],
+      "go": [MockFunction],
+      "goBack": [MockFunction],
+      "goForward": [MockFunction],
+      "length": 0,
+      "listen": [MockFunction],
+      "location": Object {
+        "hash": "",
+        "pathname": "",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [MockFunction],
+      "replace": [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "hash": "",
+              "search": "alertState=ALL&from=0&search=&severityLevel=ALL&size=20&sortDirection=desc&sortField=start_time",
+              "state": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      },
+    }
+  }
+  httpClient={[MockFunction]}
+  location={
+    Object {
+      "hash": "",
+      "search": "",
+      "state": undefined,
+    }
+  }
+  monitorIds={Array []}
+  perAlertView={true}
+>
+  <ContentPanel
+    actions={
+      Array [
+        <EuiButton
+          data-test-subj="acknowledgeAlertsButton"
+          disabled={true}
+          onClick={[Function]}
+        >
+          Acknowledge
+        </EuiButton>,
+      ]
+    }
+    bodyStyles={
+      Object {
+        "padding": "initial",
+      }
+    }
+    title="Alerts"
+    titleSize="l"
+  >
+    <EuiPanel
+      style={
+        Object {
+          "paddingLeft": "0px",
+          "paddingRight": "0px",
+        }
+      }
+    >
+      <div
+        className="euiPanel euiPanel--paddingMedium"
+        style={
+          Object {
+            "paddingLeft": "0px",
+            "paddingRight": "0px",
+          }
+        }
+      >
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiFlexItem>
+              <div
+                className="euiFlexItem"
+              >
+                <EuiTitle
+                  size="l"
+                >
+                  <h3
+                    className="euiTitle euiTitle--large"
+                  >
+                    Alerts
+                  </h3>
+                </EuiTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup
+                  alignItems="center"
+                  justifyContent="spaceBetween"
+                >
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem
+                      key="0"
+                    >
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiButton
+                          data-test-subj="acknowledgeAlertsButton"
+                          disabled={true}
+                          onClick={[Function]}
+                        >
+                          <EuiButtonDisplay
+                            data-test-subj="acknowledgeAlertsButton"
+                            disabled={true}
+                            element="button"
+                            isDisabled={true}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <button
+                              className="euiButton euiButton--primary euiButton-isDisabled"
+                              data-test-subj="acknowledgeAlertsButton"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text"
+                                  >
+                                    Acknowledge
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonDisplay>
+                        </EuiButton>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiText
+          color="subdued"
+          size="xs"
+          style={
+            Object {
+              "padding": "0px 10px",
+            }
+          }
+        >
+          <div
+            className="euiText euiText--extraSmall"
+            style={
+              Object {
+                "padding": "0px 10px",
+              }
+            }
+          >
+            <EuiTextColor
+              color="subdued"
+              component="div"
+            >
+              <div
+                className="euiTextColor euiTextColor--subdued"
+              />
+            </EuiTextColor>
+          </div>
+        </EuiText>
+        <EuiHorizontalRule
+          className=""
+          margin="xs"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+          />
+        </EuiHorizontalRule>
+        <div
+          style={
+            Object {
+              "padding": "initial",
+            }
+          }
+        >
+          <DashboardControls
+            activePage={0}
+            isAlertsFlyout={false}
+            onPageChange={[Function]}
+            onSearchChange={[Function]}
+            onSeverityChange={[Function]}
+            onStateChange={[Function]}
+            pageCount={1}
+            search=""
+            severity="ALL"
+            state="ALL"
+          >
+            <EuiFlexGroup
+              style={
+                Object {
+                  "padding": "0px 5px",
+                }
+              }
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style={
+                  Object {
+                    "padding": "0px 5px",
+                  }
+                }
+              >
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={true}
+                      incremental={false}
+                      isClearable={true}
+                      isLoading={false}
+                      onChange={[Function]}
+                      placeholder="Search"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <input
+                                className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Search"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="search"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All severity levels",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "1 (Highest)",
+                            "value": "1",
+                          },
+                          Object {
+                            "text": "2 (High)",
+                            "value": "2",
+                          },
+                          Object {
+                            "text": "3 (Medium)",
+                            "value": "3",
+                          },
+                          Object {
+                            "text": "4 (Low)",
+                            "value": "4",
+                          },
+                          Object {
+                            "text": "5 (Lowest)",
+                            "value": "5",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All severity levels
+                                </option>
+                                <option
+                                  key="1"
+                                  value="1"
+                                >
+                                  1 (Highest)
+                                </option>
+                                <option
+                                  key="2"
+                                  value="2"
+                                >
+                                  2 (High)
+                                </option>
+                                <option
+                                  key="3"
+                                  value="3"
+                                >
+                                  3 (Medium)
+                                </option>
+                                <option
+                                  key="4"
+                                  value="4"
+                                >
+                                  4 (Low)
+                                </option>
+                                <option
+                                  key="5"
+                                  value="5"
+                                >
+                                  5 (Lowest)
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiSelect
+                      data-test-subj="dashboardAlertStateFilter"
+                      onChange={[Function]}
+                      options={
+                        Array [
+                          Object {
+                            "text": "All alerts",
+                            "value": "ALL",
+                          },
+                          Object {
+                            "text": "Active",
+                            "value": "ACTIVE",
+                          },
+                          Object {
+                            "text": "Acknowledged",
+                            "value": "ACKNOWLEDGED",
+                          },
+                          Object {
+                            "text": "Completed",
+                            "value": "COMPLETED",
+                          },
+                          Object {
+                            "text": "Error",
+                            "value": "ERROR",
+                          },
+                          Object {
+                            "text": "Deleted",
+                            "value": "DELETED",
+                          },
+                        ]
+                      }
+                      value="ALL"
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon={
+                          Object {
+                            "side": "right",
+                            "type": "arrowDown",
+                          }
+                        }
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl>
+                              <select
+                                className="euiSelect"
+                                data-test-subj="dashboardAlertStateFilter"
+                                onChange={[Function]}
+                                onMouseUp={[Function]}
+                                value="ALL"
+                              >
+                                <option
+                                  key="0"
+                                  value="ALL"
+                                >
+                                  All alerts
+                                </option>
+                                <option
+                                  key="1"
+                                  value="ACTIVE"
+                                >
+                                  Active
+                                </option>
+                                <option
+                                  key="2"
+                                  value="ACKNOWLEDGED"
+                                >
+                                  Acknowledged
+                                </option>
+                                <option
+                                  key="3"
+                                  value="COMPLETED"
+                                >
+                                  Completed
+                                </option>
+                                <option
+                                  key="4"
+                                  value="ERROR"
+                                >
+                                  Error
+                                </option>
+                                <option
+                                  key="5"
+                                  value="DELETED"
+                                >
+                                  Deleted
+                                </option>
+                              </select>
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              icon={
+                                Object {
+                                  "side": "right",
+                                  "type": "arrowDown",
+                                }
+                              }
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      type="arrowDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiSelect>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                  style={
+                    Object {
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    style={
+                      Object {
+                        "justifyContent": "center",
+                      }
+                    }
+                  >
+                    <EuiPagination
+                      activePage={0}
+                      onPageClick={[Function]}
+                      pageCount={1}
+                    >
+                      <nav
+                        className="euiPagination"
+                      >
+                        <EuiI18n
+                          default="Previous page, {page}"
+                          token="euiPagination.previousPage"
+                          values={
+                            Object {
+                              "page": 0,
+                            }
+                          }
+                        >
+                          <EuiI18n
+                            default="Previous page"
+                            token="euiPagination.disabledPreviousPage"
+                          >
+                            <EuiButtonIcon
+                              aria-label="Previous page"
+                              color="text"
+                              data-test-subj="pagination-button-previous"
+                              disabled={true}
+                              iconType="arrowLeft"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-label="Previous page"
+                                className="euiButtonIcon euiButtonIcon--text"
+                                data-test-subj="pagination-button-previous"
+                                disabled={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiButtonIcon__icon"
+                                  size="m"
+                                  type="arrowLeft"
+                                >
+                                  <div>
+                                    EuiIconMock
+                                  </div>
+                                </EuiIcon>
+                              </button>
+                            </EuiButtonIcon>
+                          </EuiI18n>
+                        </EuiI18n>
+                        <ul
+                          className="euiPagination__list"
+                        >
+                          <PaginationButton
+                            key="0"
+                            pageIndex={0}
+                          >
+                            <li
+                              className="euiPagination__item"
+                            >
+                              <EuiPaginationButton
+                                hideOnMobile={true}
+                                isActive={true}
+                                onClick={[Function]}
+                                pageIndex={0}
+                                totalPages={1}
+                              >
+                                <EuiI18n
+                                  default="Page {page} of {totalPages}"
+                                  token="euiPaginationButton.longPageString"
+                                  values={
+                                    Object {
+                                      "page": 1,
+                                      "totalPages": 1,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Page {page}"
+                                    token="euiPaginationButton.shortPageString"
+                                    values={
+                                      Object {
+                                        "page": 1,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonEmpty
+                                      aria-current={true}
+                                      aria-label="Page 1 of 1"
+                                      className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                      color="text"
+                                      data-test-subj="pagination-button-0"
+                                      isDisabled={true}
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <button
+                                        aria-current={true}
+                                        aria-label="Page 1 of 1"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                        data-test-subj="pagination-button-0"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="left"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonEmpty__content"
+                                          >
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              1
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </EuiI18n>
+                                </EuiI18n>
+                              </EuiPaginationButton>
+                            </li>
+                          </PaginationButton>
+                        </ul>
+                        <EuiI18n
+                          default="Next page, {page}"
+                          token="euiPagination.nextPage"
+                          values={
+                            Object {
+                              "page": 2,
+                            }
+                          }
+                        >
+                          <EuiI18n
+                            default="Next page"
+                            token="euiPagination.disabledNextPage"
+                          >
+                            <EuiButtonIcon
+                              aria-label="Next page"
+                              color="text"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              iconType="arrowRight"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-label="Next page"
+                                className="euiButtonIcon euiButtonIcon--text"
+                                data-test-subj="pagination-button-next"
+                                disabled={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiButtonIcon__icon"
+                                  size="m"
+                                  type="arrowRight"
+                                >
+                                  <div>
+                                    EuiIconMock
+                                  </div>
+                                </EuiIcon>
+                              </button>
+                            </EuiButtonIcon>
+                          </EuiI18n>
+                        </EuiI18n>
+                      </nav>
+                    </EuiPagination>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </DashboardControls>
+          <EuiHorizontalRule
+            margin="xs"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
+            />
+          </EuiHorizontalRule>
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "dataType": "date",
+                  "field": "start_time",
+                  "name": "Alert start time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "end_time",
+                  "name": "Alert end time",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "trigger_name",
+                  "name": "Trigger name",
+                  "sortable": true,
+                  "textOnly": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "field": "severity",
+                  "name": "Severity",
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "field": "state",
+                  "name": "State",
+                  "render": [Function],
+                  "sortable": false,
+                  "truncateText": false,
+                },
+                Object {
+                  "dataType": "date",
+                  "field": "acknowledged_time",
+                  "name": "Time acknowledged",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": false,
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId={[Function]}
+            items={Array []}
+            noItemsMessage={<DashboardEmptyPrompt />}
+            onChange={[Function]}
+            pagination={
+              Object {
+                "pageIndex": 0,
+                "pageSize": 20,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  20,
+                  50,
+                ],
+                "totalItemCount": 0,
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+                "selectable": [Function],
+                "selectableMessage": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "desc",
+                  "field": "start_time",
+                },
+              }
+            }
+            tableLayout="fixed"
+          >
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
+                  >
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiI18n
+                              default="Select all rows"
+                              token="euiBasicTable.selectAllRows"
+                            >
+                              <EuiCheckbox
+                                aria-label="Select all rows"
+                                checked={false}
+                                compressed={false}
+                                disabled={true}
+                                id="_selection_column-checkbox_generated-id"
+                                indeterminate={false}
+                                label="Select all rows"
+                                onChange={[Function]}
+                              >
+                                <div
+                                  className="euiCheckbox"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_generated-id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                  <label
+                                    className="euiCheckbox__label"
+                                    htmlFor="_selection_column-checkbox_generated-id"
+                                  >
+                                    Select all rows
+                                  </label>
+                                </div>
+                              </EuiCheckbox>
+                            </EuiI18n>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": false,
+                                    "isSorted": true,
+                                    "key": "_data_s_start_time_0",
+                                    "name": "Alert start time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_end_time_1",
+                                    "name": "Alert end time",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_trigger_name_2",
+                                    "name": "Trigger name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_acknowledged_time_5",
+                                    "name": "Time acknowledged",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
+                            >
+                              <div
+                                className="euiTableSortMobile"
+                              >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
+                                    <EuiButtonEmpty
+                                      flush="right"
+                                      iconSide="right"
+                                      iconType="arrowDown"
+                                      onClick={[Function]}
+                                      size="xs"
+                                    >
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <EuiOutsideClickDetector
+                                    isDisabled={true}
+                                    onOutsideClick={[Function]}
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                      onKeyDown={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchStart={[Function]}
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  size="m"
+                                                  type="arrowDown"
+                                                >
+                                                  <div>
+                                                    EuiIconMock
+                                                  </div>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiOutsideClickDetector>
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
+                  id="generated-id"
+                  responsive={true}
+                  tableLayout="fixed"
+                >
+                  <table
+                    className="euiTable euiTable--responsive"
+                    id="generated-id"
+                    tabIndex={-1}
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCellCheckbox
+                            key="_selection_column_h"
+                          >
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiI18n
+                                  default="Select all rows"
+                                  token="euiBasicTable.selectAllRows"
+                                >
+                                  <EuiCheckbox
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    compressed={false}
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_generated-id"
+                                    indeterminate={false}
+                                    label={null}
+                                    onChange={[Function]}
+                                    type="inList"
+                                  >
+                                    <div
+                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                    >
+                                      <input
+                                        aria-label="Select all rows"
+                                        checked={false}
+                                        className="euiCheckbox__input"
+                                        data-test-subj="checkboxSelectAll"
+                                        disabled={true}
+                                        id="_selection_column-checkbox_generated-id"
+                                        onChange={[Function]}
+                                        type="checkbox"
+                                      />
+                                      <div
+                                        className="euiCheckbox__square"
+                                      />
+                                    </div>
+                                  </EuiCheckbox>
+                                </EuiI18n>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCellCheckbox>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_start_time_0"
+                            isSortAscending={false}
+                            isSorted={true}
+                            key="_data_h_start_time_0"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="descending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_start_time_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "descending",
+                                          "innerText": "Alert start time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert start time; Sorted in descending order"
+                                      >
+                                        Alert start time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiI18n
+                                    default="Sorted in {ariaSortValue} order"
+                                    token="euiTableHeaderCell.sortedAriaLabel"
+                                    values={
+                                      Object {
+                                        "ariaSortValue": "descending",
+                                      }
+                                    }
+                                  >
+                                    <EuiIcon
+                                      aria-label="Sorted in descending order"
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortDown"
+                                    >
+                                      <div>
+                                        EuiIconMock
+                                      </div>
+                                    </EuiIcon>
+                                  </EuiI18n>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_end_time_1"
+                            isSorted={false}
+                            key="_data_h_end_time_1"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_end_time_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Alert end time",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Alert end time"
+                                      >
+                                        Alert end time
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_trigger_name_2"
+                            isSorted={false}
+                            key="_data_h_trigger_name_2"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trigger_name_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Trigger name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trigger name"
+                                      >
+                                        Trigger name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_severity_3"
+                            key="_data_h_severity_3"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_severity_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Severity"
+                                  >
+                                    Severity
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_state_4"
+                            key="_data_h_state_4"
+                          >
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_state_4"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiInnerText>
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="State"
+                                  >
+                                    State
+                                  </span>
+                                </EuiInnerText>
+                              </div>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_acknowledged_time_5"
+                            isSorted={false}
+                            key="_data_h_acknowledged_time_5"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_acknowledged_time_5"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; Sorted in {ariaSortValue} order"
+                                      token="euiTableHeaderCell.titleTextWithSort"
+                                      values={
+                                        Object {
+                                          "ariaSortValue": "none",
+                                          "innerText": "Time acknowledged",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Time acknowledged"
+                                      >
+                                        Time acknowledged
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiScreenReaderOnly>
+                                    <span
+                                      className="euiScreenReaderOnly"
+                                    >
+                                      <EuiI18n
+                                        default="Click to sort in ascending order"
+                                        token="euiTableHeaderCell.clickForAscending"
+                                      >
+                                        Click to sort in ascending order
+                                      </EuiI18n>
+                                    </span>
+                                  </EuiScreenReaderOnly>
+                                </span>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody>
+                      <tbody>
+                        <EuiTableRow>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="center"
+                              colSpan={7}
+                              isMobileFullWidth={true}
+                            >
+                              <td
+                                className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                colSpan={7}
                                 style={
                                   Object {
                                     "width": undefined,

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -760,6 +760,7 @@ exports[`Dashboard renders in flyout 1`] = `
                 },
               ]
             }
+            data-test-subj="alertsDashboard_table"
             isSelectable={true}
             itemId={[Function]}
             items={Array []}
@@ -798,6 +799,7 @@ exports[`Dashboard renders in flyout 1`] = `
           >
             <div
               className="euiBasicTable"
+              data-test-subj="alertsDashboard_table"
             >
               <div>
                 <EuiTableHeaderMobile>
@@ -2497,6 +2499,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                 },
               ]
             }
+            data-test-subj="alertsDashboard_table"
             isSelectable={true}
             itemId={[Function]}
             items={Array []}
@@ -2522,6 +2525,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
           >
             <div
               className="euiBasicTable"
+              data-test-subj="alertsDashboard_table"
             >
               <div>
                 <EuiTableHeaderMobile>
@@ -4404,6 +4408,7 @@ exports[`Dashboard renders with per alert view 1`] = `
                 },
               ]
             }
+            data-test-subj="alertsDashboard_table"
             isSelectable={true}
             itemId={[Function]}
             items={Array []}
@@ -4442,6 +4447,7 @@ exports[`Dashboard renders with per alert view 1`] = `
           >
             <div
               className="euiBasicTable"
+              data-test-subj="alertsDashboard_table"
             >
               <div>
                 <EuiTableHeaderMobile>

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -59,6 +59,7 @@ exports[`Dashboard renders 1`] = `
           View alert details
         </EuiButton>,
         <EuiButton
+          data-test-subj="acknowledgeAlertsButton"
           disabled={true}
           onClick={[Function]}
         >
@@ -190,10 +191,12 @@ exports[`Dashboard renders 1`] = `
                         className="euiFlexItem"
                       >
                         <EuiButton
+                          data-test-subj="acknowledgeAlertsButton"
                           disabled={true}
                           onClick={[Function]}
                         >
                           <EuiButtonDisplay
+                            data-test-subj="acknowledgeAlertsButton"
                             disabled={true}
                             element="button"
                             isDisabled={true}
@@ -202,6 +205,7 @@ exports[`Dashboard renders 1`] = `
                           >
                             <button
                               className="euiButton euiButton--primary euiButton-isDisabled"
+                              data-test-subj="acknowledgeAlertsButton"
                               disabled={true}
                               onClick={[Function]}
                               type="button"
@@ -517,6 +521,7 @@ exports[`Dashboard renders 1`] = `
                     className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
                     <EuiSelect
+                      data-test-subj="dashboardAlertStateFilter"
                       onChange={[Function]}
                       options={
                         Array [
@@ -568,6 +573,7 @@ exports[`Dashboard renders 1`] = `
                             <EuiValidatableControl>
                               <select
                                 className="euiSelect"
+                                data-test-subj="dashboardAlertStateFilter"
                                 onChange={[Function]}
                                 onMouseUp={[Function]}
                                 value="ALL"

--- a/public/pages/Dashboard/utils/constants.js
+++ b/public/pages/Dashboard/utils/constants.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 export const EMPTY_ALERT_LIST = {

--- a/public/pages/Dashboard/utils/helpers.js
+++ b/public/pages/Dashboard/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Dashboard/utils/helpers.js
+++ b/public/pages/Dashboard/utils/helpers.js
@@ -25,12 +25,13 @@
  */
 
 import _ from 'lodash';
-import { EMPTY_ALERT_LIST, MAX_ALERT_COUNT } from './constants';
+import { DEFAULT_GET_ALERTS_QUERY_PARAMS, EMPTY_ALERT_LIST, MAX_ALERT_COUNT } from './constants';
 import { bucketColumns } from './tableUtils';
-import { DEFAULT_NUM_FLYOUT_ROWS } from '../../../components/Flyout/flyouts/alertsDashboard';
-import { DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import queryString from 'query-string';
 
 export function groupAlertsByTrigger(alerts) {
+  if (_.isUndefined(alerts)) return _.cloneDeep(EMPTY_ALERT_LIST.alerts);
   let alertsByTriggers = new Map();
   alerts.map((alert) => {
     const triggerID = alert.trigger_id;
@@ -39,7 +40,6 @@ export function groupAlertsByTrigger(alerts) {
       : addFirstAlert(alert);
     alertsByTriggers.set(triggerID, newAlertList);
   });
-
   return Array.from(alertsByTriggers, ([triggerID, alerts]) => ({ ...alerts, triggerID }));
 }
 
@@ -69,6 +69,7 @@ export function addFirstAlert(firstAlert) {
     monitor_id,
   };
 }
+
 export function addAlert(alertList, newAlert) {
   const state = newAlert.state;
   alertList[state]++;
@@ -87,7 +88,7 @@ export const renderEmptyValue = (value) => {
   return value === undefined ? DEFAULT_EMPTY_DATA : value;
 };
 
-export function insertGroupByColumn(groupBy) {
+export function insertGroupByColumn(groupBy = []) {
   let result = _.cloneDeep(bucketColumns);
   groupBy.map((fieldName) =>
     result.splice(0, 0, {
@@ -101,14 +102,70 @@ export function insertGroupByColumn(groupBy) {
   return result;
 }
 
-export function removeColumns(columnFieldNames = [], allColumns) {
-  return allColumns.filter((column) => {
-    return !_.includes(columnFieldNames, column.field);
-  });
+export function removeColumns(columnFieldNames = [], allColumns = []) {
+  return allColumns.filter((column) => !_.includes(columnFieldNames, column.field));
 }
 
-export function getInitialSize(isAlertsFlyout, perAlertView, defaultSize) {
-  if (!perAlertView) return MAX_ALERT_COUNT;
-  if (isAlertsFlyout) return DEFAULT_NUM_FLYOUT_ROWS;
-  return defaultSize;
+export function getInitialSize(
+  perAlertView = false,
+  defaultSize = DEFAULT_GET_ALERTS_QUERY_PARAMS.size
+) {
+  return perAlertView && defaultSize >= 0 ? defaultSize : MAX_ALERT_COUNT;
+}
+
+export function displayAcknowledgedAlertsToast(notifications, successfulCount = 0) {
+  const successfulText = `Successfully acknowledged ${successfulCount} ${
+    successfulCount === 1 ? 'alert' : 'alerts'
+  }.`;
+  if (successfulCount > 0) notifications.toasts.addSuccess(successfulText);
+}
+
+export function filterActiveAlerts(alerts = []) {
+  return _.filter(alerts, { state: ALERT_STATE.ACTIVE });
+}
+
+export function getQueryObjectFromState({
+  page,
+  size,
+  search,
+  sortField,
+  sortDirection,
+  severityLevel,
+  alertState,
+  monitorIds,
+  flyoutIsOpen,
+}) {
+  return {
+    page,
+    size,
+    search,
+    sortField,
+    sortDirection,
+    severityLevel,
+    alertState,
+    monitorIds,
+    flyoutIsOpen,
+  };
+}
+
+export function getURLQueryParams(location) {
+  const {
+    from = DEFAULT_GET_ALERTS_QUERY_PARAMS.from,
+    size = DEFAULT_GET_ALERTS_QUERY_PARAMS.size,
+    search = DEFAULT_GET_ALERTS_QUERY_PARAMS.search,
+    sortField = DEFAULT_GET_ALERTS_QUERY_PARAMS.sortField,
+    sortDirection = DEFAULT_GET_ALERTS_QUERY_PARAMS.sortDirection,
+    severityLevel = DEFAULT_GET_ALERTS_QUERY_PARAMS.severityLevel,
+    alertState = DEFAULT_GET_ALERTS_QUERY_PARAMS.alertState,
+  } = queryString.parse(location.search);
+
+  return {
+    from: isNaN(parseInt(from, 10)) ? DEFAULT_GET_ALERTS_QUERY_PARAMS.from : parseInt(from, 10),
+    size: isNaN(parseInt(size, 10)) ? DEFAULT_GET_ALERTS_QUERY_PARAMS.size : parseInt(size, 10),
+    search,
+    sortField,
+    sortDirection,
+    severityLevel,
+    alertState,
+  };
 }

--- a/public/pages/Dashboard/utils/helpers.test.js
+++ b/public/pages/Dashboard/utils/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Dashboard/utils/helpers.test.js
+++ b/public/pages/Dashboard/utils/helpers.test.js
@@ -1,0 +1,848 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import _ from 'lodash';
+import {
+  addAlert,
+  addFirstAlert,
+  displayAcknowledgedAlertsToast,
+  filterActiveAlerts,
+  getInitialSize,
+  getQueryObjectFromState,
+  getURLQueryParams,
+  groupAlertsByTrigger,
+  insertGroupByColumn,
+  removeColumns,
+  renderEmptyValue,
+} from './helpers';
+import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
+import { bucketColumns } from './tableUtils';
+import { DEFAULT_GET_ALERTS_QUERY_PARAMS, MAX_ALERT_COUNT } from './constants';
+import coreMock from '../../../../test/mocks/CoreMock';
+
+describe('Dashboard/utils/helpers', () => {
+  describe('groupAlertsByTrigger', () => {
+    test('with empty alerts list', () => {
+      const alerts = [];
+      const expectedOutput = [];
+      expect(groupAlertsByTrigger(alerts)).toEqual(expectedOutput);
+    });
+
+    test('with undefined alerts list', () => {
+      const alerts = undefined;
+      const expectedOutput = [];
+      expect(groupAlertsByTrigger(alerts)).toEqual(expectedOutput);
+    });
+
+    test('with valid alerts list', () => {
+      const alerts = [
+        {
+          id: 'bucket-monitor-trigger1-alert1',
+          monitor_name: 'bucket-monitor',
+          trigger_id: 'bucket-monitor-trigger1-id',
+          trigger_name: 'bucket-monitor-trigger1',
+          state: 'ACTIVE',
+          start_time: 1638360000000,
+          end_time: null,
+          agg_alert_content: {
+            parent_bucket_path: 'composite_agg',
+            bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+            bucket: {
+              doc_count: 10,
+              field1: {
+                value: 100,
+              },
+              field2: {
+                value: 200,
+              },
+              key: {
+                groupBy1: 'groupBy1Keyword',
+                groupBy2: 'groupBy2Keyword',
+              },
+            },
+          },
+        },
+        {
+          id: 'bucket-monitor-trigger1-alert2',
+          monitor_name: 'bucket-monitor',
+          trigger_id: 'bucket-monitor-trigger1-id',
+          trigger_name: 'bucket-monitor-trigger1',
+          state: 'ACTIVE',
+          start_time: 1638360000000,
+          end_time: null,
+          agg_alert_content: {
+            parent_bucket_path: 'composite_agg',
+            bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+            bucket: {
+              doc_count: 10,
+              field1: {
+                value: 100,
+              },
+              field2: {
+                value: 200,
+              },
+              key: {
+                groupBy1: 'groupBy1Keyword',
+                groupBy2: 'groupBy2Keyword',
+              },
+            },
+          },
+        },
+        {
+          id: 'bucket-monitor-trigger2-alert1',
+          monitor_name: 'bucket-monitor',
+          trigger_id: 'bucket-monitor-trigger2-id',
+          trigger_name: 'bucket-monitor-trigger2',
+          state: 'ACTIVE',
+          start_time: 1638361800000,
+          end_time: null,
+          agg_alert_content: {
+            parent_bucket_path: 'composite_agg',
+            bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+            bucket: {
+              doc_count: 10,
+              field1: {
+                value: 100,
+              },
+              field2: {
+                value: 200,
+              },
+              key: {
+                groupBy1: 'groupBy1Keyword',
+                groupBy2: 'groupBy2Keyword',
+              },
+            },
+          },
+        },
+        {
+          id: 'query-monitor-trigger1-alert1',
+          monitor_name: 'query-monitor',
+          trigger_id: 'query-monitor-trigger1-id',
+          trigger_name: 'query-monitor-trigger1',
+          state: 'ACTIVE',
+          start_time: 1638360000000,
+          end_time: null,
+        },
+        {
+          id: 'query-monitor-trigger2-alert1',
+          monitor_name: 'query-monitor',
+          trigger_id: 'query-monitor-trigger2-id',
+          trigger_name: 'query-monitor-trigger2',
+          state: 'ACTIVE',
+          start_time: 1638361800000,
+          end_time: null,
+        },
+      ];
+      const expectedOutput = [
+        {
+          ACTIVE: 2,
+          ACKNOWLEDGED: 0,
+          ERROR: 0,
+          total: 2,
+          alerts: [
+            {
+              id: 'bucket-monitor-trigger1-alert1',
+              monitor_name: 'bucket-monitor',
+              trigger_id: 'bucket-monitor-trigger1-id',
+              trigger_name: 'bucket-monitor-trigger1',
+              state: 'ACTIVE',
+              start_time: 1638360000000,
+              end_time: null,
+              agg_alert_content: {
+                parent_bucket_path: 'composite_agg',
+                bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+                bucket: {
+                  doc_count: 10,
+                  field1: {
+                    value: 100,
+                  },
+                  field2: {
+                    value: 200,
+                  },
+                  key: {
+                    groupBy1: 'groupBy1Keyword',
+                    groupBy2: 'groupBy2Keyword',
+                  },
+                },
+              },
+            },
+            {
+              id: 'bucket-monitor-trigger1-alert2',
+              monitor_name: 'bucket-monitor',
+              trigger_id: 'bucket-monitor-trigger1-id',
+              trigger_name: 'bucket-monitor-trigger1',
+              state: 'ACTIVE',
+              start_time: 1638360000000,
+              end_time: null,
+              agg_alert_content: {
+                parent_bucket_path: 'composite_agg',
+                bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+                bucket: {
+                  doc_count: 10,
+                  field1: {
+                    value: 100,
+                  },
+                  field2: {
+                    value: 200,
+                  },
+                  key: {
+                    groupBy1: 'groupBy1Keyword',
+                    groupBy2: 'groupBy2Keyword',
+                  },
+                },
+              },
+            },
+          ],
+          trigger_name: 'bucket-monitor-trigger1',
+          start_time: 1638360000000,
+          monitor_name: 'bucket-monitor',
+          triggerID: 'bucket-monitor-trigger1-id',
+        },
+        {
+          ACTIVE: 1,
+          ACKNOWLEDGED: 0,
+          ERROR: 0,
+          total: 1,
+          alerts: [
+            {
+              id: 'bucket-monitor-trigger2-alert1',
+              monitor_name: 'bucket-monitor',
+              trigger_id: 'bucket-monitor-trigger2-id',
+              trigger_name: 'bucket-monitor-trigger2',
+              state: 'ACTIVE',
+              start_time: 1638361800000,
+              end_time: null,
+              agg_alert_content: {
+                parent_bucket_path: 'composite_agg',
+                bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+                bucket: {
+                  doc_count: 10,
+                  field1: {
+                    value: 100,
+                  },
+                  field2: {
+                    value: 200,
+                  },
+                  key: {
+                    groupBy1: 'groupBy1Keyword',
+                    groupBy2: 'groupBy2Keyword',
+                  },
+                },
+              },
+            },
+          ],
+          trigger_name: 'bucket-monitor-trigger2',
+          start_time: 1638361800000,
+          monitor_name: 'bucket-monitor',
+          triggerID: 'bucket-monitor-trigger2-id',
+        },
+        {
+          ACTIVE: 1,
+          ACKNOWLEDGED: 0,
+          ERROR: 0,
+          total: 1,
+          alerts: [
+            {
+              id: 'query-monitor-trigger1-alert1',
+              monitor_name: 'query-monitor',
+              trigger_id: 'query-monitor-trigger1-id',
+              trigger_name: 'query-monitor-trigger1',
+              state: 'ACTIVE',
+              start_time: 1638360000000,
+              end_time: null,
+            },
+          ],
+          trigger_name: 'query-monitor-trigger1',
+          start_time: 1638360000000,
+          monitor_name: 'query-monitor',
+          triggerID: 'query-monitor-trigger1-id',
+        },
+        {
+          ACTIVE: 1,
+          ACKNOWLEDGED: 0,
+          ERROR: 0,
+          total: 1,
+          alerts: [
+            {
+              id: 'query-monitor-trigger2-alert1',
+              monitor_name: 'query-monitor',
+              trigger_id: 'query-monitor-trigger2-id',
+              trigger_name: 'query-monitor-trigger2',
+              state: 'ACTIVE',
+              start_time: 1638361800000,
+              end_time: null,
+            },
+          ],
+          trigger_name: 'query-monitor-trigger2',
+          start_time: 1638361800000,
+          monitor_name: 'query-monitor',
+          triggerID: 'query-monitor-trigger2-id',
+        },
+      ];
+      expect(groupAlertsByTrigger(alerts)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('addFirstAlert', () => {
+    test('with bucket-level alert', () => {
+      const alert = {
+        id: 'bucket-monitor-trigger1-alert1',
+        last_notification_time: null,
+        monitor_id: 'bucket-monitor-id',
+        monitor_name: 'bucket-monitor',
+        severity: 5,
+        trigger_id: 'bucket-monitor-trigger1-id',
+        trigger_name: 'bucket-monitor-trigger1',
+        version: 1,
+        state: 'ACTIVE',
+        start_time: 1638360000000,
+        end_time: null,
+        agg_alert_content: {
+          parent_bucket_path: 'composite_agg',
+          bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+          bucket: {
+            doc_count: 10,
+            field1: {
+              value: 100,
+            },
+            field2: {
+              value: 200,
+            },
+            key: {
+              groupBy1: 'groupBy1Keyword',
+              groupBy2: 'groupBy2Keyword',
+            },
+          },
+        },
+      };
+      const expectedOutput = {
+        ACTIVE: 1,
+        ACKNOWLEDGED: 0,
+        ERROR: 0,
+        total: 1,
+        alerts: [
+          {
+            id: 'bucket-monitor-trigger1-alert1',
+            last_notification_time: null,
+            monitor_id: 'bucket-monitor-id',
+            monitor_name: 'bucket-monitor',
+            severity: 5,
+            trigger_id: 'bucket-monitor-trigger1-id',
+            trigger_name: 'bucket-monitor-trigger1',
+            version: 1,
+            state: 'ACTIVE',
+            start_time: 1638360000000,
+            end_time: null,
+            agg_alert_content: {
+              parent_bucket_path: 'composite_agg',
+              bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+              bucket: {
+                doc_count: 10,
+                field1: {
+                  value: 100,
+                },
+                field2: {
+                  value: 200,
+                },
+                key: {
+                  groupBy1: 'groupBy1Keyword',
+                  groupBy2: 'groupBy2Keyword',
+                },
+              },
+            },
+          },
+        ],
+        version: 1,
+        trigger_name: 'bucket-monitor-trigger1',
+        severity: 5,
+        start_time: 1638360000000,
+        last_notification_time: null,
+        monitor_name: 'bucket-monitor',
+        monitor_id: 'bucket-monitor-id',
+      };
+      expect(addFirstAlert(alert)).toEqual(expectedOutput);
+    });
+    test('with query-level alert', () => {
+      const alert = {
+        id: 'query-monitor-trigger1-alert1',
+        last_notification_time: null,
+        monitor_id: 'query-monitor-id',
+        monitor_name: 'query-monitor',
+        severity: 5,
+        trigger_id: 'query-monitor-trigger1-id',
+        trigger_name: 'query-monitor-trigger1',
+        version: 1,
+        state: 'ACTIVE',
+        start_time: 1638360000000,
+        end_time: null,
+      };
+      const expectedOutput = {
+        ACTIVE: 1,
+        ACKNOWLEDGED: 0,
+        ERROR: 0,
+        total: 1,
+        alerts: [
+          {
+            id: 'query-monitor-trigger1-alert1',
+            last_notification_time: null,
+            monitor_id: 'query-monitor-id',
+            monitor_name: 'query-monitor',
+            severity: 5,
+            trigger_id: 'query-monitor-trigger1-id',
+            trigger_name: 'query-monitor-trigger1',
+            version: 1,
+            state: 'ACTIVE',
+            start_time: 1638360000000,
+            end_time: null,
+          },
+        ],
+        version: 1,
+        trigger_name: 'query-monitor-trigger1',
+        severity: 5,
+        start_time: 1638360000000,
+        last_notification_time: null,
+        monitor_name: 'query-monitor',
+        monitor_id: 'query-monitor-id',
+      };
+      expect(addFirstAlert(alert)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('addAlert', () => {
+    test('with valid alerts list', () => {
+      const alert = {
+        id: 'bucket-monitor-trigger1-alert2',
+        monitor_name: 'bucket-monitor',
+        trigger_id: 'bucket-monitor-trigger1-id',
+        trigger_name: 'bucket-monitor-trigger1',
+        state: 'ACTIVE',
+        start_time: 1638360000000,
+        end_time: null,
+        agg_alert_content: {
+          parent_bucket_path: 'composite_agg',
+          bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+          bucket: {
+            doc_count: 10,
+            field1: {
+              value: 100,
+            },
+            field2: {
+              value: 200,
+            },
+            key: {
+              groupBy1: 'groupBy1Keyword',
+              groupBy2: 'groupBy2Keyword',
+            },
+          },
+        },
+      };
+      const alertsList = {
+        ACTIVE: 1,
+        ACKNOWLEDGED: 0,
+        ERROR: 0,
+        total: 1,
+        alerts: [
+          {
+            id: 'bucket-monitor-trigger1-alert1',
+            monitor_name: 'bucket-monitor',
+            trigger_id: 'bucket-monitor-trigger1-id',
+            trigger_name: 'bucket-monitor-trigger1',
+            state: 'ACTIVE',
+            start_time: 1638360000000,
+            end_time: null,
+            agg_alert_content: {
+              parent_bucket_path: 'composite_agg',
+              bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+              bucket: {
+                doc_count: 10,
+                field1: {
+                  value: 100,
+                },
+                field2: {
+                  value: 200,
+                },
+                key: {
+                  groupBy1: 'groupBy1Keyword',
+                  groupBy2: 'groupBy2Keyword',
+                },
+              },
+            },
+          },
+        ],
+        trigger_name: 'bucket-monitor-trigger1',
+        start_time: 1638360000000,
+        monitor_name: 'bucket-monitor',
+        triggerID: 'bucket-monitor-trigger1-id',
+      };
+      const expectedOutput = {
+        ACTIVE: 2,
+        ACKNOWLEDGED: 0,
+        ERROR: 0,
+        total: 2,
+        alerts: [
+          {
+            id: 'bucket-monitor-trigger1-alert1',
+            monitor_name: 'bucket-monitor',
+            trigger_id: 'bucket-monitor-trigger1-id',
+            trigger_name: 'bucket-monitor-trigger1',
+            state: 'ACTIVE',
+            start_time: 1638360000000,
+            end_time: null,
+            agg_alert_content: {
+              parent_bucket_path: 'composite_agg',
+              bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+              bucket: {
+                doc_count: 10,
+                field1: {
+                  value: 100,
+                },
+                field2: {
+                  value: 200,
+                },
+                key: {
+                  groupBy1: 'groupBy1Keyword',
+                  groupBy2: 'groupBy2Keyword',
+                },
+              },
+            },
+          },
+          {
+            id: 'bucket-monitor-trigger1-alert2',
+            monitor_name: 'bucket-monitor',
+            trigger_id: 'bucket-monitor-trigger1-id',
+            trigger_name: 'bucket-monitor-trigger1',
+            state: 'ACTIVE',
+            start_time: 1638360000000,
+            end_time: null,
+            agg_alert_content: {
+              parent_bucket_path: 'composite_agg',
+              bucket_keys: ['groupBy1KeywordValue', 'groupBy2KeywordValue'],
+              bucket: {
+                doc_count: 10,
+                field1: {
+                  value: 100,
+                },
+                field2: {
+                  value: 200,
+                },
+                key: {
+                  groupBy1: 'groupBy1Keyword',
+                  groupBy2: 'groupBy2Keyword',
+                },
+              },
+            },
+          },
+        ],
+        trigger_name: 'bucket-monitor-trigger1',
+        start_time: 1638360000000,
+        monitor_name: 'bucket-monitor',
+        triggerID: 'bucket-monitor-trigger1-id',
+      };
+      expect(addAlert(alertsList, alert)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('renderEmptyValue', () => {
+    test('with empty value', () => {
+      const value = {};
+      expect(renderEmptyValue(value)).toEqual(value);
+    });
+
+    test('with undefined value', () => {
+      const value = undefined;
+      expect(renderEmptyValue(value)).toEqual(DEFAULT_EMPTY_DATA);
+    });
+
+    test('with defined value', () => {
+      const value = { key: 'value' };
+      expect(renderEmptyValue(value)).toEqual(value);
+    });
+  });
+
+  describe('insertGroupByColumn', () => {
+    test('with empty groupBy list', () => {
+      const groupBy = [];
+      expect(insertGroupByColumn(groupBy)).toEqual(bucketColumns);
+    });
+
+    test('with undefined groupBy list', () => {
+      const groupBy = undefined;
+      expect(insertGroupByColumn(groupBy)).toEqual(bucketColumns);
+    });
+
+    test('with valid groupBy list', () => {
+      const groupBy = ['keyword1', 'keyword2', 'keyword3'];
+      const expectedOutput = _.cloneDeep(bucketColumns);
+      expectedOutput.unshift(
+        {
+          field: 'agg_alert_content.bucket.key.keyword3',
+          name: 'keyword3',
+          render: renderEmptyValue,
+          sortable: false,
+          truncateText: false,
+        },
+        {
+          field: 'agg_alert_content.bucket.key.keyword2',
+          name: 'keyword2',
+          render: renderEmptyValue,
+          sortable: false,
+          truncateText: false,
+        },
+        {
+          field: 'agg_alert_content.bucket.key.keyword1',
+          name: 'keyword1',
+          render: renderEmptyValue,
+          sortable: false,
+          truncateText: false,
+        }
+      );
+      expect(insertGroupByColumn(groupBy)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('removeColumns', () => {
+    describe('with empty allColumns parameter', () => {
+      const allColumns = [];
+      test('with empty columnFieldNames', () => {
+        const columnFieldNames = [];
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+
+      test('with undefined columnFieldNames', () => {
+        const columnFieldNames = undefined;
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+
+      test('with valid columnFieldNames', () => {
+        const columnFieldNames = ['first column', 'third column'];
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+    });
+    describe('with undefined allColumns parameter', () => {
+      const allColumns = undefined;
+      test('with empty columnFieldNames', () => {
+        const columnFieldNames = [];
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+
+      test('with undefined columnFieldNames', () => {
+        const columnFieldNames = undefined;
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+
+      test('with valid columnFieldNames', () => {
+        const columnFieldNames = ['first column', 'third column'];
+        const expectedOutput = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+    });
+    describe('with valid allColumns parameter', () => {
+      const allColumns = [
+        { field: 'first column' },
+        { field: 'second column' },
+        { field: 'third column' },
+        { field: 'fourth column' },
+        { field: 'fifth column' },
+      ];
+
+      test('with empty columnFieldNames', () => {
+        const columnFieldNames = [];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(allColumns);
+      });
+
+      test('with undefined columnFieldNames', () => {
+        const columnFieldNames = undefined;
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(allColumns);
+      });
+
+      test('with valid columnFieldNames', () => {
+        const columnFieldNames = ['first column', 'third column'];
+        const expectedOutput = [
+          { field: 'second column' },
+          { field: 'fourth column' },
+          { field: 'fifth column' },
+        ];
+        expect(removeColumns(columnFieldNames, allColumns)).toEqual(expectedOutput);
+      });
+    });
+  });
+
+  describe('getInitialSize', () => {
+    describe('when perAlertView is false', () => {
+      const perAlertView = false;
+      test('when defaultSize is undefined', () => {
+        const defaultSize = undefined;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is 0', () => {
+        const defaultSize = 0;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is greater than 0', () => {
+        const defaultSize = 10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is less than 0', () => {
+        const defaultSize = -10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+    });
+    describe('when perAlertView is true', () => {
+      const perAlertView = test('when defaultSize is undefined', () => {
+        const defaultSize = undefined;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(
+          DEFAULT_GET_ALERTS_QUERY_PARAMS.size
+        );
+      });
+      test('when defaultSize is 0', () => {
+        const defaultSize = 0;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(defaultSize);
+      });
+      test('when defaultSize is greater than 0', () => {
+        const defaultSize = 10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(defaultSize);
+      });
+      test('when defaultSize is less than 0', () => {
+        const defaultSize = -10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+    });
+    describe('when perAlertView is undefined', () => {
+      const perAlertView = undefined;
+      test('when defaultSize is undefined', () => {
+        const defaultSize = undefined;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is 0', () => {
+        const defaultSize = 0;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is greater than 0', () => {
+        const defaultSize = 10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+      test('when defaultSize is less than 0', () => {
+        const defaultSize = -10;
+        expect(getInitialSize(perAlertView, defaultSize)).toEqual(MAX_ALERT_COUNT);
+      });
+    });
+  });
+
+  describe('displayAcknowledgedAlertsToast', () => {
+    let notifications;
+    beforeEach(() => {
+      notifications = _.cloneDeep(coreMock.notifications);
+    });
+    test('when successfulCount is less than 1', () => {
+      displayAcknowledgedAlertsToast(notifications, 0);
+      expect(notifications.toasts.addSuccess).toHaveBeenCalledTimes(0);
+    });
+    test('when successfulCount is undefined', () => {
+      displayAcknowledgedAlertsToast(notifications, undefined);
+      expect(notifications.toasts.addSuccess).toHaveBeenCalledTimes(0);
+    });
+    test('when successfulCount is 1', () => {
+      displayAcknowledgedAlertsToast(notifications, 1);
+      expect(notifications.toasts.addSuccess).toHaveBeenCalledWith(
+        'Successfully acknowledged 1 alert.'
+      );
+    });
+    test('when successfulCount is greater than 1', () => {
+      displayAcknowledgedAlertsToast(notifications, 10);
+      expect(notifications.toasts.addSuccess).toHaveBeenCalledWith(
+        'Successfully acknowledged 10 alerts.'
+      );
+    });
+  });
+
+  describe('filterActiveAlerts', () => {
+    test('with empty alerts', () => {
+      const alerts = [];
+      expect(filterActiveAlerts(alerts)).toEqual([]);
+    });
+    test('with undefined alerts', () => {
+      const alerts = undefined;
+      expect(filterActiveAlerts(alerts)).toEqual([]);
+    });
+    test('with valid alerts', () => {
+      const alerts = [
+        { state: ALERT_STATE.ACKNOWLEDGED },
+        { state: ALERT_STATE.ACTIVE },
+        { state: ALERT_STATE.ACTIVE },
+        { state: ALERT_STATE.COMPLETED },
+        { state: ALERT_STATE.DELETED },
+        { state: ALERT_STATE.ERROR },
+      ];
+      const expectedOutput = [{ state: ALERT_STATE.ACTIVE }, { state: ALERT_STATE.ACTIVE }];
+      expect(filterActiveAlerts(alerts)).toEqual(expectedOutput);
+    });
+  });
+
+  test('getQueryObjectFromState', () => {
+    const expectedOutput = {
+      page: 1,
+      size: 10,
+      search: '',
+      sortField: 'start_time',
+      sortDirection: 'desc',
+      severityLevel: 'ALL',
+      alertState: 'ALL',
+      monitorIds: ['monitor1', 'monitor2', 'monitor3'],
+      flyoutIsOpen: true,
+    };
+    const state = {
+      ...expectedOutput,
+      extraField1: 'extraField1',
+      extraField2: 'extraField2',
+      extraField3: 'extraField3',
+    };
+    expect(getQueryObjectFromState(state)).toEqual(expectedOutput);
+  });
+
+  test('getURLQueryParams', () => {
+    const location = {
+      pathname: '/dashboard',
+      search:
+        '?alertState=ACKNOWLEDGED&from=0&search=searchTerm&severityLevel=5&size=10000&sortDirection=desc&sortField=start_time',
+      hash: '',
+    };
+    const expectedOutput = {
+      from: 0,
+      size: 10000,
+      search: 'searchTerm',
+      sortField: 'start_time',
+      sortDirection: 'desc',
+      severityLevel: '5',
+      alertState: ALERT_STATE.ACKNOWLEDGED,
+    };
+    expect(getURLQueryParams(location)).toEqual(expectedOutput);
+  });
+});

--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -28,7 +28,6 @@ import React from 'react';
 import _ from 'lodash';
 import { EuiLink } from '@elastic/eui';
 import moment from 'moment';
-
 import { ALERT_STATE, DEFAULT_EMPTY_DATA } from '../../../utils/constants';
 import { PLUGIN_NAME } from '../../../../utils/constants';
 
@@ -142,19 +141,21 @@ export const alertColumns = (
   location,
   monitors,
   notifications,
-  setFlyout
+  setFlyout,
+  openFlyout,
+  closeFlyout,
+  refreshDashboard
 ) => [
   {
     field: 'total',
     name: 'Alerts',
     sortable: true,
     truncateText: false,
-    render: (total, alert) => (
-      <EuiLink
-        onClick={() => {
-          setFlyout({
-            type: 'alertsDashboard',
-            payload: {
+    render: (total, alert) => {
+      return (
+        <EuiLink
+          onClick={() => {
+            openFlyout({
               ...alert,
               history,
               httpClient,
@@ -163,13 +164,16 @@ export const alertColumns = (
               monitors,
               notifications,
               setFlyout,
-            },
-          });
-        }}
-      >
-        {`${total} alerts`}
-      </EuiLink>
-    ),
+              closeFlyout,
+              refreshDashboard,
+            });
+          }}
+          data-test-subj={`euiLink_${alert.trigger_name}`}
+        >
+          {`${total} alerts`}
+        </EuiLink>
+      );
+    },
   },
   {
     field: 'ACTIVE',

--- a/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/DeleteConfirmation.js
+++ b/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/DeleteConfirmation.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/DeleteConfirmation.test.js
+++ b/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/DeleteConfirmation.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/index.js
+++ b/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DeleteConfirmation from './DeleteConfirmation';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsActions/DestinationsActions.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsActions/DestinationsActions.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsActions/DestinationsActions.test.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsActions/DestinationsActions.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsActions/index.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsActions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DestinationsActions from './DestinationsActions';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsControls/DestinationsControls.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsControls/DestinationsControls.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsControls/DestinationsControls.test.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsControls/DestinationsControls.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/DestinationsControls/index.js
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsControls/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DestinationsControls from './DestinationsControls';

--- a/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.js
+++ b/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.test.js
+++ b/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/DestinationsList/EmptyDestinations/index.js
+++ b/public/pages/Destinations/components/DestinationsList/EmptyDestinations/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import EmptyDestinations from './EmptyDestinations';

--- a/public/pages/Destinations/components/DestinationsList/index.js
+++ b/public/pages/Destinations/components/DestinationsList/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DeleteConfirmation from './DeleteConfirmation';

--- a/public/pages/Destinations/components/createDestinations/AddEmailGroupButton/AddEmailGroupButton.js
+++ b/public/pages/Destinations/components/createDestinations/AddEmailGroupButton/AddEmailGroupButton.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/AddSenderButton/AddSenderButton.js
+++ b/public/pages/Destinations/components/createDestinations/AddSenderButton/AddSenderButton.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/CustomWebhook.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/CustomWebhook.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/HeaderParamsEditor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/MethodEditor.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/QueryParamsEditor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/URLInfo.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/URLInfo.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/index.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CustomWebhook from './CustomWebhook';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { URL_TYPE } from '../../../containers/CreateDestination/utils/constants';

--- a/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
+++ b/public/pages/Destinations/components/createDestinations/CustomWebhook/validate.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { validateUrl, validateHost } from './validate';

--- a/public/pages/Destinations/components/createDestinations/Email/Email.js
+++ b/public/pages/Destinations/components/createDestinations/Email/Email.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
+++ b/public/pages/Destinations/components/createDestinations/Email/EmailGroup.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/Email/Sender.js
+++ b/public/pages/Destinations/components/createDestinations/Email/Sender.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/Email/index.js
+++ b/public/pages/Destinations/components/createDestinations/Email/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Email from './Email';

--- a/public/pages/Destinations/components/createDestinations/Email/utils/constants.js
+++ b/public/pages/Destinations/components/createDestinations/Email/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const METHOD_TYPE = {

--- a/public/pages/Destinations/components/createDestinations/Email/utils/validate.js
+++ b/public/pages/Destinations/components/createDestinations/Email/utils/validate.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/components/createDestinations/EmailGroupEmptyPrompt/EmailGroupEmptyPrompt.js
+++ b/public/pages/Destinations/components/createDestinations/EmailGroupEmptyPrompt/EmailGroupEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/EmailGroupEmptyPrompt/index.js
+++ b/public/pages/Destinations/components/createDestinations/EmailGroupEmptyPrompt/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import EmailGroupEmptyPrompt from './EmailGroupEmptyPrompt';

--- a/public/pages/Destinations/components/createDestinations/SenderEmptyPrompt/SenderEmptyPrompt.js
+++ b/public/pages/Destinations/components/createDestinations/SenderEmptyPrompt/SenderEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/SenderEmptyPrompt/index.js
+++ b/public/pages/Destinations/components/createDestinations/SenderEmptyPrompt/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import SenderEmptyPrompt from './SenderEmptyPrompt';

--- a/public/pages/Destinations/components/createDestinations/Webhook/Webhook.js
+++ b/public/pages/Destinations/components/createDestinations/Webhook/Webhook.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/components/createDestinations/index.js
+++ b/public/pages/Destinations/components/createDestinations/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Webhook from './Webhook/Webhook';

--- a/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/CreateDestination.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/EmailRecipients.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/index.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import EmailRecipients from './EmailRecipients';

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/constants.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const RECIPIENT_TYPE = {

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { MAX_QUERY_RESULT_SIZE } from '../../../../../../utils/constants';

--- a/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/validate.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailRecipients/utils/validate.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/EmailSender.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/EmailSender.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Fragment } from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/index.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import EmailSender from './EmailSender';

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { MAX_QUERY_RESULT_SIZE } from '../../../../../../utils/constants';

--- a/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/validate.js
+++ b/public/pages/Destinations/containers/CreateDestination/EmailSender/utils/validate.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/ManageEmailGroups.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/index.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ManageEmailGroups from './ManageEmailGroups';

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/ManageSenders.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/index.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import ManageSenders from './ManageSenders';

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/utils/helpers.js
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/CreateDestination/index.js
+++ b/public/pages/Destinations/containers/CreateDestination/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import CreateDestination from './CreateDestination';

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/destinationToFormik.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/destinationToFormik.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { destinationToFormik } from '../destinationToFormik';

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/formikToDestination.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/formikToDestination.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { formikToDestination } from '../formikToDestination';

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/validation.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { validateDestinationName } from '../validations';

--- a/public/pages/Destinations/containers/CreateDestination/utils/constants.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { DESTINATION_TYPE } from '../../../utils/constants';

--- a/public/pages/Destinations/containers/CreateDestination/utils/destinationToFormik.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/destinationToFormik.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/CreateDestination/utils/formikToDestination.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/formikToDestination.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { DESTINATION_TYPE } from '../../../utils/constants';

--- a/public/pages/Destinations/containers/CreateDestination/utils/validations.js
+++ b/public/pages/Destinations/containers/CreateDestination/utils/validations.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Destinations/containers/DestinationsList/DestinationsList.js
+++ b/public/pages/Destinations/containers/DestinationsList/DestinationsList.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
+++ b/public/pages/Destinations/containers/DestinationsList/DestinationsList.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Destinations/containers/DestinationsList/index.js
+++ b/public/pages/Destinations/containers/DestinationsList/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import DestinationsList from './DestinationsList';

--- a/public/pages/Destinations/containers/DestinationsList/utils/__tests__/helpers.test.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/__tests__/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { getURLQueryParams } from '../helpers';

--- a/public/pages/Destinations/containers/DestinationsList/utils/constants.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { DESTINATION_OPTIONS } from '../../../utils/constants';

--- a/public/pages/Destinations/containers/DestinationsList/utils/deleteHelpers.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/deleteHelpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const isDeleteAllowedQuery = (type, id) => ({

--- a/public/pages/Destinations/containers/DestinationsList/utils/helpers.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import queryString from 'query-string';

--- a/public/pages/Destinations/utils/constants.js
+++ b/public/pages/Destinations/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const DESTINATION_TYPE = {

--- a/public/pages/Destinations/utils/helpers.js
+++ b/public/pages/Destinations/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/Home/Home.js
+++ b/public/pages/Home/Home.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Home/Home.test.js
+++ b/public/pages/Home/Home.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Home/index.js
+++ b/public/pages/Home/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Home from './Home';

--- a/public/pages/Main/Main.js
+++ b/public/pages/Main/Main.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Main/Main.test.js
+++ b/public/pages/Main/Main.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Main/index.js
+++ b/public/pages/Main/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Main from './Main';

--- a/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.test.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/Legend/Legend.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/Legend/Legend.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/Legend/Legende.test.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/Legend/Legende.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/POIChart/POIChart.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/POIChart/POIChart.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/POIChart/POIChart.test.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/POIChart/POIChart.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/TriggersTimeSeries.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/TriggersTimeSeries.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/TriggersTimeSeries.test.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/TriggersTimeSeries.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/helpers.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import moment from 'moment';

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/helpers.test.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import moment from 'moment';

--- a/public/pages/MonitorDetails/components/MonitorHistory/index.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export { default as TriggersTimeSeries } from './TriggersTimeSeries/TriggersTimeSeries';

--- a/public/pages/MonitorDetails/components/MonitorOverview/MonitorOverview.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/MonitorOverview.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorOverview/MonitorOverview.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/MonitorOverview.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorOverview/index.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorOverview from './MonitorOverview';

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/constants.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const weekdays = [

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import getOverviewStats from './getOverviewStats';

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getScheduleFromMonitor.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getScheduleFromMonitor.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getScheduleFromMonitor.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getScheduleFromMonitor.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import getScheduleFromMonitor from './getScheduleFromMonitor';

--- a/public/pages/MonitorDetails/components/OverviewStat/OverviewStat.js
+++ b/public/pages/MonitorDetails/components/OverviewStat/OverviewStat.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/OverviewStat/OverviewStat.test.js
+++ b/public/pages/MonitorDetails/components/OverviewStat/OverviewStat.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/components/OverviewStat/index.js
+++ b/public/pages/MonitorDetails/components/OverviewStat/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import OverviewStat from './OverviewStat';

--- a/public/pages/MonitorDetails/containers/AnomalyHistory/AnomalyHistory.js
+++ b/public/pages/MonitorDetails/containers/AnomalyHistory/AnomalyHistory.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component, Fragment } from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/DateRangePicker.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/DateRangePicker.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/MonitorHistory.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/MonitorHistory.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { PureComponent } from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/__mocks__/ui/chrome.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/__mocks__/ui/chrome.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 const chrome = {

--- a/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/DateRangePicker.test.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/DateRangePicker.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/MonitorHistory.test.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/MonitorHistory.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/testHelpers.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/testHelpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 const getRandomInt = () => Math.floor(Math.random() * 10) + 1;

--- a/public/pages/MonitorDetails/containers/MonitorHistory/index.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorHistory from './MonitorHistory';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/chartHelpers.test.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/chartHelpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import moment from 'moment-timezone';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/timeUtils.test.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/timeUtils.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import moment from 'moment';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/chartHelpers.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/chartHelpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { ALERT_STATE } from '../../../../../utils/constants';

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/constants.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const TIME_SERIES_ALERT_STATE = Object.freeze({

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/timeUtils.js
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/timeUtils.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import moment from 'moment';

--- a/public/pages/MonitorDetails/containers/Triggers/Triggers.js
+++ b/public/pages/MonitorDetails/containers/Triggers/Triggers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/MonitorDetails/containers/Triggers/Triggers.test.js
+++ b/public/pages/MonitorDetails/containers/Triggers/Triggers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/MonitorDetails/containers/Triggers/index.js
+++ b/public/pages/MonitorDetails/containers/Triggers/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Triggers from './Triggers';

--- a/public/pages/MonitorDetails/containers/utils/__tests__/helper.test.js
+++ b/public/pages/MonitorDetails/containers/utils/__tests__/helper.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { migrateTriggerMetadata } from '../helpers';

--- a/public/pages/MonitorDetails/containers/utils/helpers.js
+++ b/public/pages/MonitorDetails/containers/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { get, isEmpty } from 'lodash';

--- a/public/pages/Monitors/components/AcknowledgeModal/AcknowledgeModal.js
+++ b/public/pages/Monitors/components/AcknowledgeModal/AcknowledgeModal.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Monitors/components/AcknowledgeModal/AcknowledgeModal.test.js
+++ b/public/pages/Monitors/components/AcknowledgeModal/AcknowledgeModal.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/components/AcknowledgeModal/index.js
+++ b/public/pages/Monitors/components/AcknowledgeModal/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import AcknowledgeModal from './AcknowledgeModal';

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.test.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/components/MonitorActions/index.js
+++ b/public/pages/Monitors/components/MonitorActions/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorActions from './MonitorActions';

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/components/MonitorControls/index.js
+++ b/public/pages/Monitors/components/MonitorControls/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorControls from './MonitorControls';

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.js
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.test.js
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/index.js
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import MonitorEmptyPrompt from './MonitorEmptyPrompt';

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -10,25 +10,24 @@
  */
 
 /*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';
 import _ from 'lodash';
 import queryString from 'query-string';
 import { EuiBasicTable, EuiHorizontalRule } from '@elastic/eui';
-
 import AcknowledgeModal from '../../components/AcknowledgeModal';
 import ContentPanel from '../../../../components/ContentPanel';
 import MonitorActions from '../../components/MonitorActions';
@@ -39,6 +38,7 @@ import { getURLQueryParams } from './utils/helpers';
 import { columns as staticColumns } from './utils/tableUtils';
 import { MONITOR_ACTIONS } from '../../../../utils/constants';
 import { backendErrorNotification } from '../../../../utils/helpers';
+import { displayAcknowledgedAlertsToast } from '../../../Dashboard/utils/helpers';
 
 const MAX_MONITOR_COUNT = 1000;
 
@@ -265,6 +265,9 @@ export default class Monitors extends Component {
         .then((resp) => {
           if (!resp.ok) {
             backendErrorNotification(notifications, 'acknowledge', 'alert', resp.resp);
+          } else {
+            const successfulCount = _.get(resp, 'resp.success', []).length;
+            displayAcknowledgedAlertsToast(notifications, successfulCount);
           }
         })
         .catch((error) => error)

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React, { Component } from 'react';

--- a/public/pages/Monitors/containers/Monitors/Monitors.test.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/pages/Monitors/containers/Monitors/index.js
+++ b/public/pages/Monitors/containers/Monitors/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import Monitors from './Monitors';

--- a/public/pages/Monitors/containers/Monitors/utils/constants.js
+++ b/public/pages/Monitors/containers/Monitors/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const DEFAULT_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];

--- a/public/pages/Monitors/containers/Monitors/utils/helpers.js
+++ b/public/pages/Monitors/containers/Monitors/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { DEFAULT_QUERY_PARAMS } from './constants';

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/plugin.js
+++ b/public/plugin.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { PLUGIN_NAME } from '../utils/constants';

--- a/public/utils/CoreContext.js
+++ b/public/utils/CoreContext.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/utils/SubmitErrorHandler.js
+++ b/public/utils/SubmitErrorHandler.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { useEffect } from 'react';

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const ALERT_STATE = Object.freeze({

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/public/utils/helpers.test.js
+++ b/public/utils/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { backendErrorNotification } from './helpers';

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/public/utils/validate.test.js
+++ b/public/utils/validate.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import {

--- a/server/clusters/alerting/adPlugin.js
+++ b/server/clusters/alerting/adPlugin.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { AD_BASE_API } from '../../services/utils/constants';

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import {

--- a/server/clusters/alerting/createAlertingADCluster.js
+++ b/server/clusters/alerting/createAlertingADCluster.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import alertingADPlugin from './adPlugin';

--- a/server/clusters/alerting/createAlertingCluster.js
+++ b/server/clusters/alerting/createAlertingCluster.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import alertingPlugin from './alertingPlugin';

--- a/server/clusters/index.js
+++ b/server/clusters/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import createAlertingCluster from './alerting/createAlertingCluster';

--- a/server/index.js
+++ b/server/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { first } from 'rxjs/operators';

--- a/server/routes/alerts.js
+++ b/server/routes/alerts.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/routes/anomalyDetector.js
+++ b/server/routes/anomalyDetector.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/routes/destinations.js
+++ b/server/routes/destinations.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import alerts from './alerts';

--- a/server/routes/monitors.js
+++ b/server/routes/monitors.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/routes/opensearch.js
+++ b/server/routes/opensearch.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { schema } from '@osd/config-schema';

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export default class AlertService {

--- a/server/services/AnomalyDetectorService.js
+++ b/server/services/AnomalyDetectorService.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 import { get } from 'lodash';
 import { mapKeysDeep, toCamel } from './utils/helpers';

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -25,6 +25,7 @@
  */
 
 import _ from 'lodash';
+import { isIndexNotFoundError } from './utils/helpers';
 
 export default class DestinationsService {
   constructor(esDriver) {
@@ -198,6 +199,11 @@ export default class DestinationsService {
         },
       });
     } catch (err) {
+      if (isIndexNotFoundError(err)) {
+        return res.ok({
+          body: { ok: true, resp: { totalDestinations: 0, destinations: [] } },
+        });
+      }
       return res.ok({
         body: {
           ok: false,

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -180,7 +180,7 @@ export default class DestinationsService {
     } catch (err) {
       if (isIndexNotFoundError(err)) {
         return res.ok({
-          body: { ok: true, resp: { totalDestinations: 0, destinations: [] } },
+          body: { ok: false, resp: {} },
         });
       }
       return res.ok({

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import _ from 'lodash';

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -27,6 +27,7 @@
 import _ from 'lodash';
 
 import { INDEX } from '../../utils/constants';
+import { isIndexNotFoundError } from './utils/helpers';
 
 export default class MonitorService {
   constructor(esDriver) {
@@ -350,6 +351,11 @@ export default class MonitorService {
       });
     } catch (err) {
       console.error('Alerting - MonitorService - getMonitors', err);
+      if (isIndexNotFoundError(err)) {
+        return res.ok({
+          body: { ok: false, resp: { totalMonitors: 0, monitors: [] } },
+        });
+      }
       return res.ok({
         body: {
           ok: false,

--- a/server/services/OpensearchService.js
+++ b/server/services/OpensearchService.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export default class OpensearchService {

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import AlertService from './AlertService';

--- a/server/services/utils/__tests__/adHelpers.test.js
+++ b/server/services/utils/__tests__/adHelpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { anomalyResultMapper } from '../adHelpers';

--- a/server/services/utils/__tests__/helpers.test.js
+++ b/server/services/utils/__tests__/helpers.test.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { mapKeysDeep, toSnake } from '../helpers';

--- a/server/services/utils/adHelpers.js
+++ b/server/services/utils/adHelpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const anomalyResultMapper = (anomalyResults) => {

--- a/server/services/utils/constants.js
+++ b/server/services/utils/constants.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';

--- a/server/services/utils/helpers.js
+++ b/server/services/utils/helpers.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { get, map, mapKeys, mapValues, isPlainObject, snakeCase, camelCase } from 'lodash';

--- a/server/services/utils/helpers.js
+++ b/server/services/utils/helpers.js
@@ -24,7 +24,7 @@
  *   permissions and limitations under the License.
  */
 
-import { map, mapKeys, mapValues, isPlainObject, snakeCase, camelCase } from 'lodash';
+import { get, map, mapKeys, mapValues, isPlainObject, snakeCase, camelCase } from 'lodash';
 
 export function mapKeysDeep(obj, fn) {
   if (Array.isArray(obj)) {
@@ -39,3 +39,11 @@ export function mapKeysDeep(obj, fn) {
 export const toSnake = (value, key) => snakeCase(key);
 
 export const toCamel = (value, key) => camelCase(key);
+
+export const isIndexNotFoundError = (err) => {
+  return (
+    err.statusCode === 404 &&
+    get(err, 'body.error.reason', '') ===
+      'Configured indices are not found: [.opendistro-alerting-config]'
+  );
+};

--- a/test/enzyme.js
+++ b/test/enzyme.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { configure } from 'enzyme';

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { resolve } from 'path';

--- a/test/functional/pageObjects/alerting-common.js
+++ b/test/functional/pageObjects/alerting-common.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export function AlertingPageProvider({ getService, getPageObjects }) {

--- a/test/functional/pageObjects/index.js
+++ b/test/functional/pageObjects/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export { AlertingPageProvider } from './alerting-common';

--- a/test/functional/tests/alerting-app.js
+++ b/test/functional/tests/alerting-app.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import expect from 'expect';

--- a/test/functional/tests/index.js
+++ b/test/functional/tests/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 export default function ({ loadTestFile }) {

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -45,6 +45,7 @@ module.exports = {
     '**/*.js',
     '!**/node_modules/**',
     '!**/index.js',
+    '!<rootDir>/public/app.js',
     '!<rootDir>/public/actions/**',
     '!<rootDir>/public/components/Charts/Highlight/Highlight.js',
     '!<rootDir>/public/reducers/**',
@@ -55,6 +56,10 @@ module.exports = {
     '!<rootDir>/scripts/**',
     '!<rootDir>/build/**',
     '!<rootDir>/gather-info.js',
+    '!<rootDir>/cypress/**',
     '!**/vendor/**',
   ],
+  clearMocks: true,
+  testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+  modulePathIgnorePatterns: ['alertingDashboards'],
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 module.exports = {

--- a/test/mocks/CoreMock.js
+++ b/test/mocks/CoreMock.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 const coreMock = {

--- a/test/mocks/historyMock.js
+++ b/test/mocks/historyMock.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 const historyMock = {

--- a/test/mocks/httpClientMock.js
+++ b/test/mocks/httpClientMock.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 const httpClientMock = jest.fn();

--- a/test/mocks/index.js
+++ b/test/mocks/index.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import historyMock from './historyMock';

--- a/test/mocks/styleMock.js
+++ b/test/mocks/styleMock.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 module.exports = {};

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 import { MutationObserver } from './polyfills/mutationObserver';

--- a/test/polyfills/mutationObserver.js
+++ b/test/polyfills/mutationObserver.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 /* eslint-disable */

--- a/test/setup.jest.js
+++ b/test/setup.jest.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
  */
 
 import React from 'react';

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,27 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
- *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
  */
 
 require('babel-polyfill');

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { TRIGGER_TYPE } from '../../public/pages/CreateTrigger/containers/CreateTrigger/utils/constants';

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 // Keeping index prefix as 'opendistro' as migrating the system index is currently difficult to complete

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,13 +23,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
-  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
@@ -2163,18 +2156,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2189,7 +2170,7 @@ hoek@4.2.1:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -2552,11 +2533,6 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2826,7 +2802,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2971,14 +2947,6 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -3392,13 +3360,6 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -3491,7 +3452,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.5.8, prop-types@^15.6.2:
+prop-types@^15.5.8:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -3629,7 +3590,7 @@ react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3642,35 +3603,6 @@ react-motion@^0.5.2:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
-
-react-router-dom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
-  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-
-react-router@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
-  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
 
 react-vis@^1.8.1:
   version "1.11.7"
@@ -3744,11 +3676,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -3801,11 +3728,6 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -4351,12 +4273,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
+tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -4548,11 +4465,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
### Description
Cherry-pick commits from main to 1.x from commit [b584932](https://github.com/opensearch-project/alerting-dashboards-plugin/commit/b584932df5d5bc54da05bf646753da8494b25a4d) to [72d678b](https://github.com/opensearch-project/alerting-dashboards-plugin/commit/72d678b5ae4707361e333cb4a5ce354d87dabb87)
 
###Testing
Used `git diff upstream/main` to compare and there are no code difference.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
