### PR TITLE
[Backport 2.x] Bumped moment version to resolve dependabot alert.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob-parent": "^5.1.2",
     "json-schema": "^0.4.0",
     "minimist": "^1.2.6",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "terser": "^4.8.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,10 +2971,10 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.6"
 
-moment@^2.29.1, moment@^2.29.2:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@^2.29.1, moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description
1. Backporting `moment` version bump commit published in https://github.com/opensearch-project/alerting-dashboards-plugin/pull/308.

Will be closing https://github.com/opensearch-project/alerting-dashboards-plugin/pull/312 and https://github.com/opensearch-project/alerting-dashboards-plugin/pull/313 in favor of this PR and its backport.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
