### PR TITLE
Fixed bugs associated with alerts table, and addressed UX review feedback.

### DIFF
--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -47,7 +47,10 @@ import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../../../pages/Monitors/containers
 import queryString from 'query-string';
 import { MAX_ALERT_COUNT } from '../../../../pages/Dashboard/utils/constants';
 import { SEVERITY_OPTIONS } from '../../../../pages/CreateTrigger/utils/constants';
-import { TABLE_TAB_IDS } from '../../../../pages/Dashboard/components/FindingsDashboard/utils';
+import {
+  ALERTS_FINDING_COLUMN,
+  TABLE_TAB_IDS,
+} from '../../../../pages/Dashboard/components/FindingsDashboard/utils';
 import FindingsDashboard from '../../../../pages/Dashboard/containers/FindingsDashboard';
 
 export const DEFAULT_NUM_FLYOUT_ROWS = 10;
@@ -147,8 +150,8 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
   getBucketLevelGraphConditions = (trigger) => {
     let conditions = _.get(trigger, 'condition.script.source', '-');
-    conditions = _.replace(conditions, ' && ', '&AND&');
-    conditions = _.replace(conditions, ' || ', '&OR&');
+    conditions = conditions.replaceAll(' && ', '&AND&');
+    conditions = conditions.replaceAll(' || ', '&OR&');
     conditions = conditions.split(/&/);
     return conditions.join('\n');
   };
@@ -167,7 +170,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
   };
 
   getAlerts = async () => {
-    this.setState({ loading: true });
+    this.setState({ loading: true, tabContent: undefined });
     const {
       from,
       search,
@@ -263,8 +266,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       alertState,
       monitorIds
     );
-    this.setState({ selectedItems: [], tabContent: undefined });
-    this.setState({ tabContent: this.renderAlertsTable() });
+    this.setState({ selectedItems: [] });
     this.props.refreshDashboard();
   };
 
