### PR TITLE
Avoid nesting search inside search when executing trigger condition for preview during create monitor

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -131,7 +131,7 @@ class ConfigureTriggers extends React.Component {
       case SEARCH_TYPE.QUERY:
       case SEARCH_TYPE.GRAPH:
         const searchRequest = buildRequest(formikValues);
-        _.set(monitorToExecute, 'inputs[0].search', searchRequest);
+        _.set(monitorToExecute, 'inputs[0]', searchRequest);
         break;
       case SEARCH_TYPE.CLUSTER_METRICS:
         const clusterMetricsRequest = buildClusterMetricsRequest(formikValues);


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
The payload sent for triggering condition for preview during create monitor wraps the search field inside an extra search field which throws an error during query parsing. This PR fixes that.
 
### Issues Resolved
#332 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
