### PR TITLE
Fixed snapshot failures.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.2'
   OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
 jobs:
   tests:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,14 +2,10 @@ name: E2E Cypress tests
 on:
   pull_request:
     branches:
-      - main
-      - 1.x
-      - 2.*
+      - "*"
   push:
     branches:
-      - main
-      - 1.x
-      - 2.*
+      - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
   OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -2,14 +2,10 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - main
-      - 1.x
-      - 2.*
+      - "*"
   pull_request:
     branches:
-      - main
-      - 1.x
-      - 2.*
+      - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
 jobs:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.2'
 jobs:
   tests:
     name: Run unit tests

--- a/public/components/FormControls/FormikFieldPassword/__snapshots__/FormikFieldPassword.test.js.snap
+++ b/public/components/FormControls/FormikFieldPassword/__snapshots__/FormikFieldPassword.test.js.snap
@@ -18,9 +18,16 @@ exports[`FormikFieldPassword renders 1`] = `
       <span
         class="euiFormControlLayoutCustomIcon"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
   </div>

--- a/public/components/FormControls/FormikSelect/__snapshots__/FormikSelect.test.js.snap
+++ b/public/components/FormControls/FormikSelect/__snapshots__/FormikSelect.test.js.snap
@@ -24,9 +24,16 @@ exports[`FormikSelect renders 1`] = `
       <span
         class="euiFormControlLayoutCustomIcon"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
   </div>

--- a/public/components/FormControls/FormikSwitch/__snapshots__/FormikSwitch.test.js.snap
+++ b/public/components/FormControls/FormikSwitch/__snapshots__/FormikSwitch.test.js.snap
@@ -22,12 +22,26 @@ exports[`FormikSwitch renders 1`] = `
       <span
         class="euiSwitch__track"
       >
-        <div>
-          EuiIconMock
-        </div>
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </span>
   </button>

--- a/public/components/IconToolTip/__snapshots__/IconToolTip.test.js.snap
+++ b/public/components/IconToolTip/__snapshots__/IconToolTip.test.js.snap
@@ -4,8 +4,15 @@ exports[`IconToolTip renders 1`] = `
 <span
   class="euiToolTipAnchor"
 >
-  <div>
-    EuiIconMock
-  </div>
+  <svg
+    aria-hidden="true"
+    class="euiIcon euiIcon--medium euiIcon-isLoading"
+    focusable="false"
+    height="16"
+    role="img"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  />
 </span>
 `;

--- a/public/pages/CreateMonitor/components/ClusterMetricsMonitor/__snapshots__/ClusterMetricsMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/components/ClusterMetricsMonitor/__snapshots__/ClusterMetricsMonitor.test.js.snap
@@ -39,9 +39,17 @@ exports[`ClusterMetricsMonitor renders 1`] = `
                 target="_blank"
               >
                 Learn more
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  aria-label="External link"
+                  class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
                 <span
                   class="euiScreenReaderOnly"
                 >
@@ -106,9 +114,16 @@ exports[`ClusterMetricsMonitor renders 1`] = `
                 data-test-subj="comboBoxToggleListButton"
                 type="button"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
               </button>
             </div>
           </div>

--- a/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
@@ -48,9 +48,16 @@ exports[`MonitorDefinition renders 1`] = `
             <span
               class="euiFormControlLayoutCustomIcon"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </span>
           </div>
         </div>

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
@@ -24,9 +24,17 @@ exports[`MonitorDefinitionCard renders without AD plugin 1`] = `
         target="_blank"
       >
         Learn more
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          aria-label="External link"
+          class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
         <span
           class="euiScreenReaderOnly"
         >
@@ -161,9 +169,20 @@ exports[`MonitorDefinitionCard renders without AD plugin 2`] = `
         target="_blank"
       >
         Learn more
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-label="External link"
+          class="euiIcon euiIcon--small euiLink__externalIcon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+          />
+        </svg>
         <span
           class="euiScreenReaderOnly"
         >

--- a/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
@@ -17,9 +17,16 @@ exports[`MonitorExpressions renders 1`] = `
       <span
         class="euiToolTipAnchor"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
     <div
@@ -93,9 +100,16 @@ exports[`MonitorExpressions renders 1`] = `
       <span
         class="euiToolTipAnchor"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
     <div
