### PR TITLE
Align all flyout components to be overlay kind and add close button X in header

### DIFF
--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -19,9 +19,10 @@ Object {
     justifyContent="flexStart"
   >
     <EuiFlexItem
-      className="eui-xScrollWithShadows"
+      className="eui-textTruncate"
     >
       <EuiTitle
+        className="eui-textTruncate"
         data-test-subj="alertsDashboardFlyout_header_undefined"
         size="m"
       >

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -19,19 +19,13 @@ Object {
     justifyContent="flexStart"
   >
     <EuiFlexItem>
-      <EuiFlexGroup
-        alignItems="center"
+      <EuiTitle
+        size="m"
       >
-        <EuiFlexItem>
-          <EuiTitle
-            size="m"
-          >
-            <h3>
-              Alerts by undefined
-            </h3>
-          </EuiTitle>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+        <h3>
+          Alerts by undefined
+        </h3>
+      </EuiTitle>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -9,31 +9,40 @@ Object {
     "hideCloseButton": true,
     "size": "m",
   },
-  "footer": <EuiButtonEmpty
-    data-test-subj="alertsDashboardFlyout_closeButton_undefined"
-    iconType="cross"
-    onClick={[Function]}
-    style={
-      Object {
-        "marginLeft": "0px",
-        "paddingLeft": "0px",
-      }
-    }
-  >
-    Close
-  </EuiButtonEmpty>,
   "footerProps": Object {
     "style": Object {
       "backgroundColor": "#F5F7FA",
     },
   },
-  "header": <EuiText
-    data-test-subj="alertsDashboardFlyout_header_undefined"
+  "header": <EuiFlexGroup
+    alignItems="center"
+    justifyContent="flexStart"
   >
-    <h2>
-      Alerts by undefined
-    </h2>
-  </EuiText>,
+    <EuiFlexItem>
+      <EuiFlexGroup
+        alignItems="center"
+      >
+        <EuiFlexItem>
+          <EuiTitle
+            size="m"
+          >
+            <h3>
+              Alerts by undefined
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiButtonIcon
+        display="empty"
+        iconSize="m"
+        iconType="cross"
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>,
   "headerProps": Object {
     "hasBorder": true,
   },

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -18,8 +18,11 @@ Object {
     alignItems="center"
     justifyContent="flexStart"
   >
-    <EuiFlexItem>
+    <EuiFlexItem
+      className="eui-xScrollWithShadows"
+    >
       <EuiTitle
+        data-test-subj="alertsDashboardFlyout_header_undefined"
         size="m"
       >
         <h3>
@@ -31,6 +34,7 @@ Object {
       grow={false}
     >
       <EuiButtonIcon
+        data-test-subj="alertsDashboardFlyout_closeButton_undefined"
         display="empty"
         iconSize="m"
         iconType="cross"

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -8,7 +8,6 @@ Object {
     "data-test-subj": "alertsDashboardFlyout_undefined",
     "hideCloseButton": true,
     "size": "m",
-    "type": "push",
   },
   "footer": <EuiButtonEmpty
     data-test-subj="alertsDashboardFlyout_closeButton_undefined"

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -4,15 +4,7 @@
  */
 
 import React from 'react';
-import {
-  EuiButtonEmpty,
-  EuiText,
-  EuiFlexGroup,
-  EuiButtonIcon,
-  EuiTitle,
-  EuiFlexItem,
-  EuiButton,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiButtonIcon, EuiTitle, EuiFlexItem } from '@elastic/eui';
 import AlertsDashboardFlyoutComponent from './components/AlertsDashboardFlyoutComponent';
 
 const alertsDashboard = (payload) => {
@@ -28,13 +20,9 @@ const alertsDashboard = (payload) => {
     header: (
       <EuiFlexGroup justifyContent="flexStart" alignItems="center">
         <EuiFlexItem>
-          <EuiFlexGroup alignItems="center">
-            <EuiFlexItem>
-              <EuiTitle size={'m'}>
-                <h3>{`Alerts by ${trigger_name}`}</h3>
-              </EuiTitle>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiTitle size={'m'}>
+            <h3>{`Alerts by ${trigger_name}`}</h3>
+          </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonIcon iconType="cross" display="empty" iconSize="m" onClick={closeFlyout} />

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -19,8 +19,12 @@ const alertsDashboard = (payload) => {
     headerProps: { hasBorder: true },
     header: (
       <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-        <EuiFlexItem className="eui-xScrollWithShadows">
-          <EuiTitle size={'m'} data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}>
+        <EuiFlexItem className="eui-textTruncate">
+          <EuiTitle
+            className="eui-textTruncate"
+            size={'m'}
+            data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}
+          >
             <h3>{`Alerts by ${trigger_name}`}</h3>
           </EuiTitle>
         </EuiFlexItem>

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -19,13 +19,19 @@ const alertsDashboard = (payload) => {
     headerProps: { hasBorder: true },
     header: (
       <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-        <EuiFlexItem>
+        <EuiFlexItem className="eui-xScrollWithShadows">
           <EuiTitle size={'m'} data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}>
             <h3>{`Alerts by ${trigger_name}`}</h3>
           </EuiTitle>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon iconType="cross" display="empty" iconSize="m" onClick={closeFlyout} />
+          <EuiButtonIcon
+            data-test-subj={`alertsDashboardFlyout_closeButton_${trigger_name}`}
+            iconType="cross"
+            display="empty"
+            iconSize="m"
+            onClick={closeFlyout}
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     ),

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -20,7 +20,7 @@ const alertsDashboard = (payload) => {
     header: (
       <EuiFlexGroup justifyContent="flexStart" alignItems="center">
         <EuiFlexItem>
-          <EuiTitle size={'m'}>
+          <EuiTitle size={'m'} data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}>
             <h3>{`Alerts by ${trigger_name}`}</h3>
           </EuiTitle>
         </EuiFlexItem>

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -15,7 +15,6 @@ const alertsDashboard = (payload) => {
       size: 'm',
       hideCloseButton: true,
       'data-test-subj': `alertsDashboardFlyout_${trigger_name}`,
-      type: 'push',
     },
     headerProps: { hasBorder: true },
     header: (

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -4,7 +4,15 @@
  */
 
 import React from 'react';
-import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import {
+  EuiButtonEmpty,
+  EuiText,
+  EuiFlexGroup,
+  EuiButtonIcon,
+  EuiTitle,
+  EuiFlexItem,
+  EuiButton,
+} from '@elastic/eui';
 import AlertsDashboardFlyoutComponent from './components/AlertsDashboardFlyoutComponent';
 
 const alertsDashboard = (payload) => {
@@ -18,21 +26,22 @@ const alertsDashboard = (payload) => {
     },
     headerProps: { hasBorder: true },
     header: (
-      <EuiText data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}>
-        <h2>{`Alerts by ${trigger_name}`}</h2>
-      </EuiText>
+      <EuiFlexGroup justifyContent="flexStart" alignItems="center">
+        <EuiFlexItem>
+          <EuiFlexGroup alignItems="center">
+            <EuiFlexItem>
+              <EuiTitle size={'m'}>
+                <h3>{`Alerts by ${trigger_name}`}</h3>
+              </EuiTitle>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon iconType="cross" display="empty" iconSize="m" onClick={closeFlyout} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     ),
     footerProps: { style: { backgroundColor: '#F5F7FA' } },
-    footer: (
-      <EuiButtonEmpty
-        iconType={'cross'}
-        onClick={() => closeFlyout()}
-        style={{ paddingLeft: '0px', marginLeft: '0px' }}
-        data-test-subj={`alertsDashboardFlyout_closeButton_${trigger_name}`}
-      >
-        Close
-      </EuiButtonEmpty>
-    ),
     body: <AlertsDashboardFlyoutComponent {...payload} />,
   };
 };

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -361,7 +361,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
           columns.splice(
             0,
             0,
-            getAlertsFindingColumn(httpClient, history, true, location, notifications)
+            getAlertsFindingColumn(httpClient, history, location, notifications)
           );
           break;
         default:

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -286,6 +286,7 @@ export default class CreateMonitor extends Component {
                 plugins={plugins}
                 isAd={values.searchType === SEARCH_TYPE.AD}
                 detectorId={this.props.detectorId}
+                setFlyout={this.props.setFlyout}
               />
               <EuiSpacer />
 

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -352,7 +352,6 @@ export default class AcknowledgeAlertsModal extends Component {
             getAlertsFindingColumn(
               httpClient,
               history,
-              false,
               location,
               notifications,
               flyoutIsOpen,

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -6,13 +6,11 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
 import {
-  EuiButtonEmpty,
   EuiCodeBlock,
   EuiFlexGrid,
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
-  EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiHorizontalRule,
   EuiLink,
@@ -110,13 +108,9 @@ export default class FindingFlyout extends Component {
         <EuiFlyoutHeader hasBorder>
           <EuiFlexGroup justifyContent="flexStart" alignItems="center">
             <EuiFlexItem>
-              <EuiFlexGroup alignItems="center">
-                <EuiFlexItem>
-                  <EuiTitle size={'m'}>
-                    <h3 id={findingId || `temp_finding_${docId}`}>Document finding</h3>
-                  </EuiTitle>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              <EuiTitle size={'m'}>
+                <h3 id={findingId || `temp_finding_${docId}`}>Document finding</h3>
+              </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButtonIcon

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -70,10 +70,16 @@ export default class FindingFlyout extends Component {
 
   closeFlyout = () => {
     this.setState({ isFlyoutOpen: false });
+
+    const { dashboardFlyoutIsOpen = false, closeFlyout } = this.props;
+
+    if (typeof closeFlyout === 'function') {
+      if (dashboardFlyoutIsOpen) closeFlyout();
+    }
   };
 
   async renderFlyout() {
-    const { alert, isAlertsFlyout = false } = this.props;
+    const { alert } = this.props;
     if (!_.isEmpty(alert)) await this.getFinding();
 
     const { docList, finding } = this.state;
@@ -93,9 +99,8 @@ export default class FindingFlyout extends Component {
 
     const flyout = (
       <EuiFlyout
-        type={isAlertsFlyout ? 'overlay' : 'push'}
         onClose={this.closeFlyout}
-        ownFocus={false}
+        ownFocus={true}
         hideCloseButton={true}
         side={'right'}
         size={'m'}

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -18,6 +18,8 @@ import {
   EuiLink,
   EuiText,
   EuiTitle,
+  EuiFlexGroup,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { getFindings } from './findingsUtils';
 import { DEFAULT_GET_FINDINGS_PARAMS } from '../../../../../server/services/FindingService';
@@ -106,9 +108,25 @@ export default class FindingFlyout extends Component {
         size={'m'}
       >
         <EuiFlyoutHeader hasBorder>
-          <EuiTitle size={'m'}>
-            <h2 id={findingId || `temp_finding_${docId}`}>Document finding</h2>
-          </EuiTitle>
+          <EuiFlexGroup justifyContent="flexStart" alignItems="center">
+            <EuiFlexItem>
+              <EuiFlexGroup alignItems="center">
+                <EuiFlexItem>
+                  <EuiTitle size={'m'}>
+                    <h3 id={findingId || `temp_finding_${docId}`}>Document finding</h3>
+                  </EuiTitle>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonIcon
+                iconType="cross"
+                display="empty"
+                iconSize="m"
+                onClick={this.closeFlyout}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlyoutHeader>
 
         <EuiFlyoutBody>
@@ -162,16 +180,6 @@ export default class FindingFlyout extends Component {
             {JSON.stringify(documentDisplay, null, 3)}
           </EuiCodeBlock>
         </EuiFlyoutBody>
-
-        <EuiFlyoutFooter>
-          <EuiButtonEmpty
-            iconType={'cross'}
-            onClick={this.closeFlyout}
-            style={{ paddingLeft: '0px', marginLeft: '0px' }}
-          >
-            Close
-          </EuiButtonEmpty>
-        </EuiFlyoutFooter>
       </EuiFlyout>
     );
     this.setState({ flyout: flyout });

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -107,7 +107,7 @@ export default class FindingFlyout extends Component {
       >
         <EuiFlyoutHeader hasBorder>
           <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-            <EuiFlexItem>
+            <EuiFlexItem className="eui-xScrollWithShadows">
               <EuiTitle size={'m'}>
                 <h3 id={findingId || `temp_finding_${docId}`}>Document finding</h3>
               </EuiTitle>

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -107,8 +107,8 @@ export default class FindingFlyout extends Component {
       >
         <EuiFlyoutHeader hasBorder>
           <EuiFlexGroup justifyContent="flexStart" alignItems="center">
-            <EuiFlexItem className="eui-xScrollWithShadows">
-              <EuiTitle size={'m'}>
+            <EuiFlexItem className="eui-textTruncate">
+              <EuiTitle size={'m'} className="eui-textTruncate">
                 <h3 id={findingId || `temp_finding_${docId}`}>Document finding</h3>
               </EuiTitle>
             </EuiFlexItem>

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -73,8 +73,8 @@ export default class FindingFlyout extends Component {
 
     const { dashboardFlyoutIsOpen = false, closeFlyout } = this.props;
 
-    if (typeof closeFlyout === 'function') {
-      if (dashboardFlyoutIsOpen) closeFlyout();
+    if (typeof closeFlyout === 'function' && dashboardFlyoutIsOpen) {
+      closeFlyout();
     }
   };
 

--- a/public/pages/Dashboard/components/FindingsDashboard/findingsUtils.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/findingsUtils.js
@@ -41,7 +41,6 @@ export const ALERTS_FINDING_COLUMN = {
 export const getAlertsFindingColumn = (
   httpClient,
   history,
-  isAlertsFlyout = false,
   location,
   notifications,
   flyoutIsOpen,
@@ -58,7 +57,6 @@ export const getAlertsFindingColumn = (
         console.log('Alerts index contains an entry with 0 related document IDs:', alert);
       return (
         <FindingFlyout
-          isAlertsFlyout={isAlertsFlyout}
           alert={alert}
           httpClient={httpClient}
           history={history}

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -392,7 +392,6 @@ export default class Dashboard extends Component {
             getAlertsFindingColumn(
               httpClient,
               history,
-              false,
               location,
               notifications,
               flyoutIsOpen,

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -262,6 +262,7 @@ export default class MonitorDetails extends Component {
       history,
       httpClient,
       notifications,
+      setFlyout,
     } = this.props;
     const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID, undefined);
     const groupBy = _.get(monitor, MONITOR_GROUP_BY);
@@ -277,6 +278,7 @@ export default class MonitorDetails extends Component {
         monitorType={monitor.monitor_type}
         perAlertView={true}
         groupBy={groupBy}
+        setFlyout={setFlyout}
       />
     );
   };
@@ -344,6 +346,7 @@ export default class MonitorDetails extends Component {
       httpClient,
       notifications,
       isDarkMode,
+      setFlyout,
     } = this.props;
     const { action } = queryString.parse(location.search);
     const updatingMonitor = action === MONITOR_ACTIONS.UPDATE_MONITOR;
@@ -365,6 +368,7 @@ export default class MonitorDetails extends Component {
           monitorToEdit={monitor}
           detectorId={detectorId}
           notifications={notifications}
+          setFlyout={setFlyout}
           {...this.props}
         />
       );


### PR DESCRIPTION
### Description
Refactored all `Flyout's` to be as `type="overlay"` (default type value)
 
### Issues Resolved
Resolves #296 #297 #298 #299 #300 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
