### PR TITLE
Fixed a bug that was causing the UX to reset visual editor trigger conditions to their default values when a trigger name contained periods.

### DIFF
--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -48,16 +48,19 @@ const addVisualQueryLevelTrigger = (
     .clear()
     .type(`${thresholdValue}{enter}`);
 
-  // Type in the action name
-  cy.get(
-    `input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`
-  ).type(`${triggerName}-${triggerIndex}-action1`, { force: true });
-
-  // Click the combo box to list all the destinations
-  // Using key typing instead of clicking the menu option to avoid occasional failure
-  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].actions.0_actionDestination"]`)
-    .click({ force: true })
-    .type(`${SAMPLE_DESTINATION}{downarrow}{enter}`);
+  // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+  //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+  //  ideally take place in the before() block, and clearing should occur in the after() block.
+  // // Type in the action name
+  // cy.get(
+  //   `input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`
+  // ).type(`${triggerName}-${triggerIndex}-action1`, { force: true });
+  //
+  // // Click the combo box to list all the destinations
+  // // Using key typing instead of clicking the menu option to avoid occasional failure
+  // cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].actions.0_actionDestination"]`)
+  //   .click({ force: true })
+  //   .type(`${SAMPLE_DESTINATION}{downarrow}{enter}`);
 };
 
 describe('Query-Level Monitors', () => {

--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PLUGIN_NAME } from '../support/constants';
+import _ from 'lodash';
+import { INDEX, PLUGIN_NAME } from '../support/constants';
 import sampleQueryLevelMonitor from '../fixtures/sample_query_level_monitor';
 import sampleQueryLevelMonitorWithAlwaysTrueTrigger from '../fixtures/sample_query_level_monitor_with_always_true_trigger';
 import sampleDestination from '../fixtures/sample_destination_custom_webhook.json';
@@ -13,6 +14,51 @@ const UPDATED_MONITOR = 'updated_query_level_monitor';
 const SAMPLE_MONITOR_WITH_ANOTHER_NAME = 'sample_query_level_monitor_with_always_true_trigger';
 const SAMPLE_TRIGGER = 'sample_trigger';
 const SAMPLE_ACTION = 'sample_action';
+const SAMPLE_DESTINATION = 'sample_destination';
+
+const addVisualQueryLevelTrigger = (
+  triggerName,
+  triggerIndex,
+  isEdit = true,
+  thresholdEnum,
+  thresholdValue
+) => {
+  // Click 'Add trigger' button
+  cy.contains('Add trigger', { timeout: 20000 }).click({ force: true });
+
+  if (isEdit) {
+    // TODO: Passing button props in EUI accordion was added in newer versions (31.7.0+).
+    //  If this ever becomes available, it can be used to pass data-test-subj for the button.
+    // Since the above is currently not possible, referring to the accordion button using its content
+    cy.get('button').contains('New trigger').click();
+  }
+
+  // Type in the trigger name
+  cy.get(`input[name="triggerDefinitions[${triggerIndex}].name"]`).type(triggerName);
+
+  // Type in the condition thresholdEnum
+  cy.get(
+    `[data-test-subj="triggerDefinitions[${triggerIndex}].thresholdEnum_conditionEnumField"]`
+  ).select(thresholdEnum);
+
+  // Type in the condition thresholdValue
+  cy.get(
+    `[data-test-subj="triggerDefinitions[${triggerIndex}].thresholdValue_conditionValueField"]`
+  )
+    .clear()
+    .type(`${thresholdValue}{enter}`);
+
+  // Type in the action name
+  cy.get(
+    `input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`
+  ).type(`${triggerName}-${triggerIndex}-action1`, { force: true });
+
+  // Click the combo box to list all the destinations
+  // Using key typing instead of clicking the menu option to avoid occasional failure
+  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].actions.0_actionDestination"]`)
+    .click({ force: true })
+    .type(`${SAMPLE_DESTINATION}{downarrow}{enter}`);
+};
 
 describe('Query-Level Monitors', () => {
   beforeEach(() => {
@@ -173,9 +219,94 @@ describe('Query-Level Monitors', () => {
     });
   });
 
+  describe('can have triggers', () => {
+    before(() => {
+      cy.deleteAllMonitors();
+      cy.loadSampleEcommerceData();
+      cy.createMonitor(sampleQueryLevelMonitor);
+    });
+
+    it('with names that contain periods', () => {
+      const triggers = _.orderBy(
+        [
+          { name: '.trigger', enum: 'ABOVE' },
+          { name: 'trigger.', enum: 'BELOW' },
+          { name: '.trigger.', enum: 'EXACTLY' },
+          { name: '..trigger', enum: 'ABOVE' },
+          { name: 'trigger..', enum: 'BELOW' },
+          { name: '.trigger..', enum: 'EXACTLY' },
+          { name: '..trigger.', enum: 'ABOVE' },
+          { name: '.trigger.name', enum: 'BELOW' },
+          { name: 'trigger.name.', enum: 'EXACTLY' },
+          { name: '.trigger.name.', enum: 'ABOVE' },
+        ],
+        (trigger) => trigger.name
+      );
+
+      // Confirm we can see the created monitor in the list
+      cy.contains(SAMPLE_MONITOR);
+
+      // Select the existing monitor
+      cy.get('a').contains(SAMPLE_MONITOR).click();
+
+      // Click Edit button
+      cy.contains('Edit').click({ force: true });
+
+      // Wait for input to load and then type in the new monitor name
+      cy.get('input[name="name"]').should('have.value', SAMPLE_MONITOR);
+
+      // Select visual editor
+      cy.get('[data-test-subj="visualEditorRadioCard"]').click();
+
+      // Wait for input to load and then type in the index name
+      cy.get('#index').type(`{backspace}${INDEX.SAMPLE_DATA_ECOMMERCE}{enter}`, { force: true });
+
+      // Enter the time field
+      cy.get('#timeField').type('order_date{downArrow}{enter}', { force: true });
+
+      // Add the test triggers
+      // For simplicity, the 'value' number is used in this test for the thresholdValue, and the trigger index number.
+      for (let i = 0; i < triggers.length; i++) {
+        const trigger = triggers[i];
+        triggers[i].value = i;
+        addVisualQueryLevelTrigger(trigger.name, i, true, `IS ${trigger.enum}`, `${i}`);
+      }
+
+      // Click Update button
+      cy.get('button').contains('Update').last().click({ force: true });
+
+      // Confirm we can see the correct number of rows in the trigger list by checking <caption> element
+      cy.contains(`This table contains ${triggers.length} rows`, { timeout: 20000 });
+
+      // Click Edit button
+      cy.contains('Edit').click({ force: true });
+
+      triggers.forEach((trigger) => {
+        const triggerIndex = trigger.value;
+        // Click the trigger accordion to expand it
+        cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}]._triggerAccordion"]`).click();
+
+        // Confirm each trigger exists with the expected name and values
+        cy.get(`input[name="triggerDefinitions[${triggerIndex}].name"]`).should(
+          'have.value',
+          trigger.name
+        );
+        cy.get(
+          `[data-test-subj="triggerDefinitions[${triggerIndex}].thresholdEnum_conditionEnumField"]`
+        ).should('have.value', trigger.enum);
+        cy.get(
+          `[data-test-subj="triggerDefinitions[${triggerIndex}].thresholdValue_conditionValueField"]`
+        ).should('have.value', `${trigger.value}`);
+      });
+    });
+  });
+
   after(() => {
     // Delete all existing monitors and destinations
     cy.deleteAllMonitors();
     cy.deleteAllDestinations();
+
+    // Delete sample data
+    cy.deleteIndexByName(`${INDEX.SAMPLE_DATA_ECOMMERCE}`);
   });
 });

