### PR TITLE
Document level monitor UX bug fixes

### DIFF
--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -148,7 +148,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       this.setState({ tabContent: this.renderAlertsTable() });
   }
 
-  getBucketLevelGraphConditions = (trigger) => {
+  getMultipleGraphConditions = (trigger) => {
     let conditions = _.get(trigger, 'condition.script.source');
     if (_.isEmpty(conditions)) {
       return '-';
@@ -514,10 +514,20 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     const groupBy = _.get(monitor, MONITOR_GROUP_BY);
 
     const condition =
-      (searchType === SEARCH_TYPE.GRAPH && monitorType === MONITOR_TYPE.BUCKET_LEVEL) ||
-      MONITOR_TYPE.DOC_LEVEL
-        ? this.getBucketLevelGraphConditions(trigger)
+      searchType === SEARCH_TYPE.GRAPH &&
+      (monitorType === MONITOR_TYPE.BUCKET_LEVEL || monitorType === MONITOR_TYPE.DOC_LEVEL)
+        ? this.getMultipleGraphConditions(trigger)
         : _.get(trigger, 'condition.script.source', '-');
+
+    let displayMultipleConditions;
+    switch (monitorType) {
+      case MONITOR_TYPE.BUCKET_LEVEL:
+      case MONITOR_TYPE.DOC_LEVEL:
+        displayMultipleConditions = true;
+        break;
+      default:
+        displayMultipleConditions = false;
+    }
 
     const filters =
       monitorType === MONITOR_TYPE.BUCKET_LEVEL && searchType === SEARCH_TYPE.GRAPH
@@ -534,7 +544,15 @@ export default class AlertsDashboardFlyoutComponent extends Component {
         ? `${bucketValue} ${bucketUnitOfTime}`
         : '-';
 
-    const displayTableTabs = monitorType === MONITOR_TYPE.DOC_LEVEL;
+    let displayTableTabs;
+    switch (monitorType) {
+      case MONITOR_TYPE.DOC_LEVEL:
+        displayTableTabs = true;
+        break;
+      default:
+        displayTableTabs = false;
+        break;
+    }
     return (
       <div>
         <EuiFlexGroup>
@@ -590,9 +608,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_conditions_${trigger_name}`}>
-              <strong>
-                {monitorType === MONITOR_TYPE.BUCKET_LEVEL ? 'Conditions' : 'Condition'}
-              </strong>
+              <strong>{displayMultipleConditions ? 'Conditions' : 'Condition'}</strong>
               <p style={{ whiteSpace: 'pre-wrap' }}>
                 {loadingMonitors || loading ? 'Loading conditions...' : condition}
               </p>

--- a/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/ConfigureDocumentLevelQueries.js
+++ b/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/ConfigureDocumentLevelQueries.js
@@ -8,7 +8,8 @@ import _ from 'lodash';
 import { connect, FieldArray } from 'formik';
 import { EuiButton, EuiSpacer } from '@elastic/eui';
 import { inputLimitText } from '../../../../utils/helpers';
-import DocumentLevelQuery, { getInitialQueryValues } from './DocumentLevelQuery';
+import DocumentLevelQuery from './DocumentLevelQuery';
+import { FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES } from '../../containers/CreateMonitor/utils/constants';
 
 export const MAX_QUERIES = 10; // TODO DRAFT: Placeholder limit
 
@@ -23,7 +24,8 @@ class ConfigureDocumentLevelQueries extends Component {
       dataTypes,
       formik: { values },
     } = this.props;
-    if (_.isEmpty(values.queries)) arrayHelpers.push(_.cloneDeep(getInitialQueryValues()));
+    if (_.isEmpty(values.queries))
+      arrayHelpers.push(_.cloneDeep(FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES));
     const numOfQueries = values.queries.length;
     return (
       <div>
@@ -44,7 +46,9 @@ class ConfigureDocumentLevelQueries extends Component {
           <EuiButton
             fill={false}
             size={'s'}
-            onClick={() => arrayHelpers.push(_.cloneDeep(getInitialQueryValues(numOfQueries)))}
+            onClick={() =>
+              arrayHelpers.push(_.cloneDeep(FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES))
+            }
             disabled={numOfQueries >= MAX_QUERIES}
           >
             {numOfQueries === 0 ? 'Add query' : 'Add another query'}

--- a/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/ConfigureDocumentLevelQueryTags.js
+++ b/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/ConfigureDocumentLevelQueryTags.js
@@ -5,9 +5,13 @@
 
 import React, { Component } from 'react';
 import { connect, FieldArray } from 'formik';
-import { EuiButtonEmpty } from '@elastic/eui';
+import { EuiButtonEmpty, EuiSpacer, EuiText } from '@elastic/eui';
 import { inputLimitText } from '../../../../utils/helpers';
-import DocumentLevelQueryTag from './DocumentLevelQueryTag';
+import DocumentLevelQueryTag, { DOC_LEVEL_TAG_TOOLTIP } from './DocumentLevelQueryTag';
+import IconToolTip from '../../../../components/IconToolTip';
+import _ from 'lodash';
+import { FormikFormRow } from '../../../../components/FormControls';
+import { hasError, isInvalid } from '../../../../utils/validate';
 
 export const MAX_TAGS = 10; // TODO DRAFT: Placeholder limit
 
@@ -19,37 +23,59 @@ class ConfigureDocumentLevelQueryTags extends Component {
 
   renderTags(arrayHelpers) {
     const {
-      formik: { values },
+      formik: { errors, values },
       formFieldName = '',
       query,
       queryIndex,
     } = this.props;
     const numOfTags = query.tags.length;
+    const tagsErrors = _.get(errors, `${formFieldName}.tags`, []);
+    const containsErrors = !_.isEmpty(tagsErrors);
     return (
       <div>
-        {values.queries[queryIndex].tags.map((tag, index) => {
-          return (
-            <span style={{ paddingRight: '5px' }} key={`${formFieldName}.tags.${index}`}>
-              <DocumentLevelQueryTag
-                tag={tag}
-                tagIndex={index}
-                arrayHelpers={arrayHelpers}
-                formFieldName={`${formFieldName}.tags.${index}`}
-              />
-            </span>
-          );
-        })}
-        <div>
-          <EuiButtonEmpty
-            size={'xs'}
-            onClick={() => arrayHelpers.push('')}
-            disabled={numOfTags >= MAX_TAGS}
-            style={{ paddingTop: '5px' }}
-          >
-            + Add tag
-          </EuiButtonEmpty>
-          {inputLimitText(numOfTags, MAX_TAGS, 'tag', 'tags')}
-        </div>
+        <EuiText size={'xs'} color={containsErrors ? 'danger' : undefined}>
+          <strong>Tags</strong>
+          <i> - optional </i>
+          <IconToolTip content={DOC_LEVEL_TAG_TOOLTIP} iconType={'questionInCircle'} />
+        </EuiText>
+        <EuiSpacer size={'s'} />
+
+        {_.isEmpty(query.tags) && (
+          <div>
+            <EuiText size={'xs'}>No tags defined.</EuiText>
+          </div>
+        )}
+
+        <FormikFormRow
+          form={this.props.formik}
+          name={`${formFieldName}.tags`}
+          rowProps={{ error: hasError, isInvalid }}
+        >
+          <div>
+            {values.queries[queryIndex].tags.map((tag, index) => {
+              return (
+                <span style={{ paddingRight: '5px' }} key={`${formFieldName}.tags.${index}`}>
+                  <DocumentLevelQueryTag
+                    tag={tag}
+                    tagIndex={index}
+                    arrayHelpers={arrayHelpers}
+                    formFieldName={`${formFieldName}.tags.${index}`}
+                  />
+                </span>
+              );
+            })}
+          </div>
+        </FormikFormRow>
+
+        <EuiButtonEmpty
+          size={'xs'}
+          onClick={() => arrayHelpers.push('')}
+          disabled={numOfTags >= MAX_TAGS}
+          style={{ paddingTop: '5px' }}
+        >
+          + Add tag
+        </EuiButtonEmpty>
+        {inputLimitText(numOfTags, MAX_TAGS, 'tag', 'tags')}
       </div>
     );
   }
@@ -57,7 +83,7 @@ class ConfigureDocumentLevelQueryTags extends Component {
   render() {
     const { formFieldName } = this.props;
     return (
-      <FieldArray name={`${formFieldName}.tags`} validateOnChange={false}>
+      <FieldArray name={`${formFieldName}.tags`} validateOnChange={true}>
         {(arrayHelpers) => this.renderTags(arrayHelpers)}
       </FieldArray>
     );

--- a/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/DocumentLevelQuery.js
+++ b/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/DocumentLevelQuery.js
@@ -4,32 +4,23 @@
  */
 
 import React, { Component } from 'react';
-import _ from 'lodash';
 import { connect } from 'formik';
-import {
-  EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiSpacer,
-  EuiText,
-} from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiSpacer } from '@elastic/eui';
 import { FormikComboBox, FormikFieldText, FormikSelect } from '../../../../components/FormControls';
-import { hasError, isInvalid, required } from '../../../../utils/validate';
-import { FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES } from '../../containers/CreateMonitor/utils/constants';
-import { DOC_LEVEL_TAG_TOOLTIP } from './DocumentLevelQueryTag';
-import IconToolTip from '../../../../components/IconToolTip';
+import {
+  hasError,
+  isInvalid,
+  required,
+  validateIllegalCharacters,
+} from '../../../../utils/validate';
 import ConfigureDocumentLevelQueryTags from './ConfigureDocumentLevelQueryTags';
 import { getIndexFields } from '../MonitorExpressions/expressions/utils/dataTypes';
 import { QUERY_OPERATORS } from '../../../Dashboard/components/FindingsDashboard/utils';
 
 const ALLOWED_DATA_TYPES = ['number', 'text', 'keyword', 'boolean'];
 
-export const getInitialQueryValues = (queryIndexNum = 0) =>
-  _.cloneDeep({
-    ...FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES,
-    queryName: `Query ${queryIndexNum + 1}`,
-  });
+// TODO DRAFT: implement validation
+export const ILLEGAL_QUERY_NAME_CHARACTERS = [' '];
 
 class DocumentLevelQuery extends Component {
   constructor(props) {
@@ -46,14 +37,19 @@ class DocumentLevelQuery extends Component {
             <FormikFieldText
               name={`${formFieldName}.queryName`}
               formRow
-              fieldProps={{ validate: required }} // TODO DRAFT: implement validation
+              fieldProps={{
+                validate: validateIllegalCharacters(ILLEGAL_QUERY_NAME_CHARACTERS),
+              }}
               rowProps={{
                 label: 'Query name',
                 style: { width: '300px' },
                 isInvalid,
                 error: hasError,
               }}
-              inputProps={{ isInvalid }}
+              inputProps={{
+                placeholder: 'Enter a name for the query',
+                isInvalid,
+              }}
             />
           </EuiFlexItem>
 
@@ -123,19 +119,6 @@ class DocumentLevelQuery extends Component {
         </EuiFlexGroup>
 
         <EuiSpacer size={'m'} />
-
-        <EuiText size={'xs'}>
-          <strong>Tags</strong>
-          <i> - optional </i>
-          <IconToolTip content={DOC_LEVEL_TAG_TOOLTIP} iconType={'questionInCircle'} />
-        </EuiText>
-        <EuiSpacer size={'s'} />
-
-        {_.isEmpty(query.tags) && (
-          <div>
-            <EuiText size={'xs'}>No tags defined.</EuiText>
-          </div>
-        )}
 
         <ConfigureDocumentLevelQueryTags
           formFieldName={formFieldName}

--- a/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/DocumentLevelQueryTag.js
+++ b/public/pages/CreateMonitor/components/DocumentLevelMonitorQueries/DocumentLevelQueryTag.js
@@ -17,11 +17,14 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import { FormikFieldText } from '../../../../components/FormControls';
-import { hasError, isInvalid, required } from '../../../../utils/validate';
+import { hasError, isInvalid, validateIllegalCharacters } from '../../../../utils/validate';
 import { EXPRESSION_STYLE, POPOVER_STYLE } from '../MonitorExpressions/expressions/utils/constants';
 
 export const DOC_LEVEL_TAG_TOOLTIP = 'Tags to associate with your queries.'; // TODO DRAFT: Placeholder wording
 export const TAG_PLACEHOLDER_TEXT = 'Enter the search term'; // TODO DRAFT: Placeholder wording
+
+// TODO DRAFT: What constraints should we implement?
+export const ILLEGAL_TAG_CHARACTERS = [' '];
 
 class DocumentLevelQueryTag extends Component {
   constructor(props) {
@@ -58,7 +61,9 @@ class DocumentLevelQueryTag extends Component {
         <FormikFieldText
           name={formFieldName}
           formRow
-          fieldProps={{ validate: required }} // TODO DRAFT: What constraints should we implement?
+          fieldProps={{
+            validate: validateIllegalCharacters(ILLEGAL_TAG_CHARACTERS),
+          }}
           rowProps={{
             style: { maxWidth: '100%' },
             isInvalid,
@@ -86,8 +91,21 @@ class DocumentLevelQueryTag extends Component {
   }
 
   render() {
-    const { arrayHelpers, tag = '', tagIndex = 0 } = this.props;
+    const {
+      formik: { errors },
+      arrayHelpers,
+      formFieldName,
+      tag = '',
+      tagIndex = 0,
+    } = this.props;
     const { isPopoverOpen } = this.state;
+
+    let errorText;
+    if (!_.isEmpty(tag)) errorText = validateIllegalCharacters(ILLEGAL_TAG_CHARACTERS)(tag);
+
+    if (_.isEmpty(errorText)) delete errors[formFieldName];
+    else _.set(errors, formFieldName, validateIllegalCharacters(ILLEGAL_TAG_CHARACTERS)(tag));
+
     return (
       <EuiPopover
         id={'tag-badge-popover'}

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/MonitorDefinitionCard.js
@@ -18,8 +18,14 @@ const onChangeDefinition = (e, form) => {
 
 const MonitorDefinitionCard = ({ values, plugins }) => {
   const hasADPlugin = plugins.indexOf(OS_AD_PLUGIN) !== -1;
-  const isBucketLevelMonitor = values.monitor_type === MONITOR_TYPE.BUCKET_LEVEL;
-
+  let supportsADOption;
+  switch (values.monitor_type) {
+    case MONITOR_TYPE.QUERY_LEVEL:
+      supportsADOption = true;
+      break;
+    default:
+      supportsADOption = false;
+  }
   return (
     <div>
       <EuiText size={'xs'} style={{ paddingBottom: '0px', marginBottom: '0px' }}>
@@ -68,8 +74,8 @@ const MonitorDefinitionCard = ({ values, plugins }) => {
             }}
           />
         </EuiFlexItem>
-        {/*// Only show the anomaly detector option when anomaly detection plugin is present, but not for bucket-level monitors.*/}
-        {hasADPlugin && !isBucketLevelMonitor && (
+        {/*// Only show the anomaly detector option when anomaly detection plugin is present, and for supporting monitors.*/}
+        {hasADPlugin && supportsADOption && (
           <EuiFlexItem grow={false} style={{ width: `${MONITOR_DEFINITION_CARD_WIDTH}px` }}>
             <FormikCheckableCard
               name="searchTypeAD"

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
@@ -260,44 +260,6 @@ exports[`MonitorDefinitionCard renders without AD plugin 2`] = `
         </div>
       </div>
     </div>
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
-      style="width:275px"
-    >
-      <div
-        class="euiCheckableCard"
-      >
-        <div
-          class="euiCheckableCard__row"
-        >
-          <div
-            class="euiCheckableCard__control"
-          >
-            <div
-              class="euiRadio euiRadio--noLabel"
-              data-test-subj="anomalyDetectorRadioCard"
-            >
-              <input
-                class="euiRadio__input"
-                id="anomalyDetectorRadioCard"
-                name="searchTypeAD"
-                type="radio"
-                value="ad"
-              />
-              <div
-                class="euiRadio__circle"
-              />
-            </div>
-          </div>
-          <label
-            class="euiCheckableCard__label"
-            for="anomalyDetectorRadioCard"
-          >
-            Anomaly detector
-          </label>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -170,12 +170,14 @@ export default class CreateMonitor extends Component {
 
       let triggerType;
       switch (monitor_type) {
-        case MONITOR_TYPE.QUERY_LEVEL:
-        case MONITOR_TYPE.CLUSTER_METRICS:
-          triggerType = TRIGGER_TYPE.QUERY_LEVEL;
-          break;
         case MONITOR_TYPE.BUCKET_LEVEL:
           triggerType = TRIGGER_TYPE.BUCKET_LEVEL;
+          break;
+        case MONITOR_TYPE.DOC_LEVEL:
+          triggerType = TRIGGER_TYPE.DOC_LEVEL;
+          break;
+        default:
+          triggerType = TRIGGER_TYPE.QUERY_LEVEL;
           break;
       }
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -64,7 +64,7 @@ export const FORMIK_INITIAL_AGG_VALUES = {
 
 export const FORMIK_INITIAL_DOCUMENT_LEVEL_QUERY_VALUES = {
   id: undefined,
-  queryName: 'Query name',
+  queryName: '',
   field: '',
   operator: QUERY_OPERATORS[0].value,
   query: '',

--- a/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
@@ -389,19 +389,24 @@ exports[`Action renders with Notifications plugin installed 1`] = `
                 <div
                   class="euiSpacer euiSpacer--m"
                 />
-                <div
-                  class="euiFlexItem"
-                >
+                <div>
                   <div
-                    class="euiText euiText--extraSmall"
+                    class="euiFlexItem"
                   >
-                    <strong>
-                      Perform action
-                    </strong>
-                    <div>
-                      Per monitor execution
+                    <div
+                      class="euiText euiText--extraSmall"
+                    >
+                      <strong>
+                        Perform action
+                      </strong>
+                      <div>
+                        Per monitor execution
+                      </div>
                     </div>
                   </div>
+                  <div
+                    class="euiSpacer euiSpacer--s"
+                  />
                 </div>
                 <div
                   class="euiFormRow"
@@ -967,19 +972,24 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                 <div
                   class="euiSpacer euiSpacer--m"
                 />
-                <div
-                  class="euiFlexItem"
-                >
+                <div>
                   <div
-                    class="euiText euiText--extraSmall"
+                    class="euiFlexItem"
                   >
-                    <strong>
-                      Perform action
-                    </strong>
-                    <div>
-                      Per monitor execution
+                    <div
+                      class="euiText euiText--extraSmall"
+                    >
+                      <strong>
+                        Perform action
+                      </strong>
+                      <div>
+                        Per monitor execution
+                      </div>
                     </div>
                   </div>
+                  <div
+                    class="euiSpacer euiSpacer--s"
+                  />
                 </div>
                 <div
                   class="euiFormRow"

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -354,7 +354,10 @@ export default function Message(
           </EuiFlexGroup>
         </EuiFormRow>
       ) : (
-        <OverviewStat header={'Perform action'} value={'Per monitor execution'} />
+        <div>
+          <OverviewStat header={'Perform action'} value={'Per monitor execution'} />
+          <EuiSpacer size={'s'} />
+        </div>
       )}
 
       {actionExecutionScopeId !== NOTIFY_OPTIONS_VALUES.PER_EXECUTION ? (

--- a/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
@@ -165,19 +165,24 @@ exports[`Message renders 1`] = `
   <div
     class="euiSpacer euiSpacer--m"
   />
-  <div
-    class="euiFlexItem"
-  >
+  <div>
     <div
-      class="euiText euiText--extraSmall"
+      class="euiFlexItem"
     >
-      <strong>
-        Perform action
-      </strong>
-      <div>
-        Per monitor execution
+      <div
+        class="euiText euiText--extraSmall"
+      >
+        <strong>
+          Perform action
+        </strong>
+        <div>
+          Per monitor execution
+        </div>
       </div>
     </div>
+    <div
+      class="euiSpacer euiSpacer--s"
+    />
   </div>
   <div
     class="euiFormRow"

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -147,8 +147,7 @@ class ConfigureActions extends React.Component {
             DEFAULT_MESSAGE_SOURCE.BUCKET_LEVEL_MONITOR
           );
           break;
-        case MONITOR_TYPE.QUERY_LEVEL:
-        case MONITOR_TYPE.CLUSTER_METRICS:
+        default:
           _.set(
             initialActionValues,
             'message_template.source',
@@ -203,8 +202,16 @@ class ConfigureActions extends React.Component {
         _.set(testTrigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.actions`, [action]);
         _.set(testTrigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.condition`, condition);
         break;
-      case MONITOR_TYPE.QUERY_LEVEL:
-      case MONITOR_TYPE.CLUSTER_METRICS:
+      case MONITOR_TYPE.DOC_LEVEL:
+        action = _.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions[${index}]`);
+        condition = {
+          ..._.get(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.condition`),
+          script: { lang: 'painless', source: 'return true' },
+        };
+        _.set(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions`, [action]);
+        _.set(testTrigger, `${TRIGGER_TYPE.DOC_LEVEL}.condition`, condition);
+        break;
+      default:
         action = _.get(testTrigger, `actions[${index}]`);
         condition = {
           ..._.get(testTrigger, 'condition'),

--- a/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
@@ -122,26 +122,31 @@ class DefineDocumentLevelTrigger extends Component {
     response,
     triggerValues
   ) => {
+    const triggerConditions = _.get(triggerValues, `${fieldPath}triggerConditions`, []);
+    const selectedQueriesAndTags = triggerConditions.map((condition) =>
+      _.get(condition, 'query.queryName')
+    );
     const queries = _.get(monitorValues, 'queries', []);
+
     const tagSelectOptions = [];
     const querySelectOptions = queries.map((query) => {
       query.tags.forEach((tag) => {
         const tagOption = {
           label: tag,
           value: { queryName: tag, operator: '==', expression: `${QUERY_IDENTIFIERS.TAG}${tag}` },
+          disabled: _.includes(selectedQueriesAndTags, tag),
         };
         if (!_.includes(tagSelectOptions, tagOption)) tagSelectOptions.push(tagOption);
       });
       return {
         label: query.queryName,
         value: { ...query, expression: `${QUERY_IDENTIFIERS.NAME}${query.queryName}` },
+        disabled: _.includes(selectedQueriesAndTags, query.queryName),
       };
     });
 
-    const triggerConditions = _.get(triggerValues, `${fieldPath}triggerConditions`, []);
-    if (_.isEmpty(triggerConditions)) {
+    if (_.isEmpty(triggerConditions))
       arrayHelpers.push(_.cloneDeep(FORMIK_INITIAL_TRIGGER_CONDITION_VALUES));
-    }
 
     return triggerConditions.map((triggerCondition, index) => (
       <div key={`${fieldPath}triggerConditions.${index}`} style={{ paddingLeft: '10px' }}>

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -177,6 +177,7 @@ export default class AcknowledgeAlertsModal extends Component {
   };
 
   acknowledgeAlerts = async () => {
+    this.setState({ loading: true });
     const { selectedItems } = this.state;
     const { httpClient, notifications } = this.props;
 
@@ -227,7 +228,7 @@ export default class AcknowledgeAlertsModal extends Component {
       alertState,
       monitorIds
     );
-    this.setState({ ...this.state, selectedItems: [] });
+    this.setState({ ...this.state, loading: false, selectedItems: [] });
   };
 
   onSeverityLevelChange = (e) => {
@@ -305,6 +306,7 @@ export default class AcknowledgeAlertsModal extends Component {
       switch (monitorType) {
         case MONITOR_TYPE.QUERY_LEVEL:
         case MONITOR_TYPE.CLUSTER_METRICS:
+        case MONITOR_TYPE.DOC_LEVEL:
           return `${item.id}-${item.version}`;
         case MONITOR_TYPE.BUCKET_LEVEL:
           return item.id;

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -158,10 +158,18 @@ export default class MonitorDetails extends Component {
       notifications,
     } = this.props;
     const { monitor, ifSeqNo, ifPrimaryTerm } = this.state;
+
+    let query = { ifSeqNo, ifPrimaryTerm };
+    switch (monitor.monitor_type) {
+      case MONITOR_TYPE.DOC_LEVEL:
+        query = {};
+        break;
+    }
+
     this.setState({ updating: true });
     return httpClient
       .put(`../api/alerting/monitors/${monitorId}`, {
-        query: { ifSeqNo, ifPrimaryTerm },
+        query: { ...query },
         body: JSON.stringify({ ...monitor, ...update }),
       })
       .then((resp) => {

--- a/public/utils/validate.js
+++ b/public/utils/validate.js
@@ -31,6 +31,9 @@ export const validateActionName = (monitor, trigger) => (value) => {
     case MONITOR_TYPE.BUCKET_LEVEL:
       actions = _.get(trigger, `${TRIGGER_TYPE.BUCKET_LEVEL}.actions`, []);
       break;
+    case MONITOR_TYPE.DOC_LEVEL:
+      actions = _.get(trigger, `${TRIGGER_TYPE.DOC_LEVEL}.actions`, []);
+      break;
   }
   const matches = actions.filter((action) => action.name === value);
   if (matches.length > 1) return 'Action name is already used.';
@@ -54,6 +57,26 @@ export const validateActionThrottle = (action) => (value) => {
 
 export const required = (value) => {
   if (!value) return 'Required.';
+};
+
+export const validateIllegalCharacters = (illegalCharacters = ILLEGAL_CHARACTERS) => (value) => {
+  if (_.isEmpty(value)) return required(value);
+
+  const illegalCharactersString = illegalCharacters.join(' ');
+  let errorText = `Contains invalid characters. Cannot contain: ${illegalCharactersString}`;
+
+  if (_.includes(illegalCharacters, ' ')) {
+    errorText =
+      illegalCharacters.length === 1
+        ? 'Cannot contain spaces.'
+        : `Contains invalid characters or spaces. Cannot contain: ${illegalCharactersString}`;
+  }
+
+  let includesIllegalCharacter = false;
+  illegalCharacters.forEach((character) => {
+    if (_.includes(value, character)) includesIllegalCharacter = true;
+  });
+  if (includesIllegalCharacter) return errorText;
 };
 
 export const validateRequiredNumber = (value) => {

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -59,19 +59,12 @@ export default function alertingPlugin(Client, config, components) {
     method: 'DELETE',
   });
 
+  // TODO DRAFT: May need to add 'refresh' assignment here again.
   alerting.updateMonitor = ca({
     url: {
-      fmt: `${MONITOR_BASE_API}/<%=monitorId%>?if_seq_no=<%=ifSeqNo%>&if_primary_term=<%=ifPrimaryTerm%>&refresh=wait_for`,
+      fmt: `${MONITOR_BASE_API}/<%=monitorId%>`,
       req: {
         monitorId: {
-          type: 'string',
-          required: true,
-        },
-        ifSeqNo: {
-          type: 'string',
-          required: true,
-        },
-        ifPrimaryTerm: {
           type: 'string',
           required: true,
         },

--- a/server/routes/monitors.js
+++ b/server/routes/monitors.js
@@ -78,8 +78,8 @@ export default function (services, router) {
           id: schema.string(),
         }),
         query: schema.object({
-          ifSeqNo: schema.number(),
-          ifPrimaryTerm: schema.number(),
+          ifSeqNo: schema.maybe(schema.number()),
+          ifPrimaryTerm: schema.maybe(schema.number()),
         }),
         body: schema.any(),
       },

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -127,8 +127,15 @@ export default class MonitorService {
   updateMonitor = async (context, req, res) => {
     try {
       const { id } = req.params;
+      const params = { monitorId: id, body: req.body, refresh: 'wait_for' };
+
+      // TODO DRAFT: Are we sure we need to include ifSeqNo and ifPrimaryTerm from the UI side when updating monitors?
       const { ifSeqNo, ifPrimaryTerm } = req.query;
-      const params = { monitorId: id, ifSeqNo, ifPrimaryTerm, body: req.body };
+      if (ifSeqNo && ifPrimaryTerm) {
+        params.if_seq_no = ifSeqNo;
+        params.if_primary_term = ifPrimaryTerm;
+      }
+
       const { callAsCurrentUser } = await this.esDriver.asScoped(req);
       const updateResponse = await callAsCurrentUser('alerting.updateMonitor', params);
       const { _version, _id } = updateResponse;


### PR DESCRIPTION
### Description
1. Refactored visual editor to no longer support spaces in tags and query names. 
2. Fixed a bug that preventing creating a doc level monitor with a notification channel.
3. Fixed a bug impacting sending test notifications for doc level monitors.
4. Implemented logic to hide anomaly detection option when defining a doc level monitor.
5. Fixed alerts flyout to render correct pluralization for conditions. Adjusted spacing on action component.
6. Fixed bug that was preventing acknowledge modal from refreshing when acknowledging alerts. 
7. Fixed bug that was causing the acknowledge modal to render on the monitor details page instead of immediately acknowledging selected alerts.
8. Refactored updateMonitor API to no longer require seqNo or primaryTerm.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
