### PR TITLE
Refactored alerts table for doc level monitors to display a flyout containing finding information.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -9,7 +9,7 @@ on:
       - main
       - 1.x
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.0'
   OPENSEARCH_VERSION: '2.0.0-rc1-SNAPSHOT'
 jobs:
   tests:

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -48,7 +48,7 @@ import queryString from 'query-string';
 import { MAX_ALERT_COUNT } from '../../../../pages/Dashboard/utils/constants';
 import { SEVERITY_OPTIONS } from '../../../../pages/CreateTrigger/utils/constants';
 import {
-  ALERTS_FINDING_COLUMN,
+  getAlertsFindingColumn,
   TABLE_TAB_IDS,
 } from '../../../../pages/Dashboard/components/FindingsDashboard/utils';
 import FindingsDashboard from '../../../../pages/Dashboard/containers/FindingsDashboard';
@@ -318,15 +318,13 @@ export default class AlertsDashboardFlyoutComponent extends Component {
   }
 
   renderAlertsTable() {
-    const { trigger_name } = this.props;
-    const { monitor, monitorType } = this.state;
-    const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
-    const groupBy = _.get(monitor, MONITOR_GROUP_BY);
-
+    const { httpClient, history, location, notifications, trigger_name } = this.props;
     const {
       alerts,
       alertState,
       loading,
+      monitor,
+      monitorType,
       page,
       search,
       selectable,
@@ -337,6 +335,9 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       sortField,
       totalAlerts,
     } = this.state;
+
+    const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
+    const groupBy = _.get(monitor, MONITOR_GROUP_BY);
 
     const getItemId = (item) => {
       switch (monitorType) {
@@ -357,7 +358,11 @@ export default class AlertsDashboardFlyoutComponent extends Component {
           break;
         case MONITOR_TYPE.DOC_LEVEL:
           columns = _.cloneDeep(queryColumns);
-          columns.splice(0, 0, ALERTS_FINDING_COLUMN);
+          columns.splice(
+            0,
+            0,
+            getAlertsFindingColumn(httpClient, history, true, location, notifications)
+          );
           break;
         default:
           columns = queryColumns;
@@ -429,6 +434,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
           onStateChange={this.onAlertStateChange}
           onPageChange={this.onPageClick}
           isAlertsFlyout={true}
+          monitorType={monitorType}
         />
         <EuiHorizontalRule margin="xs" />
         <EuiBasicTable
@@ -453,10 +459,11 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     );
   }
 
-  renderFindingsTable() {
+  renderFindingsTable(findingId) {
     const { httpClient, history, location, monitor_id, notifications } = this.props;
     return (
       <FindingsDashboard
+        findingId={findingId}
         isAlertsFlyout={true}
         isPreview={false}
         monitorId={monitor_id}

--- a/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
+++ b/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
@@ -179,6 +179,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <DashboardControls
       activePage={0}
       isAlertsFlyout={true}
+      monitorType="query_level_monitor"
       onPageChange={[Function]}
       onSearchChange={[Function]}
       onStateChange={[Function]}

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -44,7 +44,7 @@ import DashboardControls from '../DashboardControls';
 import ContentPanel from '../../../../components/ContentPanel';
 import { queryColumns } from '../../utils/tableUtils';
 import DashboardEmptyPrompt from '../DashboardEmptyPrompt';
-import { ALERTS_FINDING_COLUMN } from '../FindingsDashboard/utils';
+import { getAlertsFindingColumn } from '../FindingsDashboard/utils';
 
 export const DEFAULT_NUM_MODAL_ROWS = 10;
 
@@ -273,7 +273,15 @@ export default class AcknowledgeAlertsModal extends Component {
   };
 
   render() {
-    const { monitor, onClose, triggerName } = this.props;
+    const {
+      httpClient,
+      location,
+      history,
+      monitor,
+      notifications,
+      onClose,
+      triggerName,
+    } = this.props;
     const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID);
     const groupBy = _.get(monitor, MONITOR_GROUP_BY);
     const monitorType = _.get(monitor, 'monitor_type', MONITOR_TYPE.QUERY_LEVEL);
@@ -336,7 +344,11 @@ export default class AcknowledgeAlertsModal extends Component {
           break;
         case MONITOR_TYPE.DOC_LEVEL:
           columns = _.cloneDeep(queryColumns);
-          columns.splice(0, 0, ALERTS_FINDING_COLUMN);
+          columns.splice(
+            0,
+            0,
+            getAlertsFindingColumn(httpClient, history, false, location, notifications)
+          );
           break;
         default:
           columns = queryColumns;

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -29,7 +29,7 @@ import {
 import { DEFAULT_PAGE_SIZE_OPTIONS } from '../../Monitors/containers/Monitors/utils/constants';
 import { MAX_ALERT_COUNT } from '../utils/constants';
 import AcknowledgeAlertsModal from '../components/AcknowledgeAlertsModal';
-import { ALERTS_FINDING_COLUMN } from '../components/FindingsDashboard/utils';
+import { getAlertsFindingColumn } from '../components/FindingsDashboard/utils';
 
 export default class Dashboard extends Component {
   constructor(props) {
@@ -382,7 +382,11 @@ export default class Dashboard extends Component {
           break;
         case MONITOR_TYPE.DOC_LEVEL:
           columnType = _.cloneDeep(queryColumns);
-          columnType.splice(0, 0, ALERTS_FINDING_COLUMN);
+          columnType.splice(
+            0,
+            0,
+            getAlertsFindingColumn(httpClient, history, false, location, notifications)
+          );
           break;
         default:
           columnType = queryColumns;


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
1. Moved `getFindings` method to a `utils` file so it's accessible by other classes.
2. Refactored alerts table for doc level monitors to display a flyout containing finding information.
3. Adjusted the version of `OpenSearch-Dashboards` used to run the cypress test workflow.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
