### PR TITLE
Fixed an issue that would sometimes cause the loadDestinations function to not call getChannels.

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -85,8 +85,10 @@ class ConfigureActions extends React.Component {
   }
 
   loadDestinations = async (searchText = '') => {
-    const { httpClient, values, arrayHelpers, notifications, fieldPath } = this.props;
-    const { allowList, actionDeleted, hasNotificationPlugin } = this.state;
+    const { httpClient, values, arrayHelpers, notifications, fieldPath, plugins } = this.props;
+    const { allowList, actionDeleted } = this.state;
+    const hasNotificationPlugin = plugins.indexOf(OS_NOTIFICATION_PLUGIN) !== -1;
+
     this.setState({ loadingDestinations: true });
     try {
       const response = await httpClient.get('../api/alerting/destinations', {


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
When editing an existing monitor configured with a notification channel action, sometimes the `ConfigureActions::loadDestinations` function wouldn't recognize that the notifications plugin was installed. Refactored `loadDestinations` to check for the plugin itself rather than depend on the `componentDidMount` and `componentDidUpdate` functions.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
