### PR TITLE
Implemented support for action execution configurations for doc level monitors

### DIFF
--- a/public/pages/CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers.js
+++ b/public/pages/CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers.js
@@ -6,16 +6,13 @@
 import _ from 'lodash';
 import { formikToClusterMetricsInput } from '../../../containers/CreateMonitor/utils/formikToMonitor';
 import {
-  DEFAULT_CLUSTER_METRICS_SCRIPT,
+  API_TYPES,
+  GET_API_TYPE_DEBUG_TEXT,
   ILLEGAL_PATH_PARAMETER_CHARACTERS,
+  NO_PATH_PARAMS_PLACEHOLDER_TEXT,
   PATH_PARAMETER_ILLEGAL_CHARACTER_TEXT,
   PATH_PARAMETERS_REQUIRED_TEXT,
-  API_TYPES,
-  NO_PATH_PARAMS_PLACEHOLDER_TEXT,
-  GET_API_TYPE_DEBUG_TEXT,
 } from './clusterMetricsMonitorConstants';
-import { SEARCH_TYPE } from '../../../../../utils/constants';
-import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../../../CreateTrigger/containers/CreateTrigger/utils/constants';
 import { FORMIK_INITIAL_VALUES } from '../../../containers/CreateMonitor/utils/constants';
 
 export function buildClusterMetricsRequest(values) {
@@ -64,17 +61,6 @@ export const getApiTypesRequiringPathParams = () => {
       });
   });
   return apiList;