@@ -172,9 +186,16 @@ exports[`MonitorExpressions renders 1`] = `
               <span
                 class="euiFormControlLayoutCustomIcon"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
               </span>
             </div>
           </div>
@@ -198,9 +219,16 @@ exports[`MonitorExpressions renders 1`] = `
       <span
         class="euiToolTipAnchor"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
     <div
@@ -258,9 +286,16 @@ exports[`MonitorExpressions renders 1`] = `
       <span
         class="euiToolTipAnchor"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </span>
     </div>
     <div

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/ForExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/ForExpression.test.js.snap
@@ -11,9 +11,16 @@ exports[`ForExpression renders 1`] = `
     <span
       class="euiToolTipAnchor"
     >
-      <div>
-        EuiIconMock
-      </div>
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium euiIcon-isLoading"
+        focusable="false"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      />
     </span>
   </div>
   <div
@@ -90,9 +97,16 @@ exports[`ForExpression renders 1`] = `
             <span
               class="euiFormControlLayoutCustomIcon"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </span>
           </div>
         </div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
@@ -14,9 +14,16 @@ exports[`WhereExpression renders 1`] = `
     <span
       class="euiToolTipAnchor"
     >
-      <div>
-        EuiIconMock
-      </div>
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium euiIcon-isLoading"
+        focusable="false"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      />
     </span>
   </div>
   <div

--- a/public/pages/CreateMonitor/components/MonitorTimeField/__snapshots__/MonitorTimeField.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/__snapshots__/MonitorTimeField.test.js.snap
@@ -69,9 +69,16 @@ exports[`MonitorTimeField renders 1`] = `
               data-test-subj="comboBoxToggleListButton"
               type="button"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
             </button>
           </div>
         </div>

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -46,9 +46,17 @@ exports[`QueryPerformance renders 1`] = `
           target="_blank"
         >
           Learn more
-          <div>
-            EuiIconMock
-          </div>
+          <svg
+            aria-hidden="true"
+            aria-label="External link"
+            class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
           <span
             class="euiScreenReaderOnly"
           >

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
@@ -51,9 +51,17 @@ exports[`Frequencies renders CustomCron 1`] = `
               target="_blank"
             >
               cron expressions
-              <div>
-                EuiIconMock
-              </div>
+              <svg
+                aria-hidden="true"
+                aria-label="External link"
+                class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
               <span
                 class="euiScreenReaderOnly"
               >
@@ -128,9 +136,21 @@ exports[`Frequencies renders CustomCron 1`] = `
                   data-test-subj="comboBoxToggleListButton"
                   type="button"
                 >
-                  <div>
-                    EuiIconMock
-                  </div>
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                      fill-rule="non-zero"
+                    />
+                  </svg>
                 </button>
               </div>
             </div>
