### PR TITLE
Bumped 1.x to 1.3.7. Enabled windows unit tests.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,15 +2,14 @@ name: E2E Cypress tests
 on:
   pull_request:
     branches:
-      - main
-      - 1.x
+      - "*"
   push:
     branches:
-      - main
-      - 1.x
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.3'
+  OPENSEARCH_VERSION: '1.3.7-SNAPSHOT'
+  ALERTING_PLUGIN_BRANCH: '1.3'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -31,7 +30,7 @@ jobs:
         with:
           path: alerting
           repository: opensearch-project/alerting
-          ref: 'main'
+          ref: ${{ env.ALERTING_PLUGIN_BRANCH }}
       - name: Run Opensearch with plugin
         run: |
           cd alerting

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -2,19 +2,24 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - main
-      - 1.x
+      - "*"
   pull_request:
     branches:
-      - main
-      - 1.x
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.3'
 jobs:
   tests:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
+      # Enable longer filenames for windows
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
@@ -44,9 +49,16 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
           yarn osd bootstrap
-      - name: Run tests
+      - name: Run windows tests
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
+          yarn run test:jest:windows --coverage
+      - name: Run non-windows tests
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
           cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
           yarn run test:jest --coverage
       - name: Uploads coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       # Enable longer filenames for windows

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -12,8 +12,9 @@ jobs:
   tests:
     name: Run unit tests
     strategy:
+      fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       # Enable longer filenames for windows
@@ -31,6 +32,7 @@ jobs:
         run: |
           echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
           echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+        shell: bash
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -41,6 +43,7 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+        shell: bash
       - name: Checkout Alerting OpenSearch Dashboards plugin
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
           echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
-        shell: bash
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -43,7 +42,6 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
-        shell: bash
       - name: Checkout Alerting OpenSearch Dashboards plugin
         uses: actions/checkout@v2
         with:

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.3.0",
+  "version": "1.3.7.0",
+  "opensearchDashboardsVersion": "1.3.7",
   "configPath": ["opensearch_alerting"],
   "requiredPlugins": [],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "osd": "node ../../scripts/osd",
     "opensearch": "node ../../scripts/opensearch",
     "lint": "../../node_modules/.bin/eslint '**/*.js' -c .eslintrc --ignore-path .gitignore",
+    "test:jest:windows": "SET TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "1.3.0.0",
+  "version": "1.3.7.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
1. Bumped 1.x to 1.3.7. 
2. Adjusted alerting plugin branch used by test workflows.
3. Enabled windows unit tests.
 
### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/392
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
