### PR TITLE
[Backport 1.3] Bumped 1.x to 1.3.7. Enabled windows unit tests.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,15 +2,14 @@ name: E2E Cypress tests
 on:
   pull_request:
     branches:
-      - main
-      - 1.x
+      - "*"
   push:
     branches:
-      - main
-      - 1.x
+      - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.3'
   OPENSEARCH_VERSION: '1.3.7-SNAPSHOT'
+  ALERTING_PLUGIN_BRANCH: '1.3'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -31,7 +30,7 @@ jobs:
         with:
           path: alerting
           repository: opensearch-project/alerting
-          ref: 'main'
+          ref: ${{ env.ALERTING_PLUGIN_BRANCH }}
       - name: Run Opensearch with plugin
         run: |
           cd alerting

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -2,19 +2,25 @@ name: Unit tests workflow
 on:
   push:
     branches:
-      - main
-      - 1.x
+      - "*"
   pull_request:
     branches:
-      - main
-      - 1.x
+      - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.3'
 jobs:
   tests:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
+      # Enable longer filenames for windows
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
@@ -44,9 +50,16 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
           yarn osd bootstrap
-      - name: Run tests
+      - name: Run windows tests
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
+          yarn run test:jest:windows --coverage
+      - name: Run non-windows tests
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
           cd OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
           yarn run test:jest --coverage
       - name: Uploads coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "osd": "node ../../scripts/osd",
     "opensearch": "node ../../scripts/opensearch",
     "lint": "../../node_modules/.bin/eslint '**/*.js' -c .eslintrc --ignore-path .gitignore",
+    "test:jest:windows": "SET TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "test:jest": "TZ=UTC ../../node_modules/.bin/jest --config ./test/jest.config.js",
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",


### PR DESCRIPTION
### Description
Manually backporting PR https://github.com/opensearch-project/alerting-dashboards-plugin/pull/396.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