@@ -206,9 +226,16 @@ exports[`Frequencies renders Frequency 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -262,9 +289,21 @@ exports[`Frequencies renders FrequencyPicker 1`] = `
               <span
                 class="euiFormControlLayoutCustomIcon"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7.5 13A5.506 5.506 0 012 7.5C2 4.467 4.467 2 7.5 2S13 4.467 13 7.5 10.533 13 7.5 13m0-12a6.5 6.5 0 100 13 6.5 6.5 0 000-13m3 6H8V3.5a.5.5 0 00-1 0v4a.5.5 0 00.5.5h3a.5.5 0 000-1"
+                    fill-rule="evenodd"
+                  />
+                </svg>
               </span>
             </div>
           </div>
@@ -317,9 +356,21 @@ exports[`Frequencies renders FrequencyPicker 1`] = `
               <span
                 class="euiFormControlLayoutCustomIcon"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                    fill-rule="non-zero"
+                  />
+                </svg>
               </span>
             </div>
           </div>
@@ -375,9 +426,16 @@ exports[`Frequencies renders Interval 1`] = `
               <span
                 class="euiFormControlLayoutCustomIcon"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
               </span>
             </div>
           </div>
@@ -430,9 +488,21 @@ exports[`Frequencies renders Interval 1`] = `
               <span
                 class="euiFormControlLayoutCustomIcon"
               >
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                    fill-rule="non-zero"
+                  />
+                </svg>
               </span>
             </div>
           </div>

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -789,9 +789,25 @@ exports[`AnomalyDetectors renders 1`] = `
                                             size="m"
                                             type="arrowDown"
                                           >
-                                            <div>
-                                              EuiIconMock
-                                            </div>
+                                            <EuiIconEmpty
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              />
+                                            </EuiIconEmpty>
                                           </EuiIcon>
                                         </button>
                                       </EuiFormControlLayoutCustomIcon>

--- a/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/MonitorIndex.test.js
@@ -159,6 +159,6 @@ describe('MonitorIndex', () => {
       .simulate('keyDown', { key: 'Enter' });
 
     // Validate the specific index is in the input field
-    expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('logstashEuiIconMock');
+    expect(wrapper.find('[data-test-subj="comboBoxInput"]').text()).toEqual('logstash');
   });
 });

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -779,9 +779,25 @@ exports[`MonitorIndex renders 1`] = `
                                           size="m"
                                           type="arrowDown"
                                         >
-                                          <div>
-                                            EuiIconMock
-                                          </div>
+                                          <EuiIconEmpty
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            />
+                                          </EuiIconEmpty>
                                         </EuiIcon>
                                       </button>
                                     </EuiFormControlLayoutCustomIcon>

--- a/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
@@ -21,9 +21,16 @@ exports[`Action renders with Notifications plugin installed 1`] = `
           <span
             class="euiAccordion__iconWrapper"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
           <span
             class="euiIEFlexWrapFix"
@@ -188,9 +195,16 @@ exports[`Action renders with Notifications plugin installed 1`] = `
                                   data-test-subj="comboBoxToggleListButton"
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  />
                                 </button>
                               </div>
                             </div>
@@ -212,9 +226,16 @@ exports[`Action renders with Notifications plugin installed 1`] = `
                       <span
                         class="euiButtonContent euiButtonContent--iconRight euiButton__content"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
                         <span
                           class="euiButton__text"
                         >
@@ -300,9 +321,17 @@ exports[`Action renders with Notifications plugin installed 1`] = `
                               target="_blank"
                             >
                               Learn more
-                              <div>
-                                EuiIconMock
-                              </div>
+                              <svg
+                                aria-hidden="true"
+                                aria-label="External link"
+                                class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
                               <span
                                 class="euiScreenReaderOnly"
                               >
@@ -563,9 +592,21 @@ exports[`Action renders without Notifications plugin installed 1`] = `
           <span
             class="euiAccordion__iconWrapper"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiAccordion__icon euiAccordion__icon-isOpen"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.157 13.069l4.611-4.685a.546.546 0 000-.768L5.158 2.93a.552.552 0 010-.771.53.53 0 01.759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 01-.76 0 .552.552 0 010-.771z"
+                fill-rule="nonzero"
+              />
+            </svg>
           </span>
           <span
             class="euiIEFlexWrapFix"
@@ -732,9 +773,21 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                                   disabled=""
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                      fill-rule="non-zero"
+                                    />
+                                  </svg>
                                 </button>
                               </div>
                             </div>
@@ -757,9 +810,20 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                       <span
                         class="euiButtonContent euiButtonContent--iconRight euiButton__content"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                          />
+                        </svg>
                         <span
                           class="euiButton__text"
                         >
@@ -779,9 +843,16 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                     <div
                       class="euiCallOutHeader"
                     >
-                      <div>
-                        EuiIconMock
-                      </div>
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiCallOutHeader__icon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
                       <span
                         class="euiCallOutHeader__title"
                       >
@@ -802,19 +873,23 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                             rel="noreferrer"
                           >
                             Learn more
+                            <svg
+                              aria-label="External link"
+                              class="euiIcon euiIcon--small euiLink__externalIcon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                              />
+                            </svg>
                           </a>
+                          .
                         </p>
-                        <div>
-                          <a
-                            class="euiLink euiLink--primary"
-                            href="#"
-                            rel="noreferrer"
-                          >
-                            EuiIconMock
-                          </a>
-                        </div>
-                        .
-                        <p />
                       </div>
                     </div>
                   </div>
