### PR TITLE
Bumped main branch version to 2.0 to align with OpenSearch-Dashboards. Added alpha1 qualifier to align with backend snapshot version.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,8 +9,8 @@ on:
       - main
       - 1.x
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_VERSION: '2.0.0-alpha1-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/cypress/integration/cluster_metrics_monitor_spec.js
+++ b/cypress/integration/cluster_metrics_monitor_spec.js
@@ -291,7 +291,7 @@ describe('ClusterMetricsMonitor', () => {
 
       describe('the modal CLOSE (i.e., the X button) button is clicked', () => {
         // Click the CLOSE button
-        cy.get('[class="euiButtonIcon euiButtonIcon--text euiModal__closeIcon"]').click();
+        cy.get('[aria-label="Closes this modal window"]').click();
 
         // Confirm clearTriggersModal closed
         cy.get('[data-test-subj="clusterMetricsClearTriggersModal"]').should('not.exist');

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.3.0",
+  "version": "2.0.0.0",
+  "opensearchDashboardsVersion": "2.0.0",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "1.3.0.0",
+  "version": "2.0.0.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Bumped `main` branch version to `2.0` to align with [OpenSearch-Dashboards main branch](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/package.json#L14). Added `alpha1` qualifier to align with [backend version](https://github.com/opensearch-project/alerting/pull/370).
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
