### PR TITLE
Revert single index changes for doc monitor

### DIFF
--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.js
@@ -11,7 +11,6 @@ import { EuiHealth, EuiHighlight } from '@elastic/eui';
 import { FormikComboBox } from '../../../../components/FormControls';
 import { validateIndex, hasError, isInvalid } from '../../../../utils/validate';
 import { canAppendWildcard, createReasonableWait, getMatchedOptions } from './utils/helpers';
-import { MONITOR_TYPE } from '../../../../utils/constants';
 
 const CustomOption = ({ option, searchValue, contentClassName }) => {
   const { health, label, index } = option;
@@ -67,14 +66,13 @@ class MonitorIndex extends React.Component {
     this.onSearchChange('');
   }
 
-  onCreateOption(searchValue, selectedOptions, setFieldValue, supportMultipleIndices) {
+  onCreateOption(searchValue, selectedOptions, setFieldValue) {
     const normalizedSearchValue = searchValue.trim().toLowerCase();
 
     if (!normalizedSearchValue) return;
 
     const newOption = { label: searchValue };
-    if (supportMultipleIndices) setFieldValue('index', selectedOptions.concat(newOption));
-    else setFieldValue('index', [newOption]);
+    setFieldValue('index', selectedOptions.concat(newOption));
   }
 
   async onSearchChange(searchValue) {
@@ -217,8 +215,6 @@ class MonitorIndex extends React.Component {
       false //isIncludingSystemIndices
     );
 
-    const supportMultipleIndices = this.props.monitorType !== MONITOR_TYPE.DOC_LEVEL;
-
     return (
       <FormikComboBox
         name="index"
@@ -233,7 +229,7 @@ class MonitorIndex extends React.Component {
           style: { paddingLeft: '10px' },
         }}
         inputProps={{
-          placeholder: supportMultipleIndices ? 'Select indices' : 'Select an index',
+          placeholder: 'Select indices',
           async: true,
           isLoading,
           options: visibleOptions,
@@ -244,12 +240,11 @@ class MonitorIndex extends React.Component {
             form.setFieldValue('index', options);
           },
           onCreateOption: (value, field, form) => {
-            this.onCreateOption(value, field.value, form.setFieldValue, supportMultipleIndices);
+            this.onCreateOption(value, field.value, form.setFieldValue);
           },
           onSearchChange: this.onSearchChange,
           renderOption: this.renderOption,
           isClearable: true,
-          singleSelection: supportMultipleIndices ? false : { asPlainText: true },
           'data-test-subj': 'indicesComboBox',
         }}
       />


### PR DESCRIPTION
Signed-off-by: Angie Zhang <langelzh@amazon.com>

### Description Revert changes to fix #258 to support multiple input indices for doc level monitor 
[Describe what this change achieves]
 
### Issues Resolved For #474 in alerting 
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