@@ -895,9 +970,20 @@ exports[`Action renders without Notifications plugin installed 1`] = `
                               target="_blank"
                             >
                               Learn more
-                              <div>
-                                EuiIconMock
-                              </div>
+                              <svg
+                                aria-label="External link"
+                                class="euiIcon euiIcon--small euiLink__externalIcon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                                />
+                              </svg>
                               <span
                                 class="euiScreenReaderOnly"
                               >

--- a/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
@@ -73,9 +73,17 @@ exports[`Message renders 1`] = `
                 target="_blank"
               >
                 Learn more
-                <div>
-                  EuiIconMock
-                </div>
+                <svg
+                  aria-hidden="true"
+                  aria-label="External link"
+                  class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                />
                 <span
                   class="euiScreenReaderOnly"
                 >

--- a/public/pages/CreateTrigger/components/NotificationsCallOut/__snapshots__/NotificationsCallOut.test.js.snap
+++ b/public/pages/CreateTrigger/components/NotificationsCallOut/__snapshots__/NotificationsCallOut.test.js.snap
@@ -8,9 +8,16 @@ exports[`NotifictionsCallOut renders 1`] = `
     <div
       class="euiCallOutHeader"
     >
-      <div>
-        EuiIconMock
-      </div>
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiCallOutHeader__icon"
+        focusable="false"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      />
       <span
         class="euiCallOutHeader__title"
       >
@@ -31,19 +38,20 @@ exports[`NotifictionsCallOut renders 1`] = `
             rel="noreferrer"
           >
             Learn more
+            <svg
+              aria-hidden="true"
+              aria-label="External link"
+              class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </a>
+          .
         </p>
-        <div>
-          <a
-            class="euiLink euiLink--primary"
-            href="#"
-            rel="noreferrer"
-          >
-            EuiIconMock
-          </a>
-        </div>
-        .
-        <p />
       </div>
     </div>
   </div>

