### PR TITLE
Fixed a bug that prevented the throttling settings from displaying for PER_ALERT bucket level trigger actions.

### DIFF
--- a/public/pages/CreateTrigger/components/Action/actions/Message.js
+++ b/public/pages/CreateTrigger/components/Action/actions/Message.js
@@ -172,6 +172,7 @@ export default function Message(
   switch (monitorType) {
     case MONITOR_TYPE.BUCKET_LEVEL:
       displayActionableAlertsOptions = true;
+      displayThrottlingSettings = actionExecutionScopeId === NOTIFY_OPTIONS_VALUES.PER_ALERT;
       actionableAlertsSelections = _.get(values, actionableAlertsSelectionsPath);
       break;
     case MONITOR_TYPE.DOC_LEVEL:
@@ -193,6 +194,8 @@ export default function Message(
       actionableAlertsSelections = DEFAULT_ACTIONABLE_ALERTS_SELECTIONS;
     _.set(values, actionableAlertsSelectionsPath, actionableAlertsSelections);
   }
+
+  if (!displayThrottlingSettings) _.set(values, `${actionPath}.throttle_enabled`, false);
 
   let preview = '';
   try {


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Fixed a bug that prevented the throttling settings from displaying for `PER_ALERT` bucket level trigger actions.
 
### Issues Resolved
[List any issues this PR will resolve]

### Screenshots
#### When `PER_ALERT` is selected.
![Screen Shot 2022-09-12 at 6 12 39 PM](https://user-images.githubusercontent.com/79280347/190261689-02aa79e0-652c-4626-a23f-709e7468101c.png)
#### When `PER_EXECUTION` is selected.
![Screen Shot 2022-09-12 at 6 12 44 PM](https://user-images.githubusercontent.com/79280347/190261693-bb50ecc1-0f4d-4502-be3d-001558d72474.png)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