@@ -348,6 +350,10 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       switch (monitorType) {
         case MONITOR_TYPE.BUCKET_LEVEL:
           columns = insertGroupByColumn(groupBy);
+          break;
+        case MONITOR_TYPE.DOC_LEVEL:
+          columns = _.cloneDeep(queryColumns);
+          columns.splice(0, 0, ALERTS_FINDING_COLUMN);
           break;
         default:
           columns = queryColumns;

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -149,11 +149,15 @@ export default class AlertsDashboardFlyoutComponent extends Component {
   }
 
   getBucketLevelGraphConditions = (trigger) => {
-    let conditions = _.get(trigger, 'condition.script.source', '-');
-    conditions = conditions.replaceAll(' && ', '&AND&');
-    conditions = conditions.replaceAll(' || ', '&OR&');
-    conditions = conditions.split(/&/);
-    return conditions.join('\n');
+    let conditions = _.get(trigger, 'condition.script.source');
+    if (_.isEmpty(conditions)) {
+      return '-';
+    } else {
+      conditions = conditions.replaceAll(' && ', '&AND&');
+      conditions = conditions.replaceAll(' || ', '&OR&');
+      conditions = conditions.split(/&/);
+      return conditions.join('\n');
+    }
   };
 
   getSeverityText = (severity) => {

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -60,7 +60,7 @@ const documentLevelDescription = ( // TODO DRAFT: confirm wording
 );
 
 const MonitorType = ({ values }) => (
-  <EuiFlexGrid alignItems={'flexStart'} gutterSize={'m'}>
+  <EuiFlexGrid gutterSize={'m'}>
     <EuiFlexItem grow={false}>
       <FormikCheckableCard
         name="monitorTypeQueryLevel"

--- a/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`MonitorType renders 1`] = `
 <div
-  alignitems="flexStart"
   class="euiFlexGrid euiFlexGrid--gutterMedium euiFlexGrid--wrap euiFlexGrid--responsive"
 >
   <div

--- a/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
@@ -14,7 +14,7 @@ import ContentPanel from '../../../../components/ContentPanel';
 const QueryPerformance = ({ response, actions }) => (
   <Fragment>
     <ContentPanel
-      title="Query performance"
+      title="Monitor performance"
       titleSize="s"
       panelStyles={{ paddingLeft: '10px', paddingRight: '10px' }}
       description={
@@ -31,7 +31,7 @@ const QueryPerformance = ({ response, actions }) => (
       <EuiFlexGroup alignItems="flexStart" gutterSize="xl">
         <EuiFlexItem grow={false}>
           <EuiText size="xs">
-            <strong>Query duration</strong>
+            <strong>Monitor duration</strong>
             <span style={{ display: 'block' }}>
               {`${_.get(response, 'took', DEFAULT_EMPTY_DATA)} ms`}
             </span>

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -15,7 +15,7 @@ exports[`QueryPerformance renders 1`] = `
       <h3
         class="euiTitle euiTitle--small"
       >
-        Query performance
+        Monitor performance
       </h3>
     </div>
     <div
@@ -72,7 +72,7 @@ exports[`QueryPerformance renders 1`] = `
           class="euiText euiText--extraSmall"
         >
           <strong>
-            Query duration
+            Monitor duration
           </strong>
           <span
             style="display:block"

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -109,7 +109,7 @@ export function getDocumentLevelScriptSource(conditions) {
     if (!_.isEmpty(query) && !_.isEmpty(query.queryName)) {
       const queryExpression = _.get(query, 'expression');
       const operator = query.operator === '!=' ? '!' : '';
-      scriptSourceContents.push(`(${operator}query[${queryExpression}])`);
+      scriptSourceContents.push(`${operator}query[${queryExpression}]`);
     }
   });
   return scriptSourceContents.join(' ');

--- a/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
@@ -31,7 +31,7 @@ import { backendErrorNotification, inputLimitText } from '../../../../utils/help
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
 import { buildRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
 
-const MAX_TRIGGER_CONDITIONS = 5; // TODO DRAFT: Placeholder limit
+const MAX_TRIGGER_CONDITIONS = 10;
 
 const defaultRowProps = {
   label: 'Trigger name',

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
@@ -33,6 +33,11 @@ const DashboardEmptyPrompt = ({ onCreateTrigger, isModal = false }) => {
     : inMonitorDetails
     ? createTriggerText
     : createMonitorText;
+  const actions = inMonitorDetails
+    ? undefined
+    : isModal
+    ? editMonitorButton(onCreateTrigger)
+    : createMonitorButton;
   return (
     <EuiEmptyPrompt
       style={{ maxWidth: '45em' }}
@@ -41,9 +46,7 @@ const DashboardEmptyPrompt = ({ onCreateTrigger, isModal = false }) => {
           <p>{displayText}</p>
         </EuiText>
       }
-      actions={
-        inMonitorDetails || isModal ? editMonitorButton(onCreateTrigger) : createMonitorButton
-      }
+      actions={actions}
     />
   );
 };

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiButton, EuiButtonEmpty, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 
 import { APP_PATH } from '../../../../utils/constants';
 import { PLUGIN_NAME } from '../../../../../utils/constants';
@@ -23,9 +23,7 @@ const createMonitorButton = (
   </EuiButton>
 );
 const editMonitorButton = (onCreateTrigger) => (
-  <EuiButton fill onClick={onCreateTrigger}>
-    Edit monitor
-  </EuiButton>
+  <EuiButtonEmpty onClick={onCreateTrigger}>Edit monitor</EuiButtonEmpty>
 );
 
 const DashboardEmptyPrompt = ({ onCreateTrigger, isModal = false }) => {

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -64,8 +64,8 @@ export default class FindingFlyout extends Component {
         onClose={this.closeFlyout}
         ownFocus={false}
         hideCloseButton={true}
-        side={isAlertsFlyout ? 'left' : 'right'}
-        size={'s'}
+        side={'right'}
+        size={'m'}
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size={'m'}>
@@ -119,13 +119,20 @@ export default class FindingFlyout extends Component {
             overflowHeight={600}
             inline={false}
             isCopyable
+            style={{ height: '400px' }}
           >
             {JSON.stringify(documentDisplay, null, 3)}
           </EuiCodeBlock>
         </EuiFlyoutBody>
 
         <EuiFlyoutFooter>
-          <EuiButtonEmpty onClick={this.closeFlyout}>Close</EuiButtonEmpty>
+          <EuiButtonEmpty
+            iconType={'cross'}
+            onClick={this.closeFlyout}
+            style={{ paddingLeft: '0px', marginLeft: '0px' }}
+          >
+            Close
+          </EuiButtonEmpty>
         </EuiFlyoutFooter>
       </EuiFlyout>
     );

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingsPopover.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingsPopover.js
@@ -4,16 +4,33 @@
  */
 
 import React, { useState } from 'react';
+import _ from 'lodash';
 
 import { EuiLink, EuiPopover, EuiSpacer, EuiText } from '@elastic/eui';
 
-export default function QueryPopover(queries) {
+export default function FindingsPopover({ docIds = [], queries = [] }) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
   const closePopover = () => setIsPopoverOpen(false);
 
-  const popoverContent = queries.queries.map((query, index) => {
-    return (
+  let header;
+  let popoverContent;
+  let count;
+
+  if (!_.isEmpty(docIds)) {
+    header = 'Documents';
+    popoverContent = docIds.map((docId, index) => (
+      <div key={`${docId}${index}`}>
+        {index > 0 && <EuiSpacer size={'s'} />}
+        <EuiText size={'s'}>
+          <p>{docId}</p>
+        </EuiText>
+      </div>
+    ));
+    count = popoverContent.length;
+  } else {
+    header = 'Queries';
+    popoverContent = queries.map((query, index) => (
       <div key={`${query.name}${index}`}>
         {index > 0 && <EuiSpacer size={'s'} />}
         <EuiText size={'s'}>
@@ -21,12 +38,15 @@ export default function QueryPopover(queries) {
           <p>{query.query}</p>
         </EuiText>
       </div>
-    );
-  });
+    ));
+    count = popoverContent.length;
+  }
+
+  const buttonContent = `${count} ${header}`;
 
   return (
     <EuiPopover
-      button={<EuiLink onClick={onButtonClick}>{`${queries.queries.length} Queries`}</EuiLink>}
+      button={<EuiLink onClick={onButtonClick}>{buttonContent}</EuiLink>}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
     >

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -24,10 +24,7 @@ export default class AlertService {
       size = 20,
       search = '',
       sortDirection = 'desc',
-      // If the sortField parsed from the URL isn't a valid option for this API, use a default option.
-      sortField = _.includes(_.values(GET_ALERTS_SORT_FILTERS), req.query.sortField)
-        ? req.query.sortField
-        : GET_ALERTS_SORT_FILTERS.START_TIME,
+      sortField = GET_ALERTS_SORT_FILTERS.START_TIME,
       severityLevel = 'ALL',
       alertState = 'ALL',
       monitorIds = [],
@@ -47,12 +44,6 @@ export default class AlertService {
           sortOrder: sortDirection,
         };
         break;
-      case GET_ALERTS_SORT_FILTERS.START_TIME:
-        params = {
-          sortString: sortField,
-          sortOrder: sortDirection,
-        };
-        break;
       case GET_ALERTS_SORT_FILTERS.END_TIME:
         params = {
           sortString: sortField,
@@ -67,6 +58,12 @@ export default class AlertService {
           missing: '_last',
         };
         break;
+      default:
+        // If the sortField parsed from the URL isn't a valid option for this API, use a default option.
+        params = {
+          sortString: GET_ALERTS_SORT_FILTERS.START_TIME,
+          sortOrder: sortDirection,
+        };
     }
 
     params.startIndex = from;

--- a/server/services/FindingService.js
+++ b/server/services/FindingService.js
@@ -36,10 +36,7 @@ export default class FindingService {
       size = DEFAULT_GET_FINDINGS_PARAMS.size,
       search = DEFAULT_GET_FINDINGS_PARAMS.search,
       sortDirection = DEFAULT_GET_FINDINGS_PARAMS.sortDirection,
-      // If the sortField parsed from the URL isn't a valid option for this API, use a default option.
-      sortField = _.includes(_.values(GET_FINDINGS_SORT_FIELDS), req.query.sortField)
-        ? req.query.sortField
-        : DEFAULT_GET_FINDINGS_PARAMS.sortField,
+      sortField = DEFAULT_GET_FINDINGS_PARAMS.sortField,
     } = req.query;
 
     var params;
@@ -56,12 +53,12 @@ export default class FindingService {
           sortOrder: sortDirection,
         };
         break;
-      case GET_FINDINGS_SORT_FIELDS.TIMESTAMP:
+      default:
+        // If the sortField parsed from the URL isn't a valid option for this API, use a default option.
         params = {
-          sortString: sortField,
+          sortString: GET_FINDINGS_SORT_FIELDS.TIMESTAMP,
           sortOrder: sortDirection,
         };
-        break;
     }
 
     if (!_.isEmpty(id)) params.findingId = id;


### PR DESCRIPTION
### Description
1. Refactored alerts table to display finding doc IDs. 
2. Fixed a bug that was preventing the alerts flyout table from refreshing after acknowledging alerts. 
3. Removed edit monitor button from alerts table on monitor details page. 
4. Fixed a bug that was causing the monitor create/update page to crash when changing from extraction editor to visual editor. 
5. Refactored position of finding flyout. 
6. Fixed a bug that was preventing sorting and pagination of the findings table. 
7. Repurposed QueryPopover to FindingsPopover, and added support for displaying doc IDs using the popover. 
8. Removed parentheses from the trigger condition sent to backend. 
9. Added validation for queries defined using the visual editor.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