--- a/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
@@ -26,9 +26,16 @@ exports[`DashboardControls renders 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -84,9 +91,16 @@ exports[`DashboardControls renders 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -143,9 +157,16 @@ exports[`DashboardControls renders 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -164,9 +185,16 @@ exports[`DashboardControls renders 1`] = `
         data-test-subj="pagination-button-previous"
         type="button"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </button>
       <ul
         class="euiPagination__list"
@@ -221,9 +249,16 @@ exports[`DashboardControls renders 1`] = `
         disabled=""
         type="button"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </button>
     </nav>
   </div>

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -361,9 +361,29 @@ exports[`Dashboard renders in flyout 1`] = `
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSearch
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                          />
+                                        </svg>
+                                      </EuiIconSearch>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -503,9 +523,30 @@ exports[`Dashboard renders in flyout 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconArrowDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                            fillRule="non-zero"
+                                          />
+                                        </svg>
+                                      </EuiIconArrowDown>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -577,9 +618,30 @@ exports[`Dashboard renders in flyout 1`] = `
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowLeft
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M10.843 13.069L6.232 8.384a.546.546 0 010-.768l4.61-4.685a.552.552 0 000-.771.53.53 0 00-.759 0l-4.61 4.684a1.65 1.65 0 000 2.312l4.61 4.684a.53.53 0 00.76 0 .552.552 0 000-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowLeft>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -704,9 +766,30 @@ exports[`Dashboard renders in flyout 1`] = `
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowRight
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.157 13.069l4.611-4.685a.546.546 0 000-.768L5.158 2.93a.552.552 0 010-.771.53.53 0 01.759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 01-.76 0 .552.552 0 010-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowRight>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -980,9 +1063,30 @@ exports[`Dashboard renders in flyout 1`] = `
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconArrowDown
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -1144,9 +1248,29 @@ exports[`Dashboard renders in flyout 1`] = `
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSortDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M7 11.692V3.556C7 3.249 7.224 3 7.5 3s.5.249.5.556v8.136l4.096-4.096a.5.5 0 01.707.707l-4.242 4.243a1.494 1.494 0 01-.925.433.454.454 0 01-.272 0 1.494 1.494 0 01-.925-.433L2.197 8.303a.5.5 0 11.707-.707L7 11.692z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortDown>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>
@@ -1956,9 +2080,29 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSearch
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                          />
+                                        </svg>
+                                      </EuiIconSearch>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -2096,9 +2240,30 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconArrowDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                            fillRule="non-zero"
+                                          />
+                                        </svg>
+                                      </EuiIconArrowDown>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -2238,9 +2403,30 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconArrowDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                            fillRule="non-zero"
+                                          />
+                                        </svg>
+                                      </EuiIconArrowDown>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -2312,9 +2498,30 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowLeft
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M10.843 13.069L6.232 8.384a.546.546 0 010-.768l4.61-4.685a.552.552 0 000-.771.53.53 0 00-.759 0l-4.61 4.684a1.65 1.65 0 000 2.312l4.61 4.684a.53.53 0 00.76 0 .552.552 0 000-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowLeft>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -2439,9 +2646,30 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowRight
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.157 13.069l4.611-4.685a.546.546 0 000-.768L5.158 2.93a.552.552 0 010-.771.53.53 0 01.759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 01-.76 0 .552.552 0 010-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowRight>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -2748,9 +2976,30 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconArrowDown
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -3202,9 +3451,29 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSortDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M7 11.692V3.556C7 3.249 7.224 3 7.5 3s.5.249.5.556v8.136l4.096-4.096a.5.5 0 01.707.707l-4.242 4.243a1.494 1.494 0 01-.925.433.454.454 0 01-.272 0 1.494 1.494 0 01-.925-.433L2.197 8.303a.5.5 0 11.707-.707L7 11.692z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortDown>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>
@@ -3851,9 +4120,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -3991,9 +4276,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -4133,9 +4434,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -4207,9 +4524,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconEmpty
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </EuiIconEmpty>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -4334,9 +4667,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconEmpty
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </EuiIconEmpty>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -4610,9 +4959,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconEmpty
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  />
+                                                </EuiIconEmpty>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -4774,9 +5139,25 @@ exports[`Dashboard renders with per alert view 1`] = `
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>

--- a/public/pages/Destinations/components/DestinationsList/DestinationsActions/__snapshots__/DestinationsActions.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsActions/__snapshots__/DestinationsActions.test.js.snap
@@ -21,9 +21,16 @@ exports[`<DestinationsActions /> should render DestinationsActions 1`] = `
           <span
             class="euiButtonContent euiButtonContent--iconRight euiButton__content"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
             <span
               class="euiButton__text"
             >

--- a/public/pages/Destinations/components/DestinationsList/DestinationsControls/__snapshots__/DestinationsControls.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsControls/__snapshots__/DestinationsControls.test.js.snap
@@ -26,9 +26,16 @@ exports[`<DestinationsControls /> should render DestinationsControls 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -79,9 +86,16 @@ exports[`<DestinationsControls /> should render DestinationsControls 1`] = `
           <span
             class="euiFormControlLayoutCustomIcon"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
           </span>
         </div>
       </div>
@@ -101,9 +115,16 @@ exports[`<DestinationsControls /> should render DestinationsControls 1`] = `
         disabled=""
         type="button"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </button>
       <ul
         class="euiPagination__list"
@@ -243,9 +264,16 @@ exports[`<DestinationsControls /> should render DestinationsControls 1`] = `
         data-test-subj="pagination-button-next"
         type="button"
       >
-        <div>
-          EuiIconMock
-        </div>
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       </button>
     </nav>
   </div>

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
@@ -64,9 +64,20 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                         class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                         type="button"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                          />
+                        </svg>
                       </button>
                       <div
                         class="euiModal__flex"
@@ -205,9 +216,20 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                 class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                 type="button"
                               >
-                                <div>
-                                  EuiIconMock
-                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                  />
+                                </svg>
                               </button>
                               <div
                                 class="euiModal__flex"
@@ -278,9 +300,20 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                   class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                    />
+                                  </svg>
                                 </button>
                                 <div
                                   class="euiModal__flex"
@@ -351,9 +384,20 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                     type="button"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                      />
+                                    </svg>
                                   </button>
                                   <div
                                     class="euiModal__flex"
@@ -412,9 +456,20 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                       class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                       type="button"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                        />
+                                      </svg>
                                     </button>
                                     <div
                                       class="euiModal__flex"
@@ -513,9 +568,29 @@ exports[`ManageEmailGroups renders when email is disallowed 1`] = `
                                     size="m"
                                     type="cross"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <EuiIconCross
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                        />
+                                      </svg>
+                                    </EuiIconCross>
                                   </EuiIcon>
                                 </button>
                               </EuiButtonIcon>
@@ -752,9 +827,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                         class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                         type="button"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
                       </button>
                       <div
                         class="euiModal__flex"
@@ -893,9 +975,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                 class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                 type="button"
                               >
-                                <div>
-                                  EuiIconMock
-                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
                               </button>
                               <div
                                 class="euiModal__flex"
@@ -966,9 +1055,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                   class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  />
                                 </button>
                                 <div
                                   class="euiModal__flex"
@@ -1039,9 +1135,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                     type="button"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
                                   </button>
                                   <div
                                     class="euiModal__flex"
@@ -1100,9 +1203,16 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                       class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                       type="button"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
                                     </button>
                                     <div
                                       class="euiModal__flex"
@@ -1201,9 +1311,25 @@ exports[`ManageEmailGroups renders when visible 1`] = `
                                     size="m"
                                     type="cross"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <EuiIconEmpty
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </EuiIconEmpty>
                                   </EuiIcon>
                                 </button>
                               </EuiButtonIcon>

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
@@ -64,9 +64,20 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                         class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                         type="button"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                          />
+                        </svg>
                       </button>
                       <div
                         class="euiModal__flex"
@@ -205,9 +216,20 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                 class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                 type="button"
                               >
-                                <div>
-                                  EuiIconMock
-                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                  />
+                                </svg>
                               </button>
                               <div
                                 class="euiModal__flex"
@@ -278,9 +300,20 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                   class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                    />
+                                  </svg>
                                 </button>
                                 <div
                                   class="euiModal__flex"
@@ -351,9 +384,20 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                     type="button"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                      />
+                                    </svg>
                                   </button>
                                   <div
                                     class="euiModal__flex"
@@ -412,9 +456,20 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                       class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                       type="button"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                        />
+                                      </svg>
                                     </button>
                                     <div
                                       class="euiModal__flex"
@@ -513,9 +568,29 @@ exports[`ManageSenders renders when email is disallowed 1`] = `
                                     size="m"
                                     type="cross"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <EuiIconCross
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                        />
+                                      </svg>
+                                    </EuiIconCross>
                                   </EuiIcon>
                                 </button>
                               </EuiButtonIcon>
@@ -752,9 +827,16 @@ exports[`ManageSenders renders when visible 1`] = `
                         class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                         type="button"
                       >
-                        <div>
-                          EuiIconMock
-                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
                       </button>
                       <div
                         class="euiModal__flex"
@@ -893,9 +975,16 @@ exports[`ManageSenders renders when visible 1`] = `
                                 class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                 type="button"
                               >
-                                <div>
-                                  EuiIconMock
-                                </div>
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
                               </button>
                               <div
                                 class="euiModal__flex"
@@ -966,9 +1055,16 @@ exports[`ManageSenders renders when visible 1`] = `
                                   class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                   type="button"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  />
                                 </button>
                                 <div
                                   class="euiModal__flex"
@@ -1039,9 +1135,16 @@ exports[`ManageSenders renders when visible 1`] = `
                                     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                     type="button"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
                                   </button>
                                   <div
                                     class="euiModal__flex"
@@ -1100,9 +1203,16 @@ exports[`ManageSenders renders when visible 1`] = `
                                       class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
                                       type="button"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
                                     </button>
                                     <div
                                       class="euiModal__flex"
@@ -1201,9 +1311,25 @@ exports[`ManageSenders renders when visible 1`] = `
                                     size="m"
                                     type="cross"
                                   >
-                                    <div>
-                                      EuiIconMock
-                                    </div>
+                                    <EuiIconEmpty
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      />
+                                    </EuiIconEmpty>
                                   </EuiIcon>
                                 </button>
                               </EuiButtonIcon>

--- a/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
@@ -125,9 +125,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
               size="m"
               type="alert"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <EuiIconEmpty
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiCallOutHeader__icon"
+                focusable="false"
+                role="img"
+                style={null}
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiCallOutHeader__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                />
+              </EuiIconEmpty>
             </EuiIcon>
             <span
               className="euiCallOutHeader__title"
@@ -168,9 +184,27 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                           size="s"
                           type="popout"
                         >
-                          <div>
-                            EuiIconMock
-                          </div>
+                          <EuiIconEmpty
+                            aria-hidden={true}
+                            aria-label="External link"
+                            className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                            focusable="false"
+                            role="img"
+                            style={null}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-label="External link"
+                              className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </EuiIconEmpty>
                         </EuiIcon>
                       </a>
                     </EuiLink>
@@ -359,9 +393,30 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                                     size="m"
                                                     type="arrowDown"
                                                   >
-                                                    <div>
-                                                      EuiIconMock
-                                                    </div>
+                                                    <EuiIconArrowDown
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                                          fillRule="non-zero"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconArrowDown>
                                                   </EuiIcon>
                                                   <span
                                                     className="euiButton__text"
@@ -539,9 +594,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -669,9 +740,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -743,9 +830,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconEmpty
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </EuiIconEmpty>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -870,9 +973,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconEmpty
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </EuiIconEmpty>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -1089,9 +1208,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconEmpty
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  />
+                                                </EuiIconEmpty>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -1201,9 +1336,25 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconEmpty
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        />
+                                      </EuiIconEmpty>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>
@@ -1599,9 +1750,30 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
               size="m"
               type="alert"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <EuiIconAlert
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiCallOutHeader__icon"
+                focusable="false"
+                role="img"
+                style={null}
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiCallOutHeader__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7.59 10.059L7.35 5.18h1.3L8.4 10.06h-.81zm.394 1.901a.61.61 0 01-.448-.186.606.606 0 01-.186-.444c0-.174.062-.323.186-.446a.614.614 0 01.448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 01-.189.446.607.607 0 01-.437.184zM2 14a1 1 0 01-.878-1.479l6-11a1 1 0 011.756 0l6 11A1 1 0 0114 14H2zm0-1h12L8 2 2 13z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </EuiIconAlert>
             </EuiIcon>
             <span
               className="euiCallOutHeader__title"
@@ -1642,9 +1814,29 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                           size="s"
                           type="popout"
                         >
-                          <div>
-                            EuiIconMock
-                          </div>
+                          <EuiIconPopout
+                            aria-label="External link"
+                            className="euiIcon euiIcon--small euiLink__externalIcon"
+                            focusable="false"
+                            role="img"
+                            style={null}
+                          >
+                            <svg
+                              aria-label="External link"
+                              className="euiIcon euiIcon--small euiLink__externalIcon"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                              />
+                            </svg>
+                          </EuiIconPopout>
                         </EuiIcon>
                       </a>
                     </EuiLink>
@@ -1911,9 +2103,29 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSearch
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                          />
+                                        </svg>
+                                      </EuiIconSearch>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -2001,9 +2213,30 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconArrowDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                            fillRule="non-zero"
+                                          />
+                                        </svg>
+                                      </EuiIconArrowDown>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -2075,9 +2308,30 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowLeft
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M10.843 13.069L6.232 8.384a.546.546 0 010-.768l4.61-4.685a.552.552 0 000-.771.53.53 0 00-.759 0l-4.61 4.684a1.65 1.65 0 000 2.312l4.61 4.684a.53.53 0 00.76 0 .552.552 0 000-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowLeft>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -2202,9 +2456,30 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowRight
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.157 13.069l4.611-4.685a.546.546 0 000-.768L5.158 2.93a.552.552 0 010-.771.53.53 0 01.759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 01-.76 0 .552.552 0 010-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowRight>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -2421,9 +2696,30 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconArrowDown
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -2533,9 +2829,29 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSortDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M7 11.692V3.556C7 3.249 7.224 3 7.5 3s.5.249.5.556v8.136l4.096-4.096a.5.5 0 01.707.707l-4.242 4.243a1.494 1.494 0 01-.925.433.454.454 0 01-.272 0 1.494 1.494 0 01-.925-.433L2.197 8.303a.5.5 0 11.707-.707L7 11.692z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortDown>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>
@@ -2931,9 +3247,30 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
               size="m"
               type="alert"
             >
-              <div>
-                EuiIconMock
-              </div>
+              <EuiIconAlert
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiCallOutHeader__icon"
+                focusable="false"
+                role="img"
+                style={null}
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiCallOutHeader__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7.59 10.059L7.35 5.18h1.3L8.4 10.06h-.81zm.394 1.901a.61.61 0 01-.448-.186.606.606 0 01-.186-.444c0-.174.062-.323.186-.446a.614.614 0 01.448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 01-.189.446.607.607 0 01-.437.184zM2 14a1 1 0 01-.878-1.479l6-11a1 1 0 011.756 0l6 11A1 1 0 0114 14H2zm0-1h12L8 2 2 13z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </EuiIconAlert>
             </EuiIcon>
             <span
               className="euiCallOutHeader__title"
@@ -2974,9 +3311,29 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                           size="s"
                           type="popout"
                         >
-                          <div>
-                            EuiIconMock
-                          </div>
+                          <EuiIconPopout
+                            aria-label="External link"
+                            className="euiIcon euiIcon--small euiLink__externalIcon"
+                            focusable="false"
+                            role="img"
+                            style={null}
+                          >
+                            <svg
+                              aria-label="External link"
+                              className="euiIcon euiIcon--small euiLink__externalIcon"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                              />
+                            </svg>
+                          </EuiIconPopout>
                         </EuiIcon>
                       </a>
                     </EuiLink>
@@ -3249,9 +3606,29 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                       size="m"
                                       type="search"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSearch
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                          />
+                                        </svg>
+                                      </EuiIconSearch>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -3369,9 +3746,30 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                       size="m"
                                       type="arrowDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconArrowDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                            fillRule="non-zero"
+                                          />
+                                        </svg>
+                                      </EuiIconArrowDown>
                                     </EuiIcon>
                                   </span>
                                 </EuiFormControlLayoutCustomIcon>
@@ -3443,9 +3841,30 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                   size="m"
                                   type="arrowLeft"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowLeft
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M10.843 13.069L6.232 8.384a.546.546 0 010-.768l4.61-4.685a.552.552 0 000-.771.53.53 0 00-.759 0l-4.61 4.684a1.65 1.65 0 000 2.312l4.61 4.684a.53.53 0 00.76 0 .552.552 0 000-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowLeft>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -3570,9 +3989,30 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                   size="m"
                                   type="arrowRight"
                                 >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
+                                  <EuiIconArrowRight
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.157 13.069l4.611-4.685a.546.546 0 000-.768L5.158 2.93a.552.552 0 010-.771.53.53 0 01.759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 01-.76 0 .552.552 0 010-.771z"
+                                        fillRule="nonzero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowRight>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -3789,9 +4229,30 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                                 size="s"
                                                 type="arrowDown"
                                               >
-                                                <div>
-                                                  EuiIconMock
-                                                </div>
+                                                <EuiIconArrowDown
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
                                               </EuiIcon>
                                               <span
                                                 className="euiButtonEmpty__text"
@@ -3901,9 +4362,29 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                       size="m"
                                       type="sortDown"
                                     >
-                                      <div>
-                                        EuiIconMock
-                                      </div>
+                                      <EuiIconSortDown
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M7 11.692V3.556C7 3.249 7.224 3 7.5 3s.5.249.5.556v8.136l4.096-4.096a.5.5 0 01.707.707l-4.242 4.243a1.494 1.494 0 01-.925.433.454.454 0 01-.272 0 1.494 1.494 0 01-.925-.433L2.197 8.303a.5.5 0 11.707-.707L7 11.692z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortDown>
                                     </EuiIcon>
                                   </span>
                                 </CellContents>

--- a/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
+++ b/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
@@ -22,9 +22,16 @@ exports[`MonitorActions renders 1`] = `
           <span
             class="euiButtonContent euiButtonContent--iconRight euiButton__content"
           >
-            <div>
-              EuiIconMock
-            </div>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
             <span
               class="euiButton__text"
             >


### PR DESCRIPTION
### Description
1. Updated snapshots, and slightly refactored 1 unit test, following version bump to `node` and migration from EUI to OUI.
2. Enabled unit and cypress test workflows on all branches.
3. Adjusted OSD version used by unit and cypress test workflows to align with OSD's 2.x branch version.

Closing https://github.com/opensearch-project/alerting-dashboards-plugin/pull/309, and https://github.com/opensearch-project/alerting-dashboards-plugin/pull/310 in favor of this PR.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
