### PR TITLE
Fix confidence bug

### DIFF
--- a/server/services/utils/__tests__/adHelpers.test.js
+++ b/server/services/utils/__tests__/adHelpers.test.js
@@ -72,7 +72,7 @@ describe('helpers', () => {
             dataStartTime: 1587929940000,
             dataEndTime: 1587930000000,
             anomalyGrade: 0,
-            confidence: 0,
+            confidence: '0.99',
             plotTime: 1587929970000,
           },
           {
@@ -80,7 +80,7 @@ describe('helpers', () => {
             dataStartTime: 1587930420000,
             dataEndTime: 1587930480000,
             anomalyGrade: 0,
-            confidence: 0,
+            confidence: '0.99',
             plotTime: 1587930450000,
           },
         ],

--- a/server/services/utils/adHelpers.js
+++ b/server/services/utils/adHelpers.js
@@ -22,7 +22,7 @@ export const anomalyResultMapper = (anomalyResults) => {
           ? Number.parseFloat(rest.anomalyGrade).toFixed(2)
           : 0,
       confidence:
-        rest.anomalyGrade != null && rest.anomalyGrade > 0
+        rest.confidence != null && rest.confidence > 0
           ? Number.parseFloat(rest.confidence).toFixed(2)
           : 0,
       plotTime: rest.dataStartTime + Math.floor((rest.dataEndTime - rest.dataStartTime) / 2),


### PR DESCRIPTION
### Description
This PR fixed a bug when showing confidence in trigger definition. Confidence is usually a non-decreasing function on an interval. Previously we incorrectly showed confidence only when the corresponding anomaly grade is larger than 0.

Testing done:
1. manually tested that the bug is fixed. See attached snapshots.
2. yarn test:jest

Before the fix:

![Screen Shot 2022-11-05 at 6 38 52 PM](https://user-images.githubusercontent.com/5303417/200383972-9f0a0ff0-c12d-4f78-adb5-12fdc6f2d93f.png)

After the fix:
![Screen Shot 2022-11-05 at 6 35 32 PM](https://user-images.githubusercontent.com/5303417/200384015-6035e849-5a51-4428-8040-c92493c00952.png)

Signed-off-by: Kaituo Li <kaituo@amazon.com>
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
