### PR TITLE
Sort data by date for query visualization

### DIFF
--- a/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/utils/helpers.js
@@ -91,7 +91,8 @@ export function getDataFromResponse(response, fieldName, monitorType) {
     const buckets = _.get(response, 'aggregations.composite_agg.buckets', []);
     return buckets
       .map((bucket) => getXYValuesByFieldName(bucket, fieldName))
-      .filter(filterInvalidYValues);
+      .filter(filterInvalidYValues)
+      .sort((a, b) => a.x - b.x);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
The data shown in the preview visualization for the bucket level monitor query is not sorted by time which results in random values getting selected as min and max for the x-axis. This causes the visualization to render incorrectly sometimes showing data outside the axis boundaries.
Added sorting by date which now shows the x-axis timeline correctly.

Before fix:
Notice how the timeline on x-axis is reversed and some data points show up outside the axis boundary.
![image](https://user-images.githubusercontent.com/114732919/205197844-713e559a-4031-4aa1-8222-9812ca650493.png)


After fix:
![image](https://user-images.githubusercontent.com/114732919/205197745-c4ed4d84-fb79-48a5-930a-d9a1674309f1.png)

 
### Issues Resolved
#124 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
