### PR TITLE
Backported 2.3 commits to main branch.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.2'
-  OPENSEARCH_VERSION: '2.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '2.2.1-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.2'
-  OPENSEARCH_VERSION: '2.2.1-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.3'
+  OPENSEARCH_VERSION: '2.3.0-SNAPSHOT'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "2.2.1.0",
-  "opensearchDashboardsVersion": "2.2.1",
+  "version": "2.3.0.0",
+  "opensearchDashboardsVersion": "2.3.0",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "2.2.0.0",
-  "opensearchDashboardsVersion": "2.2.0",
+  "version": "2.2.1.0",
+  "opensearchDashboardsVersion": "2.2.1",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "2.2.0.0",
+  "version": "2.2.1.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "2.2.1.0",
+  "version": "2.3.0.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/release-notes/opensearch-alerting-dashboards-plugin.release-notes-2.3.0.0.md
+++ b/release-notes/opensearch-alerting-dashboards-plugin.release-notes-2.3.0.0.md
@@ -1,0 +1,13 @@
+## Version 2.3.0.0 2022-09-08
+Compatible with OpenSearch Dashboards 2.3.0
+
+### Maintenance
+* Bumped moment version to resolve dependabot alert. ([#308](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/308))
+* Refactored dependency used by test mock. Adjusted OSD version used by test workflows. ([#318](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/318))
+* Bumped version to 2.3.0. ([#325](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/325))
+
+### Bug Fixes
+* Fixed snapshot-related unit tests. ([#311](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/311))
+
+### Documentation
+* Added 2.3 release notes. ([#326](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/326))


### PR DESCRIPTION
### Description
Bumped main branch to version 2.3. Closing https://github.com/opensearch-project/alerting-dashboards-plugin/pull/329 in favor of this PR.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