-};
-
-export const getDefaultScript = (monitorValues) => {
-  const searchType = _.get(monitorValues, 'searchType', FORMIK_INITIAL_VALUES.searchType);
-  switch (searchType) {
-    case SEARCH_TYPE.CLUSTER_METRICS:
-      const apiType = _.get(monitorValues, 'uri.api_type');
-      return _.get(API_TYPES, `${apiType}.defaultCondition`, DEFAULT_CLUSTER_METRICS_SCRIPT);
-    default:
-      return FORMIK_INITIAL_TRIGGER_VALUES.script;
-  }
 };
 
 export const getExamplePathParams = (apiType) => {

--- a/public/pages/CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers.test.js
+++ b/public/pages/CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers.test.js
@@ -6,7 +6,6 @@
 import _ from 'lodash';
 import {
   API_TYPES,
-  DEFAULT_CLUSTER_METRICS_SCRIPT,
   GET_API_TYPE_DEBUG_TEXT,
   ILLEGAL_PATH_PARAMETER_CHARACTERS,
   NO_PATH_PARAMS_PLACEHOLDER_TEXT,
@@ -19,15 +18,12 @@ import {
   getApiPath,
   getApiType,
   getApiTypesRequiringPathParams,
-  getDefaultScript,
   getExamplePathParams,
   isInvalidApiPathParameter,
   pathParamsContainIllegalCharacters,
   validateApiPathParameter,
 } from './clusterMetricsMonitorHelpers';
 import { FORMIK_INITIAL_VALUES } from '../../../containers/CreateMonitor/utils/constants';
-import { SEARCH_TYPE } from '../../../../../utils/constants';
-import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../../../CreateTrigger/containers/CreateTrigger/utils/constants';
 
 describe('clusterMetricsMonitorHelpers', () => {
   describe('buildClusterMetricsRequest', () => {
@@ -269,61 +265,6 @@ describe('clusterMetricsMonitorHelpers', () => {
       results.forEach((entry) => {
         const entryExpected = _.includes(expectedApiTypes, entry.value);
         expect(entryExpected).toEqual(true);
-      });
-    });
-  });
-
-  describe('getDefaultScript', () => {
-    test('when searchType is undefined', () => {
-      const monitorValues = undefined;
-      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.script);
-    });
-    test('when searchType is clusterMetrics and api_type is undefined', () => {
-      const monitorValues = {
-        searchType: SEARCH_TYPE.CLUSTER_METRICS,
-        uri: undefined,
-      };
-      expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
-    });
-    test('when searchType is clusterMetrics and api_type is empty', () => {
-      const monitorValues = {
-        searchType: SEARCH_TYPE.CLUSTER_METRICS,
-        uri: {
-          api_type: '',
-        },
-      };
-      expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
-    });
-    test('when searchType is clusterMetrics and api_type does not have a default condition', () => {
-      const monitorValues = {
-        searchType: SEARCH_TYPE.CLUSTER_METRICS,
-        uri: {
-          api_type: 'unknownApi',
-        },
-      };
-      expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
-    });
-
-    _.keys(SEARCH_TYPE).forEach((searchType) => {
-      test(`when searchType is ${searchType}`, () => {
-        if (SEARCH_TYPE[searchType] !== SEARCH_TYPE.CLUSTER_METRICS) {
-          const monitorValues = { searchType: searchType };
-          expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.script);
-        }
-      });
-    });
-
-    _.keys(API_TYPES).forEach((apiType) => {
-      test(`when searchType is clusterMetrics and api_type is ${apiType}`, () => {
-        const monitorValues = {
-          searchType: SEARCH_TYPE.CLUSTER_METRICS,
-          uri: {
-            api_type: apiType,
-          },
-        };
-        const expectedOutput = _.get(API_TYPES, `${apiType}.defaultCondition`);
-        if (!_.isEmpty(expectedOutput))
-          expect(getDefaultScript(monitorValues)).toEqual(expectedOutput);
       });
     });
   });

--- a/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
+++ b/public/pages/CreateMonitor/components/MonitorType/MonitorType.js
@@ -4,7 +4,6 @@
  */
 
 import React from 'react';
-import _ from 'lodash';
 import { EuiFlexGrid, EuiFlexItem, EuiText } from '@elastic/eui';
 import FormikCheckableCard from '../../../../components/FormControls/FormikCheckableCard';
 import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../utils/constants';
@@ -23,8 +22,12 @@ const onChangeDefinition = (e, form) => {
   // Clearing various form fields when changing monitor types.
   // TODO: Implement modal that confirms the change before clearing.
   form.setFieldValue('index', FORMIK_INITIAL_VALUES.index);
+  form.setFieldValue('searchType', FORMIK_INITIAL_VALUES.searchType);
   form.setFieldValue('triggerDefinitions', FORMIK_INITIAL_TRIGGER_VALUES.triggerConditions);
   switch (type) {
+    case MONITOR_TYPE.CLUSTER_METRICS:
+      form.setFieldValue('searchType', SEARCH_TYPE.CLUSTER_METRICS);
+      break;
     case MONITOR_TYPE.DOC_LEVEL:
       form.setFieldValue('query', DEFAULT_DOCUMENT_LEVEL_QUERY);
       break;
@@ -71,9 +74,7 @@ const MonitorType = ({ values }) => (
           label: 'Per query monitor',
           checked: values.monitor_type === MONITOR_TYPE.QUERY_LEVEL,
           value: MONITOR_TYPE.QUERY_LEVEL,
-          onChange: (e, field, form) => {
-            onChangeDefinition(e, form);
-          },
+          onChange: (e, field, form) => onChangeDefinition(e, form),
           children: queryLevelDescription,
           'data-test-subj': 'queryLevelMonitorRadioCard',
         }}
@@ -89,14 +90,7 @@ const MonitorType = ({ values }) => (
           label: 'Per bucket monitor',
           checked: values.monitor_type === MONITOR_TYPE.BUCKET_LEVEL,
           value: MONITOR_TYPE.BUCKET_LEVEL,
-          onChange: (e, field, form) => {
-            const searchType = _.get(values, 'searchType');
-            // Setting search type to graph when changing monitor type from query-level to bucket-level,
-            // and the search type is not supported by bucket-level monitors.
-            if (searchType !== SEARCH_TYPE.GRAPH || searchType !== SEARCH_TYPE.QUERY)
-              form.setFieldValue('searchType', SEARCH_TYPE.GRAPH);
-            onChangeDefinition(e, form);
-          },
+          onChange: (e, field, form) => onChangeDefinition(e, form),
           children: bucketLevelDescription,
           'data-test-subj': 'bucketLevelMonitorRadioCard',
         }}
@@ -112,10 +106,7 @@ const MonitorType = ({ values }) => (
           label: 'Per cluster metrics monitor',
           checked: values.monitor_type === MONITOR_TYPE.CLUSTER_METRICS,
           value: MONITOR_TYPE.CLUSTER_METRICS,
-          onChange: (e, field, form) => {
-            form.setFieldValue('searchType', SEARCH_TYPE.CLUSTER_METRICS);
-            onChangeDefinition(e, form);
-          },
+          onChange: (e, field, form) => onChangeDefinition(e, form),
           children: clusterMetricsDescription,
           'data-test-subj': 'clusterMetricsMonitorRadioCard',
         }}
@@ -131,9 +122,7 @@ const MonitorType = ({ values }) => (
           label: 'Per document monitor',
           checked: values.monitor_type === MONITOR_TYPE.DOC_LEVEL,
           value: MONITOR_TYPE.DOC_LEVEL,
-          onChange: (e, field, form) => {
-            onChangeDefinition(e, form);
-          },
+          onChange: (e, field, form) => onChangeDefinition(e, form),
           children: documentLevelDescription,
           'data-test-subj': 'docLevelMonitorRadioCard',
         }}