--- a/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/TriggerExpressions.js
@@ -22,7 +22,6 @@ class TriggerExpressions extends Component {
 
   render() {
     const { label, keyFieldName, valueFieldName } = this.props;
-
     return (
       <EuiFormRow label={label} style={{ width: '390px' }}>
         <EuiFlexGroup alignItems={'flexStart'} gutterSize={'m'}>
@@ -33,7 +32,11 @@ class TriggerExpressions extends Component {
                   isInvalid={touched.thresholdEnum && !!errors.thresholdEnum}
                   error={errors.thresholdEnum}
                 >
-                  <EuiSelect options={THRESHOLD_ENUM_OPTIONS} {...rest} />
+                  <EuiSelect
+                    options={THRESHOLD_ENUM_OPTIONS}
+                    data-test-subj={`${keyFieldName}_conditionEnumField`}
+                    {...rest}
+                  />
                 </EuiFormRow>
               )}
             </Field>
@@ -46,7 +49,10 @@ class TriggerExpressions extends Component {
                   isInvalid={touched.thresholdValue && !!errors.thresholdValue}
                   error={errors.thresholdValue}
                 >
-                  <EuiFieldNumber {...field} />
+                  <EuiFieldNumber
+                    data-test-subj={`${valueFieldName}_conditionValueField`}
+                    {...field}
+                  />
                 </EuiFormRow>
               )}
             </Field>

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -150,7 +150,7 @@ export function formikToTriggerUiMetadata(values, monitorUiMetadata) {
           };
         }
 
