### PR TITLE
Configure test workflows to run on 1.x branches

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - main
+      - 1.x
   push:
     branches:
       - main
+      - 1.x
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
   OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - 1.x
   pull_request:
     branches:
       - main
+      - 1.x
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
 jobs:


### PR DESCRIPTION
Signed-off-by: Annie Lee <leeyun@amazon.com>

### Description
Configure test workflows to run on 1.x branches
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
