### PR TITLE
Implemented a fix for issue 258 which was allowing the UX to define more than 1 index for document level monitors.

### DIFF
--- a/cypress/integration/document_level_monitor_spec.js
+++ b/cypress/integration/document_level_monitor_spec.js
@@ -261,7 +261,7 @@ describe('DocumentLevelMonitor', () => {
 
         // TODO: Test with Notifications plugin
 
-        // Click the create button
+        // Click the update button
         cy.get('button').contains('Update').last().click();
 
         // Confirm we can see only one row in the trigger list by checking <caption> element
@@ -335,6 +335,38 @@ describe('DocumentLevelMonitor', () => {
 
         // Confirm we can see the new trigger
         cy.contains(newTriggerName);
+      });
+
+      it('with only 1 index', () => {
+        // This test ensures the bug in this issue has been fixed
+        // https://github.com/opensearch-project/alerting-dashboards-plugin/issues/258
+
+        // Creating the test monitor
+        cy.createMonitor(sampleDocumentLevelMonitor);
+        cy.reload();
+
+        // Confirm the created monitor can be seen
+        cy.contains(SAMPLE_DOCUMENT_LEVEL_MONITOR);
+
+        // Select the monitor
+        cy.get('a').contains(SAMPLE_DOCUMENT_LEVEL_MONITOR).click({ force: true });
+
+        // Click Edit button
+        cy.contains('Edit').click({ force: true });
+
+        // Click on the Index field and type in multiple index names to replicate the bug
+        cy.get('#index')
+          .click({ force: true })
+          .type(`indexName1{enter}indexName2{enter}`, { force: true })
+          .trigger('blur', { force: true });
+
+        // Confirm Index field only contains the expected text
+        cy.get('[data-test-subj="indicesComboBox"]').should('not.have.text', TESTING_INDEX);
+        cy.get('[data-test-subj="indicesComboBox"]').should('not.have.text', 'indexName1');
+        cy.get('[data-test-subj="indicesComboBox"]').should('have.text', 'indexName2');
+
+        // Click the update button
+        cy.get('button').contains('Update').last().click();
       });
     });
   });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -67,13 +67,14 @@ class MonitorIndex extends React.Component {
     this.onSearchChange('');
   }
 
-  onCreateOption(searchValue, selectedOptions, setFieldValue) {
+  onCreateOption(searchValue, selectedOptions, setFieldValue, supportMultipleIndices) {
     const normalizedSearchValue = searchValue.trim().toLowerCase();
 
     if (!normalizedSearchValue) return;
 
     const newOption = { label: searchValue };
-    setFieldValue('index', selectedOptions.concat(newOption));
+    if (supportMultipleIndices) setFieldValue('index', selectedOptions.concat(newOption));
+    else setFieldValue('index', [newOption]);
   }
 
   async onSearchChange(searchValue) {
@@ -226,13 +227,13 @@ class MonitorIndex extends React.Component {
         rowProps={{
           label: 'Index',
           helpText:
-            'You can use a * as a wildcard or date math index resolution in your index pattern', // TODO DRAFT: Confirm wildcard wording is appropriate for doc level monitors
+            'You can use a * as a wildcard or date math index resolution in your index pattern',
           isInvalid,
           error: hasError,
           style: { paddingLeft: '10px' },
         }}
         inputProps={{
-          placeholder: supportMultipleIndices ? 'Select indices' : 'Select index',
+          placeholder: supportMultipleIndices ? 'Select indices' : 'Select an index',
           async: true,
           isLoading,
           options: visibleOptions,
@@ -243,7 +244,7 @@ class MonitorIndex extends React.Component {
             form.setFieldValue('index', options);
           },
           onCreateOption: (value, field, form) => {
-            this.onCreateOption(value, field.value, form.setFieldValue);
+            this.onCreateOption(value, field.value, form.setFieldValue, supportMultipleIndices);
           },
           onSearchChange: this.onSearchChange,
           renderOption: this.renderOption,


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Implemented a fix for issue 258 which was allowing the UX to define more than 1 index for document level monitors.
 
### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/258
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
