### PR TITLE
Keep monitor table cell width flexible; Check for whether monitor is enabled when displaying related action

### DIFF
--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -166,7 +166,7 @@ describe('Query-Level Monitors', () => {
       cy.contains(SAMPLE_MONITOR, { timeout: 20000 });
 
       // Select the existing monitor
-      cy.get('a').contains(SAMPLE_MONITOR, { timeout: 20000 }).click();
+      cy.get(`[data-test-subj="${SAMPLE_MONITOR}"]`).click();
 
       // Click Edit button
       cy.contains('Edit', { timeout: 20000 }).click({ force: true });
@@ -195,7 +195,7 @@ describe('Query-Level Monitors', () => {
       cy.contains(SAMPLE_MONITOR, { timeout: 20000 });
 
       // Select the existing monitor
-      cy.get('a').contains(SAMPLE_MONITOR, { timeout: 20000 }).click({ force: true });
+      cy.get(`[data-test-subj="${SAMPLE_MONITOR}"]`).click({ force: true });
 
       // Click Edit button
       cy.contains('Edit', { timeout: 20000 }).click({ force: true });
@@ -304,7 +304,7 @@ describe('Query-Level Monitors', () => {
       cy.contains(SAMPLE_MONITOR);
 
       // Select the existing monitor
-      cy.get('a').contains(SAMPLE_MONITOR).click();
+      cy.get(`[data-test-subj="${SAMPLE_MONITOR}"]`).click();
 
       // Click Edit button
       cy.contains('Edit').click({ force: true });
@@ -373,7 +373,7 @@ describe('Query-Level Monitors', () => {
       cy.contains(SAMPLE_DAYS_INTERVAL_MONITOR, { timeout: 20000 });
 
       // Select the existing monitor
-      cy.get('a').contains(SAMPLE_DAYS_INTERVAL_MONITOR).click({ force: true });
+      cy.get(`[data-test-subj="${SAMPLE_DAYS_INTERVAL_MONITOR}"]`).click({ force: true });
 
       // Click Edit button
       cy.contains('Edit').click({ force: true });
@@ -398,7 +398,7 @@ describe('Query-Level Monitors', () => {
       cy.contains(SAMPLE_CRON_EXPRESSION_MONITOR, { timeout: 20000 });
 
       // Select the existing monitor
-      cy.get('a').contains(SAMPLE_CRON_EXPRESSION_MONITOR).click({ force: true });
+      cy.get(`[data-test-subj="${SAMPLE_CRON_EXPRESSION_MONITOR}"]`).click({ force: true });
 
       // Click Edit button
       cy.contains('Edit').click({ force: true });

--- a/public/pages/Destinations/components/NotificationsInfoCallOut/NotificationsInfoCallOut.js
+++ b/public/pages/Destinations/components/NotificationsInfoCallOut/NotificationsInfoCallOut.js
@@ -8,18 +8,17 @@ import { EuiCallOut, EuiButton, EuiSpacer } from '@elastic/eui';
 import { MANAGE_CHANNELS_PATH } from '../../../CreateTrigger/utils/constants';
 
 const NotificationsInfoCallOut = ({ hasNotificationPlugin }) => {
-  console.log(`NotificationsInfoCallOut: ${hasNotificationPlugin}`);
   return (
     <div>
       <EuiCallOut title="Destinations have become channels in Notifications.">
         <p>
           Your destinations have been migrated to Notifications, a new centralized place to manage
           your notification channels. Destinations will be deprecated going forward.
-          <EuiSpacer size="l" />
-          {hasNotificationPlugin && (
-            <EuiButton href={MANAGE_CHANNELS_PATH}>View Notifications</EuiButton>
-          )}
         </p>
+        <EuiSpacer size="l" />
+        {hasNotificationPlugin && (
+          <EuiButton href={MANAGE_CHANNELS_PATH}>View Notifications</EuiButton>
+        )}
       </EuiCallOut>
       <EuiSpacer size="l" />
     </div>

--- a/public/pages/Destinations/components/NotificationsInfoCallOut/__snapshots__/NotificationsInfoCallOut.test.js.snap
+++ b/public/pages/Destinations/components/NotificationsInfoCallOut/__snapshots__/NotificationsInfoCallOut.test.js.snap
@@ -41,7 +41,6 @@ exports[`NotificationsInfoCallOut renders when Notifications plugin is installed
             </span>
           </span>
         </a>
-        <p />
       </div>
     </div>
   </div>
@@ -77,7 +76,6 @@ exports[`NotificationsInfoCallOut renders when Notifications plugin is not insta
         <div
           class="euiSpacer euiSpacer--l"
         />
-        <p />
       </div>
     </div>
   </div>

--- a/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
@@ -82,14 +82,14 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                 >
                   <p>
                     Your destinations have been migrated to Notifications, a new centralized place to manage your notification channels. Destinations will be deprecated going forward.
-                    <EuiSpacer
-                      size="l"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--l"
-                      />
-                    </EuiSpacer>
                   </p>
+                  <EuiSpacer
+                    size="l"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
                 </div>
               </EuiTextColor>
             </div>
@@ -1556,14 +1556,14 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                 >
                   <p>
                     Your destinations have been migrated to Notifications, a new centralized place to manage your notification channels. Destinations will be deprecated going forward.
-                    <EuiSpacer
-                      size="l"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--l"
-                      />
-                    </EuiSpacer>
                   </p>
+                  <EuiSpacer
+                    size="l"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
                 </div>
               </EuiTextColor>
             </div>
@@ -2888,14 +2888,14 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                 >
                   <p>
                     Your destinations have been migrated to Notifications, a new centralized place to manage your notification channels. Destinations will be deprecated going forward.
-                    <EuiSpacer
-                      size="l"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--l"
-                      />
-                    </EuiSpacer>
                   </p>
+                  <EuiSpacer
+                    size="l"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
                 </div>
               </EuiTextColor>
             </div>

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -75,7 +75,7 @@ export default class Monitors extends Component {
       ...staticColumns,
       {
         name: 'Actions',
-        width: '75px',
+        width: '60px',
         actions: [
           {
             name: 'Acknowledge',
@@ -86,11 +86,13 @@ export default class Monitors extends Component {
             name: 'Enable',
             description: 'Enable this Monitor',
             onClick: this.onClickEnable,
+            available: (item) => !item.enabled,
           },
           {
             name: 'Disable',
             description: 'Disable this Monitor',
             onClick: this.onClickDisable,
+            available: (item) => item.enabled,
           },
           {
             name: 'Delete',

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -41,7 +41,6 @@ exports[`Monitors renders 1`] = `
           "sortable": true,
           "textOnly": true,
           "truncateText": true,
-          "width": "150px",
         },
         Object {
           "field": "user",
@@ -50,7 +49,6 @@ exports[`Monitors renders 1`] = `
           "sortable": true,
           "textOnly": true,
           "truncateText": true,
-          "width": "100px",
         },
         Object {
           "field": "latestAlert",
@@ -58,7 +56,6 @@ exports[`Monitors renders 1`] = `
           "sortable": false,
           "textOnly": true,
           "truncateText": true,
-          "width": "150px",
         },
         Object {
           "field": "enabled",
@@ -66,7 +63,6 @@ exports[`Monitors renders 1`] = `
           "render": [Function],
           "sortable": false,
           "truncateText": false,
-          "width": "100px",
         },
         Object {
           "dataType": "date",
@@ -75,35 +71,30 @@ exports[`Monitors renders 1`] = `
           "render": [Function],
           "sortable": true,
           "truncateText": false,
-          "width": "150px",
         },
         Object {
           "field": "active",
           "name": "Active",
           "sortable": true,
           "truncateText": false,
-          "width": "100px",
         },
         Object {
           "field": "acknowledged",
           "name": "Acknowledged",
           "sortable": true,
           "truncateText": false,
-          "width": "100px",
         },
         Object {
           "field": "errors",
           "name": "Errors",
           "sortable": true,
           "truncateText": false,
-          "width": "100px",
         },
         Object {
           "field": "ignored",
           "name": "Ignored",
           "sortable": true,
           "truncateText": false,
-          "width": "100px",
         },
         Object {
           "actions": Array [
@@ -113,11 +104,13 @@ exports[`Monitors renders 1`] = `
               "onClick": [Function],
             },
             Object {
+              "available": [Function],
               "description": "Enable this Monitor",
               "name": "Enable",
               "onClick": [Function],
             },
             Object {
+              "available": [Function],
               "description": "Disable this Monitor",
               "name": "Disable",
               "onClick": [Function],
@@ -129,7 +122,7 @@ exports[`Monitors renders 1`] = `
             },
           ],
           "name": "Actions",
-          "width": "75px",
+          "width": "60px",
         },
       ]
     }

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -40,7 +40,6 @@ exports[`Monitors renders 1`] = `
           "render": [Function],
           "sortable": true,
           "textOnly": true,
-          "truncateText": true,
         },
         Object {
           "field": "user",

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -22,7 +22,6 @@ export const columns = [
     sortable: true,
     truncateText: true,
     textOnly: true,
-    width: '150px',
     render: (name, item) => <EuiLink href={`${PLUGIN_NAME}#/monitors/${item.id}`}>{name}</EuiLink>,
   },
   {
@@ -31,7 +30,6 @@ export const columns = [
     sortable: true,
     truncateText: true,
     textOnly: true,
-    width: '100px',
     /* There are 3 cases:
     1. Monitors created by older versions and never updated.
        These monitors won’t have User details in the monitor object. `monitor.user` will be null.
@@ -47,14 +45,12 @@ export const columns = [
     sortable: false,
     truncateText: true,
     textOnly: true,
-    width: '150px',
   },
   {
     field: 'enabled',
     name: 'State',
     sortable: false,
     truncateText: false,
-    width: '100px',
     render: (enabled) => (enabled ? 'Enabled' : 'Disabled'),
   },
   {
@@ -64,34 +60,29 @@ export const columns = [
     truncateText: false,
     render: renderTime,
     dataType: 'date',
-    width: '150px',
   },
   {
     field: 'active',
     name: 'Active',
     sortable: true,
     truncateText: false,
-    width: '100px',
   },
   {
     field: 'acknowledged',
     name: 'Acknowledged',
     sortable: true,
     truncateText: false,
-    width: '100px',
   },
   {
     field: 'errors',
     name: 'Errors',
     sortable: true,
     truncateText: false,
-    width: '100px',
   },
   {
     field: 'ignored',
     name: 'Ignored',
     sortable: true,
     truncateText: false,
-    width: '100px',
   },
 ];

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -20,9 +20,12 @@ export const columns = [
     field: 'name',
     name: 'Monitor name',
     sortable: true,
-    truncateText: true,
     textOnly: true,
-    render: (name, item) => <EuiLink href={`${PLUGIN_NAME}#/monitors/${item.id}`}>{name}</EuiLink>,
+    render: (name, item) => (
+      <EuiLink data-test-subj={name} href={`${PLUGIN_NAME}#/monitors/${item.id}`}>
+        {name}
+      </EuiLink>
+    ),
   },
   {
     field: 'user',


### PR DESCRIPTION
Signed-off-by: Amardeepsingh Siglani <amardeep7194@gmail.com>

### Description
This PR fixes two things:
1. Removes static widths assigned to table cells in the monitor table to ensure the table rows resize according to browser width and doesn't overflow the content
2. Checks for whether monitor is enabled or not when displaying `Enable`/`Disable` actions.
 
### Issues Resolved
#253 
#401 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