-        _.set(queryLevelTriggersUiMetadata, `${trigger.name}`, triggerMetadata);
+        queryLevelTriggersUiMetadata[trigger.name] = triggerMetadata;
       });
       return queryLevelTriggersUiMetadata;
 
@@ -161,7 +161,7 @@ export function formikToTriggerUiMetadata(values, monitorUiMetadata) {
           value: condition.thresholdValue,
           enum: condition.thresholdEnum,
         }));
-        _.set(bucketLevelTriggersUiMetadata, `${trigger.name}`, triggerMetadata);
+        bucketLevelTriggersUiMetadata[trigger.name] = triggerMetadata;
       });
       return bucketLevelTriggersUiMetadata;
   }

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -46,37 +46,47 @@ export function queryLevelTriggerToFormik(trigger, monitor) {
     min_time_between_executions: minTimeBetweenExecutions,
     rolling_window_size: rollingWindowSize,
   } = trigger.query_level_trigger;
+
+  const triggersUiMetadata = _.get(monitor, 'ui_metadata.triggers', {});
   const thresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].enum`,
+    triggersUiMetadata[name],
+    'enum',
     FORMIK_INITIAL_TRIGGER_VALUES.thresholdEnum
   );
   const thresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].value`,
+    triggersUiMetadata[name],
+    'value',
     FORMIK_INITIAL_TRIGGER_VALUES.thresholdValue
   );
+
+  const adTriggerMetadata = _.get(triggersUiMetadata[name], 'adTriggerMetadata', {});
+  /*
+    If trigger type doesn't exist fallback to query trigger with following reasons
+    1. User has changed monitory type from normal monitor to AD monitor.
+    2. User has created / updated from API and visiting OpenSearch Dashboards to do other operations.
+   */
+  const triggerType = _.get(adTriggerMetadata, 'triggerType', TRIGGER_TYPE.ALERT_TRIGGER);
   const anomalyConfidenceThresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.value`,
+    adTriggerMetadata,
+    'anomalyConfidence.value',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdValue
   );
   const anomalyConfidenceThresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.enum`,
+    adTriggerMetadata,
+    'anomalyConfidence.enum',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdEnum
   );
   const anomalyGradeThresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.value`,
+    adTriggerMetadata,
+    'anomalyGrade.value',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdValue
   );
   const anomalyGradeThresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.enum`,
+    adTriggerMetadata,
+    'anomalyGrade.enum',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdEnum
   );
-  const triggerType = _.get(monitor, `ui_metadata.triggers[${name}].adTriggerMetadata.triggerType`);
+
   return {
     ..._.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES),
     id,
