### PR TITLE
Fixed an issue that was causing the results of the ctx object to be empty. 

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -44,18 +44,7 @@ class ConfigureTriggers extends React.Component {
   }
 
   componentDidMount() {
-    const {
-      monitor: { monitor_type },
-      monitorValues: { uri },
-    } = this.props;
-    switch (monitor_type) {
-      case MONITOR_TYPE.BUCKET_LEVEL:
-        this.onQueryMappings();
-        break;
-      case MONITOR_TYPE.CLUSTER_METRICS:
-        if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
-        break;
-    }
+    this.monitorSetupByType();
   }
 
   componentDidUpdate(prevProps) {
@@ -86,21 +75,23 @@ class ConfigureTriggers extends React.Component {
 
     const prevInputs = prevProps.monitor.inputs[0];
     const currInputs = this.props.monitor.inputs[0];
-    if (!_.isEqual(prevInputs, currInputs)) {
-      const {
-        monitor: { monitor_type },
-        monitorValues: { uri },
-      } = this.props;
-      switch (monitor_type) {
-        case MONITOR_TYPE.BUCKET_LEVEL:
-          this.onQueryMappings();
-          break;
-        case MONITOR_TYPE.CLUSTER_METRICS:
-          if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
-          break;
-      }
-    }
+    if (!_.isEqual(prevInputs, currInputs)) this.monitorSetupByType();
   }
+
+  monitorSetupByType = () => {
+    const {
+      monitor: { monitor_type },
+      monitorValues: { uri },
+    } = this.props;
+    switch (monitor_type) {
+      case MONITOR_TYPE.BUCKET_LEVEL:
+        this.onQueryMappings();
+        break;
+      case MONITOR_TYPE.CLUSTER_METRICS:
+        if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
+        break;
+    }
+  };
 
   prepareAddTriggerButton = () => {
     const { monitorValues, triggerArrayHelpers, triggerValues } = this.props;

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -17,8 +17,6 @@ import { getPathsPerDataType } from '../../../CreateMonitor/containers/DefineMon
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
 import { buildRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
 import { backendErrorNotification, inputLimitText } from '../../../../utils/helpers';
-import moment from 'moment';
-import { formikToTrigger } from '../CreateTrigger/utils/formikToTrigger';
 import DefineDocumentLevelTrigger from '../DefineDocumentLevelTrigger/DefineDocumentLevelTrigger';
 import {
   buildClusterMetricsRequest,
@@ -34,9 +32,6 @@ class ConfigureTriggers extends React.Component {
     this.state = {
       dataTypes: {},
       executeResponse: null,
-      isBucketLevelMonitor:
-        _.get(props, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL) ===
-        MONITOR_TYPE.BUCKET_LEVEL,
       triggerDeleted: false,
       addTriggerButton: this.prepareAddTriggerButton(),
       triggerEmptyPrompt: this.prepareTriggerEmptyPrompt(),
@@ -50,20 +45,20 @@ class ConfigureTriggers extends React.Component {
 
   componentDidMount() {
     const {
-      monitorValues: { searchType, uri },
+      monitor: { monitor_type },
+      monitorValues: { uri },
     } = this.props;
-    const { isBucketLevelMonitor } = this.state;
-    if (searchType === SEARCH_TYPE.CLUSTER_METRICS && canExecuteClusterMetricsMonitor(uri))
-      this.onRunExecute();
-    if (isBucketLevelMonitor) this.onQueryMappings();
+    switch (monitor_type) {
+      case MONITOR_TYPE.BUCKET_LEVEL:
+        this.onQueryMappings();
+        break;
+      case MONITOR_TYPE.CLUSTER_METRICS:
+        if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
+        break;
+    }
   }
 
   componentDidUpdate(prevProps) {
-    const prevMonitorType = _.get(prevProps, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
-    const currMonitorType = _.get(this.props, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
-    if (prevMonitorType !== currMonitorType)
-      _.set(this.state, 'isBucketLevelMonitor', currMonitorType === MONITOR_TYPE.BUCKET_LEVEL);
-
     const prevSearchType = _.get(
       prevProps,
       'monitorValues.searchType',
@@ -92,8 +87,18 @@ class ConfigureTriggers extends React.Component {
     const prevInputs = prevProps.monitor.inputs[0];
     const currInputs = this.props.monitor.inputs[0];
     if (!_.isEqual(prevInputs, currInputs)) {
-      const { isBucketLevelMonitor } = this.state;
-      if (isBucketLevelMonitor) this.onQueryMappings();
+      const {
+        monitor: { monitor_type },
+        monitorValues: { uri },
+      } = this.props;
+      switch (monitor_type) {
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          this.onQueryMappings();
+          break;
+        case MONITOR_TYPE.CLUSTER_METRICS:
+          if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
+          break;
+      }
     }
   }
 
@@ -186,18 +191,6 @@ class ConfigureTriggers extends React.Component {
     }
   }
 
-  getTriggerContext = (executeResponse, monitor, values) => {
-    return {
-      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).format(),
-      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).format(),
-      results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
-      trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
-      alert: null,
-      error: null,
-      monitor: monitor,
-    };
-  };
-
   renderDefineTrigger = (triggerArrayHelpers, index) => {
     const {
       edit,
@@ -212,13 +205,11 @@ class ConfigureTriggers extends React.Component {
       notificationService,
       plugins,
     } = this.props;
-
     const { executeResponse } = this.state;
     return (
       <DefineTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}
@@ -255,7 +246,6 @@ class ConfigureTriggers extends React.Component {
       <DefineBucketLevelTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}
@@ -293,7 +283,6 @@ class ConfigureTriggers extends React.Component {
       <DefineDocumentLevelTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -17,8 +17,6 @@ import { getPathsPerDataType } from '../../../CreateMonitor/containers/DefineMon
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
 import { buildRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
 import { backendErrorNotification, inputLimitText } from '../../../../utils/helpers';
-import moment from 'moment';
-import { formikToTrigger } from '../CreateTrigger/utils/formikToTrigger';
 import DefineDocumentLevelTrigger from '../DefineDocumentLevelTrigger/DefineDocumentLevelTrigger';
 import {
   buildClusterMetricsRequest,
@@ -34,9 +32,6 @@ class ConfigureTriggers extends React.Component {
     this.state = {
       dataTypes: {},
       executeResponse: null,
-      isBucketLevelMonitor:
-        _.get(props, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL) ===
-        MONITOR_TYPE.BUCKET_LEVEL,
       triggerDeleted: false,
       addTriggerButton: this.prepareAddTriggerButton(),
       triggerEmptyPrompt: this.prepareTriggerEmptyPrompt(),
@@ -50,20 +45,20 @@ class ConfigureTriggers extends React.Component {
 
   componentDidMount() {
     const {
-      monitorValues: { searchType, uri },
+      monitor: { monitor_type },
+      monitorValues: { uri },
     } = this.props;
-    const { isBucketLevelMonitor } = this.state;
-    if (searchType === SEARCH_TYPE.CLUSTER_METRICS && canExecuteClusterMetricsMonitor(uri))
-      this.onRunExecute();
-    if (isBucketLevelMonitor) this.onQueryMappings();
+    switch (monitor_type) {
+      case MONITOR_TYPE.BUCKET_LEVEL:
+        this.onQueryMappings();
+        break;
+      case MONITOR_TYPE.CLUSTER_METRICS:
+        if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
+        break;
+    }
   }
 
   componentDidUpdate(prevProps) {
-    const prevMonitorType = _.get(prevProps, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
-    const currMonitorType = _.get(this.props, 'monitor.monitor_type', MONITOR_TYPE.QUERY_LEVEL);
-    if (prevMonitorType !== currMonitorType)
-      _.set(this.state, 'isBucketLevelMonitor', currMonitorType === MONITOR_TYPE.BUCKET_LEVEL);
-
     const prevSearchType = _.get(
       prevProps,
       'monitorValues.searchType',
@@ -92,8 +87,18 @@ class ConfigureTriggers extends React.Component {
     const prevInputs = prevProps.monitor.inputs[0];
     const currInputs = this.props.monitor.inputs[0];
     if (!_.isEqual(prevInputs, currInputs)) {
-      const { isBucketLevelMonitor } = this.state;
-      if (isBucketLevelMonitor) this.onQueryMappings();
+      const {
+        monitor: { monitor_type },
+        monitorValues: { uri },
+      } = this.props;
+      switch (monitor_type) {
+        case MONITOR_TYPE.BUCKET_LEVEL:
+          this.onQueryMappings();
+          break;
+        case MONITOR_TYPE.CLUSTER_METRICS:
+          if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
+          break;
+      }
     }
   }
 
@@ -131,7 +136,7 @@ class ConfigureTriggers extends React.Component {
       case SEARCH_TYPE.QUERY:
       case SEARCH_TYPE.GRAPH:
         const searchRequest = buildRequest(formikValues);
-        _.set(monitorToExecute, 'inputs[0].search', searchRequest);
+        _.set(monitorToExecute, 'inputs[0]', searchRequest);
         break;
       case SEARCH_TYPE.CLUSTER_METRICS:
         const clusterMetricsRequest = buildClusterMetricsRequest(formikValues);
@@ -186,18 +191,6 @@ class ConfigureTriggers extends React.Component {
     }
   }
 
-  getTriggerContext = (executeResponse, monitor, values) => {
-    return {
-      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).format(),
-      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).format(),
-      results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
-      trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
-      alert: null,
-      error: null,
-      monitor: monitor,
-    };
-  };
-
   renderDefineTrigger = (triggerArrayHelpers, index) => {
     const {
       edit,
@@ -212,13 +205,11 @@ class ConfigureTriggers extends React.Component {
       notificationService,
       plugins,
     } = this.props;
-
     const { executeResponse } = this.state;
     return (
       <DefineTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}
@@ -255,7 +246,6 @@ class ConfigureTriggers extends React.Component {
       <DefineBucketLevelTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}
@@ -293,7 +283,6 @@ class ConfigureTriggers extends React.Component {
       <DefineDocumentLevelTrigger
         edit={edit}
         triggerArrayHelpers={triggerArrayHelpers}
-        context={this.getTriggerContext(executeResponse, monitor, triggerValues)}
         executeResponse={executeResponse}
         monitor={monitor}
         monitorValues={monitorValues}

--- a/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger.js
@@ -21,6 +21,7 @@ import { FieldArray } from 'formik';
 import ConfigureActions from '../ConfigureActions';
 import { inputLimitText } from '../../../../utils/helpers';
 import { DEFAULT_TRIGGER_NAME, SEVERITY_OPTIONS } from '../../utils/constants';
+import { getTriggerContext } from '../../utils/helper';
 
 const defaultRowProps = {
   label: 'Trigger name',
@@ -49,7 +50,6 @@ const selectInputProps = {
 };
 
 const propTypes = {
-  context: PropTypes.object.isRequired,
   executeResponse: PropTypes.object,
   monitorValues: PropTypes.object.isRequired,
   onRun: PropTypes.func.isRequired,
@@ -205,7 +205,6 @@ class DefineBucketLevelTrigger extends Component {
     const {
       edit,
       triggerArrayHelpers,
-      context,
       executeResponse,
       monitor,
       monitorValues,
@@ -222,6 +221,7 @@ class DefineBucketLevelTrigger extends Component {
       plugins,
     } = this.props;
     const fieldPath = triggerIndex !== undefined ? `triggerDefinitions[${triggerIndex}].` : '';
+    const context = getTriggerContext(executeResponse, monitor, triggerValues, triggerIndex);
     const isGraph = _.get(monitorValues, 'searchType') === SEARCH_TYPE.GRAPH;
     const response = _.get(executeResponse, 'input_results.results[0]');
     const triggerName = _.get(triggerValues, `${fieldPath}name`, DEFAULT_TRIGGER_NAME);

--- a/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineDocumentLevelTrigger/DefineDocumentLevelTrigger.js
@@ -30,6 +30,7 @@ import DocumentLevelTriggerExpression from './DocumentLevelTriggerExpression';
 import { backendErrorNotification, inputLimitText } from '../../../../utils/helpers';
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
 import { buildRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
+import { getTriggerContext } from '../../utils/helper';
 
 const MAX_TRIGGER_CONDITIONS = 10;
 
@@ -58,7 +59,6 @@ const selectInputProps = {
 };
 
 const propTypes = {
-  context: PropTypes.object.isRequired,
   executeResponse: PropTypes.object,
   monitorValues: PropTypes.object.isRequired,
   onRun: PropTypes.func.isRequired,
@@ -166,7 +166,6 @@ class DefineDocumentLevelTrigger extends Component {
     const {
       edit,
       triggerArrayHelpers,
-      context,
       monitor,
       monitorValues,
       onRun,
@@ -181,6 +180,7 @@ class DefineDocumentLevelTrigger extends Component {
       plugins,
     } = this.props;
     const executeResponse = _.get(this.state, 'executeResponse', this.props.executeResponse);
+    const context = getTriggerContext(executeResponse, monitor, triggerValues, triggerIndex);
     const fieldPath = triggerIndex !== undefined ? `triggerDefinitions[${triggerIndex}].` : '';
     const isGraph = _.get(monitorValues, 'searchType') === SEARCH_TYPE.GRAPH;
     const response = _.get(executeResponse, 'input_results.results[0]');

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -26,6 +26,7 @@ import {
   canExecuteClusterMetricsMonitor,
 } from '../../../CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers';
 import { DEFAULT_TRIGGER_NAME, SEVERITY_OPTIONS } from '../../utils/constants';
+import { getTriggerContext } from '../../utils/helper';
 
 const defaultRowProps = {
   label: 'Trigger name',
@@ -59,7 +60,6 @@ const selectInputProps = {
 };
 
 const propTypes = {
-  context: PropTypes.object.isRequired,
   executeResponse: PropTypes.object,
   monitorValues: PropTypes.object.isRequired,
   onRun: PropTypes.func.isRequired,
@@ -134,7 +134,7 @@ class DefineTrigger extends Component {
     const {
       edit,
       triggerArrayHelpers,
-      context,
+      monitor,
       monitorValues,
       onRun,
       setFlyout,
@@ -148,6 +148,7 @@ class DefineTrigger extends Component {
       plugins,
     } = this.props;
     const executeResponse = _.get(this.state, 'executeResponse', this.props.executeResponse);
+    const context = getTriggerContext(executeResponse, monitor, triggerValues, triggerIndex);
     const fieldPath = triggerIndex !== undefined ? `triggerDefinitions[${triggerIndex}].` : '';
     const isGraph = _.get(monitorValues, 'searchType') === SEARCH_TYPE.GRAPH;
     const isAd = _.get(monitorValues, 'searchType') === SEARCH_TYPE.AD;

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -15,6 +15,8 @@ import {
   FORMIK_INITIAL_DOC_LEVEL_SCRIPT,
   FORMIK_INITIAL_TRIGGER_VALUES,
 } from '../containers/CreateTrigger/utils/constants';
+import moment from 'moment';
+import { formikToTrigger } from '../containers/CreateTrigger/utils/formikToTrigger';
 
 export const getChannelOptions = (channels, allowedTypes) =>
   allowedTypes.map((type) => ({
@@ -45,4 +47,18 @@ export const getDefaultScript = (monitorValues) => {
     default:
       return FORMIK_INITIAL_TRIGGER_VALUES.script;
   }
+};
+
+export const getTriggerContext = (executeResponse, monitor, values, triggerIndex) => {
+  let trigger = formikToTrigger(values, _.get(monitor, 'ui_metadata', {}));
+  if (_.isArray(trigger) && triggerIndex >= 0) trigger = trigger[triggerIndex];
+  return {
+    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).format(),
+    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).format(),
+    results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
+    trigger: trigger,
+    alert: null,
+    error: null,
+    monitor: monitor,
+  };
 };


### PR DESCRIPTION
### Description
1. Fixed an issue that was causing the results of the ctx object to be empty when viewing the available `ctx` variables in the Trigger condition `Info` flyout. 
2. Fixed an issue that was causing variables like `ctx.trigger.name` to not populate in the message preview.

### Known issues
1. ~~https://github.com/opensearch-project/alerting-dashboards-plugin/issues/333 describes an issue that's causing the `ctx.monitor.schedule.period.interval` and `ctx.monitor.schedule.period.unit` to be blank when the notification is sent to the webhook. This is still under investigation. The message preview in the UI **does** show those values, suggesting this may be a backend issue.~~ As discussed in issue https://github.com/opensearch-project/alerting-dashboards-plugin/issues/333, this known issue results from the backend, and there is a PR published to address it.

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/152
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/333

### Screenshots
![Screen Shot 2022-09-28 at 9 03 33 PM](https://user-images.githubusercontent.com/79280347/193072003-dfbf14fd-e626-4308-9d4c-60ea36a24d15.png)
![Screen Shot 2022-09-28 at 9 04 09 PM](https://user-images.githubusercontent.com/79280347/193072011-cecd4dfa-3418-47b1-8d92-7979580cd39c.png)
![Screen Shot 2022-09-28 at 9 06 36 PM](https://user-images.githubusercontent.com/79280347/193072015-5b1bcba6-5d0c-48b4-81d7-cb6d62446824.png)
![Screen Shot 2022-09-28 at 9 08 06 PM](https://user-images.githubusercontent.com/79280347/193072021-a7757d62-b3ff-4d9d-8599-bf9242df5b35.png)
![Screen Shot 2022-09-28 at 9 11 12 PM](https://user-images.githubusercontent.com/79280347/193072024-f230bc93-c02f-4311-8bad-50a7bd7423e9.png)
![Screen Shot 2022-09-28 at 9 12 57 PM](https://user-images.githubusercontent.com/79280347/193072025-12fd4078-d7c4-4ce6-b8fa-94cfba406562.png)
![Screen Shot 2022-09-28 at 9 13 27 PM](https://user-images.githubusercontent.com/79280347/193072030-45bd1276-2c96-48cb-8244-2ed7599bc7ec.png)
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
