### PR TITLE
bug/alerting-action-preview

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -141,7 +141,6 @@ class ConfigureTriggers extends React.Component {
         console.log(`Unsupported searchType found: ${JSON.stringify(searchType)}`, searchType);
     }
 
-    // compare the body here to that in define mnitor
     httpClient
       .post('../api/alerting/monitors/_execute', { body: JSON.stringify(monitorToExecute) })
       .then((resp) => {

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -131,7 +131,7 @@ class ConfigureTriggers extends React.Component {
       case SEARCH_TYPE.QUERY:
       case SEARCH_TYPE.GRAPH:
         const searchRequest = buildRequest(formikValues);
-        _.set(monitorToExecute, 'inputs[0].search', searchRequest);
+        _.set(monitorToExecute, 'inputs[0]', searchRequest);
         break;
       case SEARCH_TYPE.CLUSTER_METRICS:
         const clusterMetricsRequest = buildClusterMetricsRequest(formikValues);
@@ -141,6 +141,7 @@ class ConfigureTriggers extends React.Component {
         console.log(`Unsupported searchType found: ${JSON.stringify(searchType)}`, searchType);
     }
 
+    // compare the body here to that in define mnitor
     httpClient
       .post('../api/alerting/monitors/_execute', { body: JSON.stringify(monitorToExecute) })
       .then((resp) => {

--- a/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/DefineTrigger.js
@@ -81,12 +81,14 @@ class DefineTrigger extends Component {
   componentDidMount() {
     const {
       monitorValues: { searchType, uri },
+      onRun,
     } = this.props;
     switch (searchType) {
       case SEARCH_TYPE.CLUSTER_METRICS:
         if (canExecuteClusterMetricsMonitor(uri)) this.onRunExecute();
         break;
       default:
+        onRun();
         this.onRunExecute();
     }
   }


### PR DESCRIPTION
Signed-off-by: David Sinclair <dsincla@rei.com>

### Description
- Fixes how the alert query response is saved, so it is stored in the same way as the DefineMonitor component here: `public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js`
- In `componentDidMount` of DefineTrigger, also run the `onRun` method to get the `context` saved from the upper `ConfigureActions` component, which is the same `context` used to display preview messages.
 
### Issues Resolved
This will hopefully resolve https://github.com/opensearch-project/alerting-dashboards-plugin/issues/152 -- note, the correct use of Mustache template for the issue in the ticket would be like this:

```
{{#ctx.results.0.hits.hits.0}}
{{_source.agent}}
{{/ctx.results.0.hits.hits.0}}
```
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