@@ -89,11 +99,7 @@ export function queryLevelTriggerToFormik(trigger, monitor) {
     thresholdEnum,
     thresholdValue,
     anomalyDetector: {
-      /*If trigger type doesn't exist fallback to query trigger with following reasons
-        1. User has changed monitory type from normal monitor to AD monitor.
-        2. User has created / updated from API and visiting OpenSearch Dashboards to do other operations.
-      */
-      triggerType: triggerType ? triggerType : TRIGGER_TYPE.ALERT_TRIGGER,
+      triggerType,
       anomalyGradeThresholdValue,
       anomalyGradeThresholdEnum,
       anomalyConfidenceThresholdValue,
@@ -118,37 +124,46 @@ export function bucketLevelTriggerToFormik(trigger, monitor) {
   const triggerConditions = getBucketLevelTriggerConditions(condition);
   const where = getWhereExpression(composite_agg_filter);
 
+  const triggersUiMetadata = _.get(monitor, 'ui_metadata.triggers', {});
   const thresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].enum`,
+    triggersUiMetadata[name],
+    'enum',
     FORMIK_INITIAL_TRIGGER_VALUES.thresholdEnum
   );
   const thresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].value`,
+    triggersUiMetadata,
+    'value',
     FORMIK_INITIAL_TRIGGER_VALUES.thresholdValue
   );
+
+  const adTriggerMetadata = _.get(triggersUiMetadata[name], 'adTriggerMetadata', {});
+  /*
+    If trigger type doesn't exist fallback to query trigger with following reasons
+    1. User has changed monitory type from normal monitor to AD monitor.
+    2. User has created / updated from API and visiting OpenSearch Dashboards to do other operations.
+   */
+  const triggerType = _.get(adTriggerMetadata, 'triggerType', TRIGGER_TYPE.ALERT_TRIGGER);
   const anomalyConfidenceThresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.value`,
+    adTriggerMetadata,
+    'anomalyConfidence.value',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdValue
   );
   const anomalyConfidenceThresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyConfidence.enum`,
+    adTriggerMetadata,
+    'anomalyConfidence.enum',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyConfidenceThresholdEnum
   );
   const anomalyGradeThresholdValue = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.value`,
+    adTriggerMetadata,
+    'anomalyGrade.value',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdValue
   );
   const anomalyGradeThresholdEnum = _.get(
-    monitor,
-    `ui_metadata.triggers[${name}].adTriggerMetadata.anomalyGrade.enum`,
+    adTriggerMetadata,
+    'anomalyGrade.enum',
     FORMIK_INITIAL_TRIGGER_VALUES.anomalyDetector.anomalyGradeThresholdEnum
   );
-  const triggerType = _.get(monitor, `ui_metadata.triggers[${name}].adTriggerMetadata.triggerType`);
+
   return {
     ..._.cloneDeep(FORMIK_INITIAL_TRIGGER_VALUES),
     id,
@@ -164,11 +179,7 @@ export function bucketLevelTriggerToFormik(trigger, monitor) {
     thresholdValue,
     where,
     anomalyDetector: {
-      /*If trigger type doesn't exist fallback to query trigger with following reasons
-        1. User has changed monitory type from normal monitor to AD monitor.
-        2. User has created / updated from API and visiting OpenSearch Dashboards to do other operations.
-      */
-      triggerType: triggerType ? triggerType : TRIGGER_TYPE.ALERT_TRIGGER,
+      triggerType,
       anomalyGradeThresholdValue,
       anomalyGradeThresholdEnum,
       anomalyConfidenceThresholdValue,

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -201,7 +201,7 @@ class DefineTrigger extends Component {
       <EuiAccordion
         id={triggerName}
         buttonContent={
-          <EuiTitle size={'s'}>
+          <EuiTitle size={'s'} data-test-subj={`${fieldPath}_triggerAccordion`}>
             <h1>{_.isEmpty(triggerName) ? DEFAULT_TRIGGER_NAME : triggerName}</h1>
           </EuiTitle>
         }


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Fixed a bug that was causing the UX to reset visual editor trigger conditions to their default values when a trigger name contained periods.

```js
fields = {
  Cusip: {
    ".trigger": 123,
    "trigger": 56
  }
};

_.get(fields, "Cusip..trigger", 11) 
# returns 56
# seems lodash will squash the .. to .
```
 
### Issues Resolved
#203 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
