### PR TITLE
Fixed an issue preventing doc level monitors from adding execution policy as expected.

### DIFF
--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -151,11 +151,14 @@ export default function Message(
 
   let defaultNotifyOption;
   switch (monitorType) {
+    case MONITOR_TYPE.BUCKET_LEVEL:
+      defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_ALERT;
+      break;
     case MONITOR_TYPE.DOC_LEVEL:
       defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_EXECUTION;
       break;
     default:
-      defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_ALERT;
+      defaultNotifyOption = NOTIFY_OPTIONS_VALUES.PER_EXECUTION;
   }
   let actionExecutionScopeId = editableActionExecutionPolicy
     ? _.get(action, 'action_execution_policy.action_execution_scope', defaultNotifyOption)

--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -175,6 +175,7 @@ export default function Message(
       displayActionableAlertsOptions = false;
       displayThrottlingSettings = false;
       actionableAlertsSelections = [];
+      _.set(action, 'action_execution_policy.action_execution_scope', actionExecutionScopeId);
       break;
     default:
       displayActionableAlertsOptions = false;


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Fixed an issue preventing doc level monitors from adding execution policy as expected.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
