### PR TITLE
Temporarily disabled destination use in some cypress tests to resolve flakiness.

### DIFF
--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -79,21 +79,27 @@ const addTriggerToVisualEditorMonitor = (triggerName, triggerIndex, actionName, 
     .type('a*')
     .trigger('blur', { force: true });
 
-  // Type in the action name
-  cy.get(`input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`).type(actionName, {
-    force: true,
-  });
-
-  // Click the combo box to list all the destinations
-  // Using key typing instead of clicking the menu option to avoid occasional failure
-  cy.get(`div[name="triggerDefinitions[${triggerIndex}].actions.0.destination_id"]`)
-    .click({ force: true })
-    .type('{downarrow}{enter}');
+  // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+  //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+  //  ideally take place in the before() block, and clearing should occur in the after() block.
+  // // Type in the action name
+  // cy.get(`input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`).type(actionName, {
+  //   force: true,
+  // });
+  //
+  // // Click the combo box to list all the destinations
+  // // Using key typing instead of clicking the menu option to avoid occasional failure
+  // cy.get(`div[name="triggerDefinitions[${triggerIndex}].actions.0.destination_id"]`)
+  //   .click({ force: true })
+  //   .type('{downarrow}{enter}');
 };
 
 describe('Bucket-Level Monitors', () => {
   before(() => {
-    cy.createDestination(sampleDestination);
+    // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+    //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+    //  ideally take place in the before() block, and clearing should occur in the after() block.
+    // cy.createDestination(sampleDestination);
 
     // Load sample data
     cy.loadSampleEcommerceData();
@@ -156,14 +162,17 @@ describe('Bucket-Level Monitors', () => {
       // Type in the trigger name
       cy.get('input[name="triggerDefinitions[0].name"]').type(SAMPLE_TRIGGER);
 
-      // Type in the action name
-      cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
-
-      // Click the combo box to list all the destinations
-      // Using key typing instead of clicking the menu option to avoid occasional failure
-      cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
-        .click({ force: true })
-        .type('{downarrow}{enter}');
+      // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+      //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+      //  ideally take place in the before() block, and clearing should occur in the after() block.
+      // // Type in the action name
+      // cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
+      //
+      // // Click the combo box to list all the destinations
+      // // Using key typing instead of clicking the menu option to avoid occasional failure
+      // cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
+      //   .click({ force: true })
+      //   .type('{downarrow}{enter}');
 
       // Click the create button
       cy.get('button').contains('Create').click();
@@ -260,14 +269,14 @@ describe('Bucket-Level Monitors', () => {
       cy.deleteAllMonitors();
     });
 
-    describe('when defined by extraction query', () => {
-      beforeEach(() => {
-        cy.createMonitor(sampleExtractionQueryMonitor);
-      });
-
-      // by adding trigger
-      it('by adding trigger', () => {});
-    });
+    // TODO: Implement test
+    // describe('when defined by extraction query', () => {
+    //   beforeEach(() => {
+    //     cy.createMonitor(sampleExtractionQueryMonitor);
+    //   });
+    //
+    //   it('by adding trigger', () => {});
+    // });
 
     describe('when defined by visual editor', () => {
       beforeEach(() => {

--- a/cypress/integration/cluster_metrics_monitor_spec.js
+++ b/cypress/integration/cluster_metrics_monitor_spec.js
@@ -43,21 +43,27 @@ const addClusterMetricsTrigger = (triggerName, triggerIndex, actionName, isEdit,
       .trigger('blur', { force: true });
   });
 
-  // Type in the action name
-  cy.get(`input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`).type(actionName, {
-    force: true,
-  });
-
-  // Click the combo box to list all the destinations
-  // Using key typing instead of clicking the menu option to avoid occasional failure
-  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].actions.0_actionDestination"]`)
-    .click({ force: true })
-    .type(`${SAMPLE_DESTINATION}{downarrow}{enter}`);
+  // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+  //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+  //  ideally take place in the before() block, and clearing should occur in the after() block.
+  // // Type in the action name
+  // cy.get(`input[name="triggerDefinitions[${triggerIndex}].actions.0.name"]`).type(actionName, {
+  //   force: true,
+  // });
+  //
+  // // Click the combo box to list all the destinations
+  // // Using key typing instead of clicking the menu option to avoid occasional failure
+  // cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].actions.0_actionDestination"]`)
+  //   .click({ force: true })
+  //   .type(`${SAMPLE_DESTINATION}{downarrow}{enter}`);
 };
 
 describe('ClusterMetricsMonitor', () => {
   before(() => {
-    cy.createDestination(sampleDestination);
+    // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+    //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+    //  ideally take place in the before() block, and clearing should occur in the after() block.
+    // cy.createDestination(sampleDestination);
 
     // Load sample data
     cy.loadSampleEcommerceData();
@@ -109,14 +115,17 @@ describe('ClusterMetricsMonitor', () => {
       // Type in the trigger name
       cy.get('input[name="triggerDefinitions[0].name"]').type(SAMPLE_TRIGGER);
 
-      // Type in the action name
-      cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
-
-      // Click the combo box to list all the destinations
-      // Using key typing instead of clicking the menu option to avoid occasional failure
-      cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
-        .click({ force: true })
-        .type('{downarrow}{enter}');
+      // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+      //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+      //  ideally take place in the before() block, and clearing should occur in the after() block.
+      // // Type in the action name
+      // cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
+      //
+      // // Click the combo box to list all the destinations
+      // // Using key typing instead of clicking the menu option to avoid occasional failure
+      // cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
+      //   .click({ force: true })
+      //   .type('{downarrow}{enter}');
 
       // Click the create button
       cy.get('button').contains('Create').click();
@@ -163,14 +172,17 @@ describe('ClusterMetricsMonitor', () => {
       // Type in the trigger name
       cy.get('input[name="triggerDefinitions[0].name"]').type(SAMPLE_TRIGGER);
 
-      // Type in the action name
-      cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
-
-      // Click the combo box to list all the destinations
-      // Using key typing instead of clicking the menu option to avoid occasional failure
-      cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
-        .click({ force: true })
-        .type('{downarrow}{enter}');
+      // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+      //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+      //  ideally take place in the before() block, and clearing should occur in the after() block.
+      // // Type in the action name
+      // cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION);
+      //
+      // // Click the combo box to list all the destinations
+      // // Using key typing instead of clicking the menu option to avoid occasional failure
+      // cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
+      //   .click({ force: true })
+      //   .type('{downarrow}{enter}');
 
       // Click the create button
       cy.get('button').contains('Create').click();

--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -29,7 +29,11 @@ describe('Query-Level Monitors', () => {
   describe('can be created', () => {
     before(() => {
       cy.deleteAllMonitors();
-      cy.createDestination(sampleDestination);
+
+      // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+      //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+      //  ideally take place in the before() block, and clearing should occur in the after() block.
+      // cy.createDestination(sampleDestination);
     });
 
     it('by extraction query', () => {
@@ -57,16 +61,19 @@ describe('Query-Level Monitors', () => {
       // Type in the trigger name
       cy.get('input[name="triggerDefinitions[0].name"]').type(SAMPLE_TRIGGER, { force: true });
 
-      // Type in the action name
-      cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION, {
-        force: true,
-      });
-
-      // Click the combo box to list all the destinations
-      // Using key typing instead of clicking the menu option to avoid occasional failure
-      cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
-        .click({ force: true })
-        .type('{downarrow}{enter}');
+      // FIXME: Temporarily removing destination creation to resolve flakiness. It seems deleteAllDestinations()
+      //  is executing mid-testing. Need to further investigate a more ideal solution. Destination creation should
+      //  ideally take place in the before() block, and clearing should occur in the after() block.
+      // // Type in the action name
+      // cy.get('input[name="triggerDefinitions[0].actions.0.name"]').type(SAMPLE_ACTION, {
+      //   force: true,
+      // });
+      //
+      // // Click the combo box to list all the destinations
+      // // Using key typing instead of clicking the menu option to avoid occasional failure
+      // cy.get('div[name="triggerDefinitions[0].actions.0.destination_id"]')
+      //   .click({ force: true })
+      //   .type('{downarrow}{enter}');
 
       // Click the create button
       cy.get('button').contains('Create').click({ force: true });


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Automatic destination migration to notification channels was causing destinations to be deleted while cypress tests were executing. For now, we're commenting out the portions of those tests that use destinations. The tests will be refactored in the future to make use of notification channels once the notifications frontend is implemented.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