--- a/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
@@ -389,24 +389,101 @@ exports[`Action renders with Notifications plugin installed 1`] = `
                 <div
                   class="euiSpacer euiSpacer--m"
                 />
-                <div>
+                <div
+                  class="euiFormRow"
+                  id="generated-id-row"
+                  style="max-width:100%"
+                >
                   <div
-                    class="euiFlexItem"
+                    class="euiFormRow__labelWrapper"
+                  >
+                    <label
+                      class="euiFormLabel euiFormRow__label"
+                      for="generated-id"
+                    >
+                      <span
+                        style="color:#343741"
+                      >
+                        Perform action
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+                      id="generated-id"
                     >
-                      <strong>
-                        Perform action
-                      </strong>
-                      <div>
-                        Per monitor execution
+                      <div
+                        class="euiFlexItem"
+                      >
+                        <div
+                          class="euiFormRow"
+                          id="testPathactions.0.action_execution_policy.action_execution_scope-form-row-row"
+                        >
+                          <div
+                            class="euiFormRow__fieldWrapper"
+                          >
+                            <div
+                              class="euiRadio"
+                            >
+                              <input
+                                class="euiRadio__input"
+                                id="testPathactions.0.action_execution_policy.per_execution"
+                                name="testPathactions.0.action_execution_policy.action_execution_scope"
+                                type="radio"
+                                value="per_execution"
+                              />
+                              <div
+                                class="euiRadio__circle"
+                              />
+                              <label
+                                class="euiRadio__label"
+                                for="testPathactions.0.action_execution_policy.per_execution"
+                              >
+                                Per execution
+                              </label>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem"
+                      >
+                        <div
+                          class="euiFormRow"
+                          id="testPathactions.0.action_execution_policy.action_execution_scope-form-row-row"
+                        >
+                          <div
+                            class="euiFormRow__fieldWrapper"
+                          >
+                            <div
+                              class="euiRadio"
+                            >
+                              <input
+                                checked=""
+                                class="euiRadio__input"
+                                id="testPathactions.0.action_execution_policy.per_alert"
+                                name="testPathactions.0.action_execution_policy.action_execution_scope"
+                                type="radio"
+                                value="per_alert"
+                              />
+                              <div
+                                class="euiRadio__circle"
+                              />
+                              <label
+                                class="euiRadio__label"
+                                for="testPathactions.0.action_execution_policy.per_alert"
+                              >
+                                Per alert
+                              </label>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="euiSpacer euiSpacer--s"
-                  />
                 </div>
                 <div
                   class="euiFormRow"
@@ -972,24 +1049,101 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                 <div
                   class="euiSpacer euiSpacer--m"
                 />
-                <div>
+                <div
+                  class="euiFormRow"
+                  id="generated-id-row"
+                  style="max-width:100%"
+                >
                   <div
-                    class="euiFlexItem"
+                    class="euiFormRow__labelWrapper"
+                  >
+                    <label
+                      class="euiFormLabel euiFormRow__label"
+                      for="generated-id"
+                    >
+                      <span
+                        style="color:#343741"
+                      >
+                        Perform action
+                      </span>
+                    </label>
+                  </div>
+                  <div
+                    class="euiFormRow__fieldWrapper"
                   >
                     <div
-                      class="euiText euiText--extraSmall"
+                      class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+                      id="generated-id"
                     >
-                      <strong>
-                        Perform action
-                      </strong>
-                      <div>
-                        Per monitor execution
+                      <div
+                        class="euiFlexItem"
+                      >
+                        <div
+                          class="euiFormRow"
+                          id="testPathactions.0.action_execution_policy.action_execution_scope-form-row-row"
+                        >
+                          <div
+                            class="euiFormRow__fieldWrapper"
+                          >
+                            <div
+                              class="euiRadio"
+                            >
+                              <input
+                                class="euiRadio__input"
+                                id="testPathactions.0.action_execution_policy.per_execution"
+                                name="testPathactions.0.action_execution_policy.action_execution_scope"
+                                type="radio"
+                                value="per_execution"
+                              />
+                              <div
+                                class="euiRadio__circle"
+                              />
+                              <label
+                                class="euiRadio__label"
+                                for="testPathactions.0.action_execution_policy.per_execution"
+                              >
+                                Per execution
+                              </label>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem"
+                      >
+                        <div
+                          class="euiFormRow"
+                          id="testPathactions.0.action_execution_policy.action_execution_scope-form-row-row"
+                        >
+                          <div
+                            class="euiFormRow__fieldWrapper"
+                          >
+                            <div
+                              class="euiRadio"
+                            >
+                              <input
+                                checked=""
+                                class="euiRadio__input"
+                                id="testPathactions.0.action_execution_policy.per_alert"
+                                name="testPathactions.0.action_execution_policy.action_execution_scope"
+                                type="radio"
+                                value="per_alert"
+                              />
+                              <div
+                                class="euiRadio__circle"
+                              />
+                              <label
+                                class="euiRadio__label"
+                                for="testPathactions.0.action_execution_policy.per_alert"
+                              >
+                                Per alert
+                              </label>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    class="euiSpacer euiSpacer--s"
-                  />
                 </div>
                 <div
                   class="euiFormRow"

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -139,15 +139,17 @@ export default function Message(
 ) {
   const [displayPreview, setDisplayPreview] = useState(false);
   const onDisplayPreviewChange = (e) => setDisplayPreview(e.target.checked);
-  const isBucketLevelMonitor =
-    _.get(context, 'ctx.monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL) ===
-    MONITOR_TYPE.BUCKET_LEVEL;
+  const monitorType = _.get(context, 'ctx.monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
+  const editableActionExecutionPolicy =
+    monitorType === MONITOR_TYPE.BUCKET_LEVEL || MONITOR_TYPE.DOC_LEVEL;
+
   const actionPath = `${fieldPath}actions.${index}`;
-  const actionExecutionPolicyPath = isBucketLevelMonitor
+  const actionExecutionPolicyPath = editableActionExecutionPolicy
     ? `${actionPath}.action_execution_policy`
     : actionPath;
+  const actionableAlertsSelectionsPath = `${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`;
 
-  let actionExecutionScopeId = isBucketLevelMonitor
+  let actionExecutionScopeId = editableActionExecutionPolicy
     ? _.get(
         action,
         'action_execution_policy.action_execution_scope',
@@ -157,24 +159,31 @@ export default function Message(
   if (!_.isString(actionExecutionScopeId))
     actionExecutionScopeId = _.keys(actionExecutionScopeId)[0];
 
-  let actionableAlertsSelections = _.get(
-    values,
-    `${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`
-  );
+  let actionableAlertsSelections;
+  let displayActionableAlertsOptions;
+  let displayThrottlingSettings;
+  switch (monitorType) {
+    case MONITOR_TYPE.BUCKET_LEVEL:
+      displayActionableAlertsOptions = true;
+      actionableAlertsSelections = _.get(values, actionableAlertsSelectionsPath);
+      break;
+    case MONITOR_TYPE.DOC_LEVEL:
+      displayActionableAlertsOptions = false;
+      displayThrottlingSettings = false;
+      actionableAlertsSelections = [];
+      break;
+    default:
+      displayActionableAlertsOptions = false;
+      displayThrottlingSettings = actionExecutionScopeId !== NOTIFY_OPTIONS_VALUES.PER_EXECUTION;
+  }
 
   if (actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT) {
-    if (_.get(values, `${actionPath}.throttle.value`) === undefined) {
+    if (_.get(values, `${actionPath}.throttle.value`) === undefined)
       _.set(values, `${actionPath}.throttle.value`, 10);
-    }
 
-    if (actionableAlertsSelections === undefined) {
-      _.set(
-        values,
-        `${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`,
-        DEFAULT_ACTIONABLE_ALERTS_SELECTIONS
-      );
+    if (actionableAlertsSelections === undefined)
       actionableAlertsSelections = DEFAULT_ACTIONABLE_ALERTS_SELECTIONS;
-    }
+    _.set(values, actionableAlertsSelectionsPath, actionableAlertsSelections);
   }
 
   let preview = '';
@@ -237,7 +246,7 @@ export default function Message(
         {renderSendTestMessageButton(
           index,
           sendTestMessage,
-          isBucketLevelMonitor,
+          monitorType === MONITOR_TYPE.BUCKET_LEVEL,
           displayPreview,
           onDisplayPreviewChange,
           fieldPath
@@ -264,7 +273,7 @@ export default function Message(
 
       <EuiSpacer size="m" />
 
-      {isBucketLevelMonitor ? (
+      {editableActionExecutionPolicy ? (
         <EuiFormRow
           label={<span style={{ color: '#343741' }}>Perform action</span>}
           style={{ maxWidth: '100%' }}
@@ -279,9 +288,7 @@ export default function Message(
                   value: NOTIFY_OPTIONS_VALUES.PER_EXECUTION,
                   checked: actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_EXECUTION,
                   label: NOTIFY_OPTIONS_LABELS.PER_EXECUTION,
-                  onChange: (e, field, form) => {
-                    field.onChange(e);
-                  },
+                  onChange: (e, field, form) => field.onChange(e),
                 }}
               />
             </EuiFlexItem>
@@ -294,63 +301,49 @@ export default function Message(
                   value: NOTIFY_OPTIONS_VALUES.PER_ALERT,
                   checked: actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT,
                   label: NOTIFY_OPTIONS_LABELS.PER_ALERT,
-                  onChange: (e, field, form) => {
-                    field.onChange(e);
-                  },
+                  onChange: (e, field, form) => field.onChange(e),
                 }}
               />
             </EuiFlexItem>
 
-            <EuiFlexItem>
-              {actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT ? (
-                <EuiFormRow style={{ maxWidth: '100%' }}>
-                  <EuiFlexGroup
-                    alignItems="center"
-                    style={{
-                      margin: '0px',
-                      maxWidth: '100%',
+            {actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT &&
+            displayActionableAlertsOptions ? (
+              <EuiFormRow style={{ maxWidth: '100%' }}>
+                <EuiFlexGroup
+                  alignItems="center"
+                  style={{
+                    margin: '0px',
+                    maxWidth: '100%',
+                  }}
+                >
+                  <FormikComboBox
+                    name={actionableAlertsSelectionsPath}
+                    formRow
+                    fieldProps={{ validate: validateActionableAlertsSelections }}
+                    rowProps={{
+                      label: 'Actionable alerts',
+                      style: { width: '400px' },
+                      isInvalid:
+                        actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT &&
+                        _.isEmpty(actionableAlertsSelections),
+                      error: NO_ACTIONABLE_ALERT_SELECTIONS,
                     }}
-                  >
-                    <FormikComboBox
-                      name={`${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`}
-                      formRow
-                      fieldProps={{ validate: validateActionableAlertsSelections }}
-                      rowProps={{
-                        label: 'Actionable alerts',
-                        style: { width: '400px' },
-                        isInvalid:
-                          actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT &&
-                          _.isEmpty(
-                            _.get(
-                              action,
-                              `action_execution_policy.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`
-                            )
-                          ),
-                        error: NO_ACTIONABLE_ALERT_SELECTIONS,
-                      }}
-                      inputProps={{
-                        placeholder: 'Select alert options',
-                        options: ACTIONABLE_ALERTS_OPTIONS,
-                        onBlur: (e, field, form) => {
-                          form.setFieldTouched(
-                            `${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`,
-                            true
-                          );
-                        },
-                        onChange: (options, field, form) => {
-                          form.setFieldValue(
-                            `${actionExecutionPolicyPath}.action_execution_scope.${NOTIFY_OPTIONS_VALUES.PER_ALERT}.actionable_alerts`,
-                            options
-                          );
-                        },
-                        isClearable: true,
-                        selectedOptions: actionableAlertsSelections,
-                      }}
-                    />
-                  </EuiFlexGroup>
-                </EuiFormRow>
-              ) : null}
-            </EuiFlexItem>
+                    inputProps={{
+                      placeholder: 'Select alert options',
+                      options: ACTIONABLE_ALERTS_OPTIONS,
+                      onBlur: (e, field, form) => {
+                        form.setFieldTouched(actionableAlertsSelectionsPath, true);
+                      },
+                      onChange: (options, field, form) => {
+                        form.setFieldValue(actionableAlertsSelectionsPath, options);
+                      },
+                      isClearable: true,
+                      selectedOptions: actionableAlertsSelections,
+                    }}
+                  />
+                </EuiFlexGroup>
+              </EuiFormRow>
+            ) : null}
           </EuiFlexGroup>
         </EuiFormRow>
       ) : (
@@ -360,7 +353,7 @@ export default function Message(
         </div>
       )}
 
-      {actionExecutionScopeId !== NOTIFY_OPTIONS_VALUES.PER_EXECUTION ? (
+      {displayThrottlingSettings ? (
         <EuiFormRow label={'Throttling'} style={{ paddingBottom: '10px', maxWidth: '100%' }}>
           <EuiFlexGroup direction="column">
             <EuiFlexItem grow={false} style={{ marginBottom: '0px' }}>

--- a/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
@@ -165,24 +165,101 @@ exports[`Message renders 1`] = `
   <div
     class="euiSpacer euiSpacer--m"
   />
-  <div>
+  <div
+    class="euiFormRow"
+    id="generated-id-row"
+    style="max-width:100%"
+  >
     <div
-      class="euiFlexItem"
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        class="euiFormLabel euiFormRow__label"
+        for="generated-id"
+      >
+        <span
+          style="color:#343741"
+        >
+          Perform action
+        </span>
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiText euiText--extraSmall"
+        class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+        id="generated-id"
       >
-        <strong>
-          Perform action
-        </strong>
-        <div>
-          Per monitor execution
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiFormRow"
+            id="undefinedactions.0.action_execution_policy.action_execution_scope-form-row-row"
+          >
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiRadio"
+              >
+                <input
+                  class="euiRadio__input"
+                  id="undefinedactions.0.action_execution_policy.per_execution"
+                  name="undefinedactions.0.action_execution_policy.action_execution_scope"
+                  type="radio"
+                  value="per_execution"
+                />
+                <div
+                  class="euiRadio__circle"
+                />
+                <label
+                  class="euiRadio__label"
+                  for="undefinedactions.0.action_execution_policy.per_execution"
+                >
+                  Per execution
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiFormRow"
+            id="undefinedactions.0.action_execution_policy.action_execution_scope-form-row-row"
+          >
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiRadio"
+              >
+                <input
+                  checked=""
+                  class="euiRadio__input"
+                  id="undefinedactions.0.action_execution_policy.per_alert"
+                  name="undefinedactions.0.action_execution_policy.action_execution_scope"
+                  type="radio"
+                  value="per_alert"
+                />
+                <div
+                  class="euiRadio__circle"
+                />
+                <label
+                  class="euiRadio__label"
+                  for="undefinedactions.0.action_execution_policy.per_alert"
+                >
+                  Per alert
+                </label>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--s"
-    />
   </div>
   <div
     class="euiFormRow"

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -23,9 +23,9 @@ import DefineDocumentLevelTrigger from '../DefineDocumentLevelTrigger/DefineDocu
 import {
   buildClusterMetricsRequest,
   canExecuteClusterMetricsMonitor,
-  getDefaultScript,
 } from '../../../CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers';
 import { FORMIK_INITIAL_VALUES } from '../../../CreateMonitor/containers/CreateMonitor/utils/constants';
+import { getDefaultScript } from '../../utils/helper';
 
 class ConfigureTriggers extends React.Component {
   constructor(props) {
@@ -85,12 +85,8 @@ class ConfigureTriggers extends React.Component {
       FORMIK_INITIAL_VALUES.uri.api_type
     );
     if (prevSearchType !== currSearchType || prevApiType !== currApiType) {
-      switch (currSearchType) {
-        case SEARCH_TYPE.CLUSTER_METRICS:
-          _.set(this.state, 'addTriggerButton', this.prepareAddTriggerButton());
-          _.set(this.state, 'triggerEmptyPrompt', this.prepareTriggerEmptyPrompt());
-          break;
-      }
+      this.setState({ addTriggerButton: this.prepareAddTriggerButton() });
+      this.setState({ triggerEmptyPrompt: this.prepareTriggerEmptyPrompt() });
     }
 
     const prevInputs = prevProps.monitor.inputs[0];
@@ -318,6 +314,7 @@ class ConfigureTriggers extends React.Component {
 
   renderTriggers = (triggerArrayHelpers) => {
     const { monitorValues, triggerValues } = this.props;
+    const { triggerEmptyPrompt } = this.state;
     const hasTriggers = !_.isEmpty(_.get(triggerValues, 'triggerDefinitions'));
 
     const triggerContent = (arrayHelpers, index) => {
@@ -331,18 +328,16 @@ class ConfigureTriggers extends React.Component {
       }
     };
 
-    return hasTriggers ? (
-      triggerValues.triggerDefinitions.map((trigger, index) => {
-        return (
-          <div key={index}>
-            {triggerContent(triggerArrayHelpers, index)}
-            <EuiHorizontalRule margin={'s'} />
-          </div>
-        );
-      })
-    ) : (
-      <TriggerEmptyPrompt arrayHelpers={triggerArrayHelpers} />
-    );
+    return hasTriggers
+      ? triggerValues.triggerDefinitions.map((trigger, index) => {
+          return (
+            <div key={index}>
+              {triggerContent(triggerArrayHelpers, index)}
+              <EuiHorizontalRule margin={'s'} />
+            </div>
+          );
+        })
+      : triggerEmptyPrompt;
   };
 
   render() {

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -73,6 +73,11 @@ export const FORMIK_INITIAL_TRIGGER_VALUES = {
   actions: undefined,
 };
 
+export const FORMIK_INITIAL_DOC_LEVEL_SCRIPT = {
+  lang: FORMIK_INITIAL_TRIGGER_VALUES.script.lang,
+  source: '(query[name=<queryName>] || query[name=<queryName>]) && query[tag=<queryTag>]',
+};
+
 export const HITS_TOTAL_RESULTS_PATH = 'ctx.results[0].hits.total.value';
 export const AGGREGATION_RESULTS_PATH = 'ctx.results[0].aggregations.metric.value';
 export const ANOMALY_GRADE_RESULT_PATH = 'ctx.results[0].aggregations.max_anomaly_grade.value';

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -73,7 +73,8 @@ export function formikToBucketLevelTrigger(values, monitorUiMetadata) {
 
 export function formikToDocumentLevelTrigger(values, monitorUiMetadata) {
   const condition = formikToDocumentLevelTriggerCondition(values, monitorUiMetadata);
-  const actions = formikToAction(values);
+  // const actions = formikToAction(values); // todo hurneyt
+  const actions = formikToBucketLevelTriggerAction(values);
   return {
     document_level_trigger: {
       id: values.id,

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/triggerToFormik.js
@@ -175,7 +175,7 @@ export function bucketLevelTriggerToFormik(trigger, monitor) {
     severity,
     script,
     bucketSelector,
-    actions: getBucketLevelTriggerActions(actions),
+    actions: getExecutionPolicyActions(actions),
     triggerConditions,
     minTimeBetweenExecutions,
     rollingWindowSize,
@@ -209,14 +209,14 @@ export function documentLevelTriggerToFormik(trigger, monitor) {
     name,
     severity,
     script,
-    actions,
+    actions: getExecutionPolicyActions(actions),
     minTimeBetweenExecutions,
     rollingWindowSize,
     triggerConditions: triggerUiMetadata,
   };
 }
 
-export function getBucketLevelTriggerActions(actions) {
+export function getExecutionPolicyActions(actions) {
   const executionPolicyPath = 'action_execution_policy.action_execution_scope';
   return _.cloneDeep(actions).map((action) => {
     const actionExecutionPolicy = _.get(action, `${executionPolicyPath}`);

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -3,8 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import _ from 'lodash';
 import { DESTINATION_TYPE } from '../../Destinations/utils/constants';
-import { BACKEND_CHANNEL_TYPE } from '../../../utils/constants';
+import { BACKEND_CHANNEL_TYPE, MONITOR_TYPE } from '../../../utils/constants';
+import { FORMIK_INITIAL_VALUES } from '../../CreateMonitor/containers/CreateMonitor/utils/constants';
+import {
+  API_TYPES,
+  DEFAULT_CLUSTER_METRICS_SCRIPT,
+} from '../../CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorConstants';
+import {
+  FORMIK_INITIAL_DOC_LEVEL_SCRIPT,
+  FORMIK_INITIAL_TRIGGER_VALUES,
+} from '../containers/CreateTrigger/utils/constants';
 
 export const getChannelOptions = (channels, allowedTypes) =>
   allowedTypes.map((type) => ({
@@ -20,4 +30,19 @@ export const toChannelType = (type) => {
   }
 
   return type;
+};
+
+export const getDefaultScript = (monitorValues) => {
+  const monitorType = _.get(monitorValues, 'monitor_type', FORMIK_INITIAL_VALUES.monitor_type);
+  switch (monitorType) {
+    case MONITOR_TYPE.BUCKET_LEVEL:
+      return FORMIK_INITIAL_TRIGGER_VALUES.bucketSelector;
+    case MONITOR_TYPE.CLUSTER_METRICS:
+      const apiType = _.get(monitorValues, 'uri.api_type');
+      return _.get(API_TYPES, `${apiType}.defaultCondition`, DEFAULT_CLUSTER_METRICS_SCRIPT);
+    case MONITOR_TYPE.DOC_LEVEL:
+      return FORMIK_INITIAL_DOC_LEVEL_SCRIPT;
+    default:
+      return FORMIK_INITIAL_TRIGGER_VALUES.script;
+  }
 };

--- a/public/pages/CreateTrigger/utils/helper.test.js
+++ b/public/pages/CreateTrigger/utils/helper.test.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import _ from 'lodash';
+import { getDefaultScript } from './helper';
+import { MONITOR_TYPE } from '../../../utils/constants';
+import {
+  FORMIK_INITIAL_DOC_LEVEL_SCRIPT,
+  FORMIK_INITIAL_TRIGGER_VALUES,
+} from '../containers/CreateTrigger/utils/constants';
+import {
+  API_TYPES,
+  DEFAULT_CLUSTER_METRICS_SCRIPT,
+} from '../../CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorConstants';
+
+describe('CreateTrigger/utils/helper', () => {
+  describe('getDefaultScript', () => {
+    test('when monitor_type is undefined', () => {
+      const monitorValues = undefined;
+      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.script);
+    });
+
+    test(`when monitor_type is ${MONITOR_TYPE.BUCKET_LEVEL}`, () => {
+      const monitorValues = { monitor_type: MONITOR_TYPE.BUCKET_LEVEL };
+      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.bucketSelector);
+    });
+
+    test(`when monitor_type is ${MONITOR_TYPE.DOC_LEVEL}`, () => {
+      const monitorValues = { monitor_type: MONITOR_TYPE.DOC_LEVEL };
+      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_DOC_LEVEL_SCRIPT);
+    });
+
+    test(`when monitor_type is ${MONITOR_TYPE.QUERY_LEVEL}`, () => {
+      const monitorValues = { monitor_type: MONITOR_TYPE.QUERY_LEVEL };
+      expect(getDefaultScript(monitorValues)).toEqual(FORMIK_INITIAL_TRIGGER_VALUES.script);
+    });
+
+    describe(`when monitor_type is ${MONITOR_TYPE.CLUSTER_METRICS}`, () => {
+      test('and api_type is undefined', () => {
+        const monitorValues = {
+          monitor_type: MONITOR_TYPE.CLUSTER_METRICS,
+          uri: undefined,
+        };
+        expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
+      });
+
+      test('and api_type is empty', () => {
+        const monitorValues = {
+          monitor_type: MONITOR_TYPE.CLUSTER_METRICS,
+          uri: {
+            api_type: '',
+          },
+        };
+        expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
+      });
+
+      test('and api_type does not have a default condition', () => {
+        const monitorValues = {
+          monitor_type: MONITOR_TYPE.CLUSTER_METRICS,
+          uri: {
+            api_type: 'unknownApi',
+          },
+        };
+        expect(getDefaultScript(monitorValues)).toEqual(DEFAULT_CLUSTER_METRICS_SCRIPT);
+      });
+
+      _.keys(API_TYPES).forEach((apiType) => {
+        test(`and api_type is ${apiType}`, () => {
+          const monitorValues = {
+            monitor_type: MONITOR_TYPE.CLUSTER_METRICS,
+            uri: {
+              api_type: apiType,
+            },
+          };
+          const expectedOutput = _.get(API_TYPES, `${apiType}.defaultCondition`);
+          if (!_.isEmpty(expectedOutput))
+            expect(getDefaultScript(monitorValues)).toEqual(expectedOutput);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description
1. Refactored actions component for doc level monitors to support configuration action execution options.
2. Implemented an example trigger condition for doc level monitors that are defined using the extraction query editor. 
3. Implemented additional form-reset logic when changing monitor types. 
4. Moved getDefaultScript to a separate helper class, and refactored the unit tests, to accommodate other monitor types.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
