### PR TITLE
Implemented support for configuring up to 10 data filters for query and bucket level monitors using the visual editor.

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.6'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
 jobs:
   tests:
     name: Run unit tests

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.6'
 jobs:
   tests:
     name: Run unit tests

--- a/cypress/fixtures/sample_alerts_flyout_bucket_level_monitor.json
+++ b/cypress/fixtures/sample_alerts_flyout_bucket_level_monitor.json
@@ -121,13 +121,7 @@
       "groupBy": ["customer_gender", "user"],
       "bucketValue": 10,
       "bucketUnitOfTime": "d",
-      "where": {
-        "fieldName": [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is"
-      }
+      "filters": []
     },
     "monitor_type": "bucket_level_monitor"
   }

--- a/cypress/fixtures/sample_alerts_flyout_query_level_monitor.json
+++ b/cypress/fixtures/sample_alerts_flyout_query_level_monitor.json
@@ -88,13 +88,7 @@
       "groupBy": ["user"],
       "bucketValue": 10,
       "bucketUnitOfTime": "d",
-      "where": {
-        "fieldName": [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is"
-      }
+      "filters": []
     },
     "monitor_type": "query_level_monitor"
   }

--- a/cypress/fixtures/sample_cluster_metrics_monitor.json
+++ b/cypress/fixtures/sample_cluster_metrics_monitor.json
@@ -51,13 +51,7 @@
       "groupBy": [],
       "bucketValue": 1,
       "bucketUnitOfTime": "h",
-      "where": {
-        "fieldName": [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is"
-      }
+      "filters": []
     },
     "monitor_type": "cluster_metrics_monitor"
   }

--- a/cypress/fixtures/sample_visual_editor_bucket_level_monitor.json
+++ b/cypress/fixtures/sample_visual_editor_bucket_level_monitor.json
@@ -102,13 +102,7 @@
       "timeField": "order_date",
       "groupedOverTop": 5,
       "bucketUnitOfTime": "h",
-      "where": {
-        "fieldName": [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is"
-      },
+      "filters": [],
       "groupBy": ["user"],
       "aggregations": [
         {

--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -222,7 +222,7 @@ describe('Bucket-Level Monitors', () => {
       // Add a metric for the query
       cy.get('[data-test-subj="addMetricButton"]').click({ force: true });
 
-      cy.get('[data-test-subj="metrics.0.aggregationTypeSelect"]').select('count');
+      cy.get('[data-test-subj="metrics.0.aggregationTypeSelect"]').select('count', { force: true });
 
       cy.get('[data-test-subj="metrics.0.ofFieldComboBox"]').type(
         `${COUNT_METRIC_FIELD}{downArrow}{enter}`
@@ -233,7 +233,7 @@ describe('Bucket-Level Monitors', () => {
       // Add a second metric for the query
       cy.get('[data-test-subj="addMetricButton"]').click({ force: true });
 
-      cy.get('[data-test-subj="metrics.1.aggregationTypeSelect"]').select('avg');
+      cy.get('[data-test-subj="metrics.1.aggregationTypeSelect"]').select('avg', { force: true });
 
       cy.get('[data-test-subj="metrics.1.ofFieldComboBox"]').type(
         `${AVERAGE_METRIC_FIELD}{downArrow}{enter}`

--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -34,7 +34,7 @@ const addTriggerToVisualEditorMonitor = (triggerName, triggerIndex, actionName, 
     // TODO: Passing button props in EUI accordion was added in newer versions (31.7.0+).
     //  If this ever becomes available, it can be used to pass data-test-subj for the button.
     // Since the above is currently not possible, referring to the accordion button using its content
-    cy.get('button').contains('New trigger').click();
+    cy.get('button').contains('New trigger').click({ force: true });
   }
 
   // Type in the trigger name
@@ -50,7 +50,7 @@ const addTriggerToVisualEditorMonitor = (triggerName, triggerIndex, actionName, 
     .type('200');
 
   // Add another metric condition for the trigger
-  cy.get('[data-test-subj="addTriggerConditionButton"]').click();
+  cy.get('[data-test-subj="addTriggerConditionButton"]').click({ force: true });
 
   cy.get(`[name="triggerDefinitions[${triggerIndex}].triggerConditions[1].andOrCondition"]`).select(
     'OR'
@@ -69,15 +69,17 @@ const addTriggerToVisualEditorMonitor = (triggerName, triggerIndex, actionName, 
     .type('300');
 
   // Add a trigger where filter
-  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].where.addFilterButton"]`).click();
+  cy.get(`[data-test-subj="triggerDefinitions[${triggerIndex}].addFilterButton"]`).click({
+    force: true,
+  });
 
-  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.fieldName"]`).type(
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].filters.0.fieldName"]`).type(
     `${GROUP_BY_FIELD}{downarrow}{enter}`
   );
 
-  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.operator"]`).select('includes');
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].filters.0.operator"]`).select('includes');
 
-  cy.get(`[name="triggerDefinitions[${triggerIndex}].where.fieldValue"]`)
+  cy.get(`[name="triggerDefinitions[${triggerIndex}].filters.0.fieldValue"]`)
     .type('a*')
     .trigger('blur', { force: true });
 
@@ -131,13 +133,13 @@ describe('Bucket-Level Monitors', () => {
       cy.contains('There are no existing monitors');
 
       // Go to create monitor page
-      cy.contains('Create monitor').click();
+      cy.contains('Create monitor').click({ force: true });
 
       // Select the Bucket-Level Monitor type
-      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click();
+      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click({ force: true });
 
       // Select extraction query for method of definition
-      cy.get('[data-test-subj="extractionQueryEditorRadioCard"]').click();
+      cy.get('[data-test-subj="extractionQueryEditorRadioCard"]').click({ force: true });
 
       // Wait for input to load and then type in the monitor name
       cy.get('input[name="name"]').type(SAMPLE_EXTRACTION_QUERY_MONITOR);
@@ -179,7 +181,7 @@ describe('Bucket-Level Monitors', () => {
       //   .type('{downarrow}{enter}');
 
       // Click the create button
-      cy.get('button').contains('Create').click();
+      cy.get('button').contains('Create').click({ force: true });
 
       // Confirm we can see only one row in the trigger list by checking <caption> element
       cy.contains('This table contains 1 row');
@@ -188,7 +190,7 @@ describe('Bucket-Level Monitors', () => {
       cy.contains(SAMPLE_TRIGGER);
 
       // Go back to the Monitors list
-      cy.get('a').contains('Monitors').click();
+      cy.get('a').contains('Monitors').click({ force: true });
 
       // Confirm we can see the created monitor in the list
       cy.contains(SAMPLE_EXTRACTION_QUERY_MONITOR);
@@ -199,13 +201,13 @@ describe('Bucket-Level Monitors', () => {
       cy.contains('There are no existing monitors');
 
       // Go to create monitor page
-      cy.contains('Create monitor').click();
+      cy.contains('Create monitor').click({ force: true });
 
       // Select the Bucket-Level Monitor type
-      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click();
+      cy.get('[data-test-subj="bucketLevelMonitorRadioCard"]').click({ force: true });
 
       // Select visual editor for method of definition
-      cy.get('[data-test-subj="visualEditorRadioCard"]').click();
+      cy.get('[data-test-subj="visualEditorRadioCard"]').click({ force: true });
 
       // Wait for input to load and then type in the monitor name
       cy.get('input[name="name"]').type(SAMPLE_VISUAL_EDITOR_MONITOR);
@@ -218,7 +220,7 @@ describe('Bucket-Level Monitors', () => {
       cy.get('#timeField').type(`${TIME_FIELD}{downArrow}{enter}`, { force: true });
 
       // Add a metric for the query
-      cy.get('[data-test-subj="addMetricButton"]').click();
+      cy.get('[data-test-subj="addMetricButton"]').click({ force: true });
 
       cy.get('[data-test-subj="metrics.0.aggregationTypeSelect"]').select('count');
 
@@ -226,10 +228,10 @@ describe('Bucket-Level Monitors', () => {
         `${COUNT_METRIC_FIELD}{downArrow}{enter}`
       );
 
-      cy.get('button').contains('Save').click();
+      cy.get('button').contains('Save').click({ force: true });
 
       // Add a second metric for the query
-      cy.get('[data-test-subj="addMetricButton"]').click();
+      cy.get('[data-test-subj="addMetricButton"]').click({ force: true });
 
       cy.get('[data-test-subj="metrics.1.aggregationTypeSelect"]').select('avg');
 
@@ -237,22 +239,22 @@ describe('Bucket-Level Monitors', () => {
         `${AVERAGE_METRIC_FIELD}{downArrow}{enter}`
       );
 
-      cy.get('button').contains('Save').click();
+      cy.get('button').contains('Save').click({ force: true });
 
       // Add a group by field for the query
-      cy.get('[data-test-subj="addGroupByButton"]').click();
+      cy.get('[data-test-subj="addGroupByButton"]').click({ force: true });
 
       cy.get('[data-test-subj="groupBy.0.ofFieldComboBox"]').type(
         `${GROUP_BY_FIELD}{downArrow}{enter}`
       );
 
-      cy.get('button').contains('Save').click();
+      cy.get('button').contains('Save').click({ force: true });
 
       // Add trigger
       addTriggerToVisualEditorMonitor(SAMPLE_TRIGGER, 0, SAMPLE_ACTION, false);
 
       // Click the create button
-      cy.get('button').contains('Create').click();
+      cy.get('button').contains('Create').click({ force: true });
 
       // Confirm we can see only one row in the trigger list by checking <caption> element
       cy.contains('This table contains 1 row');
@@ -336,7 +338,7 @@ describe('Bucket-Level Monitors', () => {
         });
 
         // Click the update button
-        cy.get('button').contains('Update').last().click();
+        cy.get('button').contains('Update').last().click({ force: true });
 
         // Confirm we're on the Monitor Details page by searching for the History element
         cy.contains('History', { timeout: 20000 });

--- a/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
@@ -212,31 +212,34 @@ exports[`MonitorExpressions renders 1`] = `
       >
         No filters defined.
       </div>
-    </div>
-    <button
-      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-      data-test-subj="where.addFilterButton"
-      style="padding-top:5px"
-      type="button"
-    >
-      <span
-        class="euiButtonContent euiButtonEmpty__content"
+      <div
+        class="euiSpacer euiSpacer--xs"
+      />
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+        data-test-subj="addFilterButton"
+        style="padding-top:5px"
+        type="button"
       >
         <span
-          class="euiButtonEmpty__text"
+          class="euiButtonContent euiButtonEmpty__content"
         >
-          + Add filter
+          <span
+            class="euiButtonEmpty__text"
+          >
+            + Add filter
+          </span>
         </span>
-      </span>
-    </button>
-    <div
-      class="euiText euiText--extraSmall"
-      style="padding-left:10px"
-    >
+      </button>
       <div
-        class="euiTextColor euiTextColor--subdued"
+        class="euiText euiText--extraSmall"
+        style="padding-left:10px"
       >
-        You can add up to 1  data filter.
+        <div
+          class="euiTextColor euiTextColor--subdued"
+        >
+          You can add up to 10 more data filters.
+        </div>
       </div>
     </div>
   </div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -93,7 +93,7 @@ class WhereExpression extends Component {
                       ...FORMIK_INITIAL_WHERE_EXPRESSION_VALUES,
                       operator: TRIGGER_OPERATORS_MAP.INCLUDE,
                     }
-                  : FORMIK_INITIAL_WHERE_EXPRESSION_VALUES
+                  : { ...FORMIK_INITIAL_WHERE_EXPRESSION_VALUES }
               );
             }}
             style={{ paddingTop: '5px' }}

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -5,50 +5,21 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'formik';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPopover,
-  EuiButtonEmpty,
-  EuiText,
-  EuiBadge,
-  EuiSpacer,
-} from '@elastic/eui';
+import { connect, FieldArray } from 'formik';
+import { EuiButtonEmpty, EuiText, EuiSpacer } from '@elastic/eui';
 import _ from 'lodash';
-import {
-  Expressions,
-  POPOVER_STYLE,
-  EXPRESSION_STYLE,
-  WHERE_BOOLEAN_FILTERS,
-} from './utils/constants';
-import {
-  getOperators,
-  displayText,
-  validateRange,
-  isNullOperator,
-  isRangeOperator,
-} from './utils/whereHelpers';
-import { hasError, isInvalid } from '../../../../../utils/validate';
-import {
-  FormikComboBox,
-  FormikSelect,
-  FormikFieldNumber,
-  FormikFieldText,
-} from '../../../../../components/FormControls';
-import { getFilteredIndexFields, getIndexFields } from './utils/dataTypes';
+import { Expressions } from './utils/constants';
+import { isNullOperator } from './utils/whereHelpers';
 import {
   FILTERS_TOOLTIP_TEXT,
+  FORMIK_INITIAL_WHERE_EXPRESSION_VALUES,
   FORMIK_INITIAL_VALUES,
 } from '../../../containers/CreateMonitor/utils/constants';
-import { DATA_TYPES } from '../../../../../utils/constants';
-import {
-  TRIGGER_COMPARISON_OPERATORS,
-  TRIGGER_OPERATORS_MAP,
-} from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
+import { TRIGGER_OPERATORS_MAP } from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
 import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../../../CreateTrigger/containers/CreateTrigger/utils/constants';
 import { inputLimitText } from '../../../../../utils/helpers';
 import IconToolTip from '../../../../../components/IconToolTip';
+import WherePopover from './WherePopover';
 
 const propTypes = {
   formik: PropTypes.object.isRequired,
@@ -58,170 +29,100 @@ const propTypes = {
   openExpression: PropTypes.func.isRequired,
 };
 
-const ALLOWED_TYPES = ['number', 'text', 'keyword', 'boolean'];
-
-const MAX_NUM_WHERE_EXPRESSION = 1;
+const MAX_NUM_WHERE_EXPRESSION = {
+  DATA_FILTERS: 10,
+  KEYWORD_FILTERS: 1,
+};
 
 class WhereExpression extends Component {
   constructor(props) {
     super(props);
   }
 
-  handleFieldChange = (option, field, form) => {
-    this.props.onMadeChanges();
-    this.resetValues();
-    form.setFieldValue(field.name, option);
-    // User can remove where condition
-    if (option.length === 0) {
-      this.resetValues();
-      form.setFieldError('where', undefined);
-    }
-  };
-
-  handleOperatorChange = (e, field, form) => {
-    this.props.onMadeChanges();
-    field.onChange(e);
-    form.setFieldError('where', undefined);
-  };
-
-  handleChangeWrapper = (e, field) => {
-    this.props.onMadeChanges();
-    field.onChange(e);
-  };
-
-  handleClosePopOver = async () => {
+  renderFiltersBadges(filters, filtersArrayHelpers, whereFilterHeader) {
     const {
-      formik: { values },
-      closeExpression,
-      fieldPath = '',
-    } = this.props;
-    // Explicitly invoking validation, this component unmount after it closes.
-    const fieldName = _.get(values, `${fieldPath}where.fieldName`, '');
-    const fieldOperator = _.get(values, `${fieldPath}where.operator`, 'is');
-    const fieldValue = _.get(values, `${fieldPath}where.fieldValue`, '');
-    if (fieldName > 0) {
-      await this.props.formik.validateForm();
-    }
-    if (
-      _.isEmpty(fieldName) ||
-      (!isNullOperator(fieldOperator) && _.isEmpty(fieldValue.toString()))
-    )
-      this.resetValues();
-    closeExpression(Expressions.WHERE);
-  };
-
-  resetValues = () => {
-    const { fieldPath, formik, useTriggerFieldOperators = false } = this.props;
-    if (useTriggerFieldOperators) {
-      _.set(formik, `values.${fieldPath}where`, FORMIK_INITIAL_TRIGGER_VALUES.where);
-      formik.setValues({ ...formik.values });
-    } else {
-      formik.setValues({
-        ...formik.values,
-        where: { ...FORMIK_INITIAL_VALUES.where },
-      });
-    }
-  };
-
-  renderBetweenAnd = () => {
-    const {
-      formik: { values },
-      fieldPath = '',
-    } = this.props;
-    return (
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem>
-          <FormikFieldNumber
-            name={`${fieldPath}where.fieldRangeStart`}
-            fieldProps={{
-              validate: (value) => validateRange(value, _.get(values, `${fieldPath}where`)),
-            }}
-            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText textAlign="center">TO</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <FormikFieldNumber
-            name={`${fieldPath}where.fieldRangeEnd`}
-            fieldProps={{
-              validate: (value) => validateRange(value, _.get(values, `${fieldPath}where`)),
-            }}
-            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    );
-  };
-
-  renderValueField = (fieldType, fieldOperator) => {
-    const { fieldPath = '' } = this.props;
-    if (fieldType === DATA_TYPES.NUMBER) {
-      return isRangeOperator(fieldOperator) ? (
-        this.renderBetweenAnd()
-      ) : (
-        <FormikFieldNumber
-          name={`${fieldPath}where.fieldValue`}
-          inputProps={{ onChange: this.handleChangeWrapper }}
-          formRow
-          rowProps={{ isInvalid, error: hasError }}
-        />
-      );
-    } else if (fieldType === DATA_TYPES.BOOLEAN) {
-      return (
-        <FormikSelect
-          name={`${fieldPath}where.fieldValue`}
-          inputProps={{
-            onChange: this.handleChangeWrapper,
-            options: WHERE_BOOLEAN_FILTERS,
-            isInvalid,
-          }}
-        />
-      );
-    } else {
-      return (
-        <FormikFieldText
-          name={`${fieldPath}where.fieldValue`}
-          inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
-        />
-      );
-    }
-  };
-
-  render() {
-    const {
-      formik: { values },
       openedStates,
+      closeExpression,
       openExpression,
       dataTypes,
       indexFieldFilters,
       useTriggerFieldOperators = false,
       fieldPath = '',
+      formik,
+      onMadeChanges,
     } = this.props;
+    const maxNumWhereExpressions = useTriggerFieldOperators
+      ? MAX_NUM_WHERE_EXPRESSION.KEYWORD_FILTERS
+      : MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS;
+    return (
+      <div>
+        {filters.length === 0 ? (
+          <EuiText size={'xs'}>No filters defined.</EuiText>
+        ) : (
+          <div style={{ maxWidth: '75%' }}>
+            {filters.map((filter, index) => (
+              <span key={`${fieldPath}filters.${index}`} style={{ paddingRight: '5px' }}>
+                <WherePopover
+                  closePopover={() => closeExpression(Expressions.WHERE)}
+                  dataTypes={dataTypes}
+                  indexFieldFilters={indexFieldFilters}
+                  fieldPath={`${fieldPath}filters.${index}.`}
+                  filtersArrayHelpers={filtersArrayHelpers}
+                  formik={formik}
+                  index={index}
+                  onMadeChanges={onMadeChanges}
+                  openPopover={() => openExpression(Expressions.WHERE)}
+                  openedState={openedStates.WHERE}
+                  useTriggerFieldOperators={useTriggerFieldOperators}
+                  values={filter}
+                  whereFilterHeader={whereFilterHeader}
+                />
+              </span>
+            ))}
+          </div>
+        )}
 
-    const indexFields =
-      indexFieldFilters !== undefined
-        ? getFilteredIndexFields(dataTypes, ALLOWED_TYPES, indexFieldFilters)
-        : getIndexFields(dataTypes, ALLOWED_TYPES);
-    const fieldType = _.get(values, `${fieldPath}where.fieldName[0].type`, 'number');
-    let fieldOperator = _.get(values, `${fieldPath}where.operator`, 'is');
-    if (useTriggerFieldOperators && !_.includes(_.values(TRIGGER_OPERATORS_MAP), fieldOperator)) {
-      fieldOperator = TRIGGER_OPERATORS_MAP.INCLUDE;
-      _.set(values, `${fieldPath}where.operator`, fieldOperator);
-    }
+        <EuiSpacer size={'xs'} />
+        {filters.length < maxNumWhereExpressions && (
+          <EuiButtonEmpty
+            size="xs"
+            data-test-subj={`${fieldPath}addFilterButton`}
+            onClick={() => {
+              openExpression(Expressions.WHERE);
+              filtersArrayHelpers.push(
+                useTriggerFieldOperators
+                  ? {
+                      ...FORMIK_INITIAL_WHERE_EXPRESSION_VALUES,
+                      operator: TRIGGER_OPERATORS_MAP.INCLUDE,
+                    }
+                  : FORMIK_INITIAL_WHERE_EXPRESSION_VALUES
+              );
+            }}
+            style={{ paddingTop: '5px' }}
+          >
+            + Add filter
+          </EuiButtonEmpty>
+        )}
 
-    const fieldOperators = useTriggerFieldOperators
-      ? TRIGGER_COMPARISON_OPERATORS
-      : getOperators(fieldType);
+        {inputLimitText(
+          filters.length,
+          maxNumWhereExpressions,
+          _.lowerCase(whereFilterHeader),
+          _.lowerCase(`${whereFilterHeader}s`),
+          { paddingLeft: '10px' }
+        )}
+      </div>
+    );
+  }
 
+  render() {
+    const {
+      formik: { values },
+      useTriggerFieldOperators = false,
+      fieldPath = '',
+    } = this.props;
     const whereFilterHeader = useTriggerFieldOperators ? 'Keyword filter' : 'Data filter';
-
-    const whereValues = _.get(values, `${fieldPath}where`);
-    const whereFieldName = _.get(whereValues, 'fieldName[0].label', undefined);
-
-    const showAddButtonFlag = !openedStates[Expressions.WHERE] && !whereFieldName;
-
+    const filters = _.get(values, `${fieldPath}filters`, FORMIK_INITIAL_VALUES.filters);
     return (
       <div>
         <EuiText size="xs">
@@ -231,86 +132,11 @@ class WhereExpression extends Component {
         </EuiText>
         <EuiSpacer size={'s'} />
 
-        {showAddButtonFlag ? (
-          <div>
-            <EuiText size={'xs'}>No filters defined.</EuiText>
-          </div>
-        ) : (
-          <EuiPopover
-            id={`${whereFilterHeader}-badge-popover`}
-            button={
-              <div style={{ paddingBottom: '5px' }}>
-                <EuiBadge
-                  color="hollow"
-                  iconSide="right"
-                  iconType="cross"
-                  iconOnClick={() => this.resetValues()}
-                  iconOnClickAriaLabel="Remove filter"
-                  onClick={() => {
-                    openExpression(Expressions.WHERE);
-                  }}
-                  onClickAriaLabel="Edit where filter"
-                >
-                  {displayText(_.get(values, `${fieldPath}where`))}
-                </EuiBadge>
-              </div>
-            }
-            isOpen={openedStates.WHERE}
-            closePopover={this.handleClosePopOver}
-            panelPaddingSize="none"
-            ownFocus
-            withTitle
-            anchorPosition="downLeft"
-          >
-            <div style={POPOVER_STYLE}>
-              <EuiFlexGroup style={{ ...EXPRESSION_STYLE }}>
-                <EuiFlexItem grow={false} style={{ width: 200 }}>
-                  <FormikComboBox
-                    name={`${fieldPath}where.fieldName`}
-                    inputProps={{
-                      placeholder: 'Select a field',
-                      options: indexFields,
-                      onChange: this.handleFieldChange,
-                      isClearable: false,
-                      singleSelection: { asPlainText: true },
-                    }}
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <FormikSelect
-                    name={`${fieldPath}where.operator`}
-                    inputProps={{
-                      onChange: this.handleOperatorChange,
-                      options: fieldOperators,
-                    }}
-                  />
-                </EuiFlexItem>
-                {!isNullOperator(fieldOperator) && (
-                  <EuiFlexItem>{this.renderValueField(fieldType, fieldOperator)}</EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            </div>
-          </EuiPopover>
-        )}
-
-        {showAddButtonFlag && (
-          <EuiButtonEmpty
-            size="xs"
-            data-test-subj={`${fieldPath}where.addFilterButton`}
-            onClick={() => openExpression(Expressions.WHERE)}
-            style={{ paddingTop: '5px' }}
-          >
-            + Add filter
-          </EuiButtonEmpty>
-        )}
-
-        {inputLimitText(
-          showAddButtonFlag ? 0 : 1,
-          MAX_NUM_WHERE_EXPRESSION,
-          _.lowerCase(whereFilterHeader),
-          _.lowerCase(`${whereFilterHeader}s`),
-          { paddingLeft: '10px' }
-        )}
+        <FieldArray name={`${fieldPath}filters`} validateOnChange={true}>
+          {(filtersArrayHelpers) =>
+            this.renderFiltersBadges(filters, filtersArrayHelpers, whereFilterHeader)
+          }
+        </FieldArray>
       </div>
     );
   }

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -9,14 +9,12 @@ import { connect, FieldArray } from 'formik';
 import { EuiButtonEmpty, EuiText, EuiSpacer } from '@elastic/eui';
 import _ from 'lodash';
 import { Expressions } from './utils/constants';
-import { isNullOperator } from './utils/whereHelpers';
 import {
   FILTERS_TOOLTIP_TEXT,
   FORMIK_INITIAL_WHERE_EXPRESSION_VALUES,
   FORMIK_INITIAL_VALUES,
 } from '../../../containers/CreateMonitor/utils/constants';
 import { TRIGGER_OPERATORS_MAP } from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
-import { FORMIK_INITIAL_TRIGGER_VALUES } from '../../../../CreateTrigger/containers/CreateTrigger/utils/constants';
 import { inputLimitText } from '../../../../../utils/helpers';
 import IconToolTip from '../../../../../components/IconToolTip';
 import WherePopover from './WherePopover';

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.js
@@ -29,7 +29,7 @@ const propTypes = {
   openExpression: PropTypes.func.isRequired,
 };
 
-const MAX_NUM_WHERE_EXPRESSION = {
+export const MAX_NUM_WHERE_EXPRESSION = {
   DATA_FILTERS: 10,
   KEYWORD_FILTERS: 1,
 };

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -44,7 +44,7 @@ describe('WhereExpression', () => {
   });
   test('calls openExpression when clicking expression', () => {
     const wrapper = mount(getMountWrapper());
-    const button = wrapper.find('[data-test-subj="where.addFilterButton"]').first();
+    const button = wrapper.find('[data-test-subj="addFilterButton"]').first();
     button.simulate('click');
     wrapper.update();
     expect(openExpression).toHaveBeenCalled();
@@ -63,6 +63,8 @@ describe('WhereExpression', () => {
 
   test('should render text input for the text data types', async () => {
     const wrapper = mount(getMountWrapper(true));
+    wrapper.find('[data-test-subj="addFilterButton"]').hostNodes().simulate('click');
+
     wrapper
       .find('[data-test-subj="comboBoxSearchInput"]')
       .hostNodes()
@@ -73,8 +75,8 @@ describe('WhereExpression', () => {
 
     wrapper.update();
     const values = wrapper.find(WhereExpression).props().formik.values;
-    expect(values.where.fieldName).toEqual([{ label: 'cityName', type: 'text' }]);
-    expect(values.where.operator).toEqual(OPERATORS_MAP.IS.value);
+    expect(values.filters[0].fieldName).toEqual([{ label: 'cityName', type: 'text' }]);
+    expect(values.filters[0].operator).toEqual(OPERATORS_MAP.IS.value);
     expect(wrapper.find(FormikFieldText).length).toBe(1);
     expect(wrapper.find(FormikFieldNumber).length).toBe(0);
   });

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -5,13 +5,14 @@
 
 import React from 'react';
 import { Formik } from 'formik';
-import { render, mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 import { EuiPopover } from '@elastic/eui';
 
 import { FORMIK_INITIAL_VALUES } from '../../../containers/CreateMonitor/utils/constants';
-import WhereExpression from './WhereExpression';
-import { FormikFieldText, FormikFieldNumber } from '../../../../../components/FormControls';
+import WhereExpression, { MAX_NUM_WHERE_EXPRESSION } from './WhereExpression';
+import { FormikFieldNumber, FormikFieldText } from '../../../../../components/FormControls';
 import { OPERATORS_MAP } from './utils/constants';
+import { TRIGGER_OPERATORS_MAP } from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
 
 const dataTypes = {
   integer: new Set(['age']),
@@ -20,7 +21,7 @@ const dataTypes = {
 };
 const openExpression = jest.fn();
 const closeExpression = jest.fn();
-const getMountWrapper = (state = false) => (
+const getMountWrapper = (state = false, useTriggerFieldOperators = false) => (
   <Formik initialValues={FORMIK_INITIAL_VALUES}>
     {(props) => (
       <WhereExpression
@@ -30,6 +31,7 @@ const getMountWrapper = (state = false) => (
         openExpression={openExpression}
         closeExpression={closeExpression}
         onMadeChanges={jest.fn()}
+        useTriggerFieldOperators={useTriggerFieldOperators}
       />
     )}
   </Formik>
@@ -79,5 +81,63 @@ describe('WhereExpression', () => {
     expect(values.filters[0].operator).toEqual(OPERATORS_MAP.IS.value);
     expect(wrapper.find(FormikFieldText).length).toBe(1);
     expect(wrapper.find(FormikFieldNumber).length).toBe(0);
+  });
+
+  test(`monitor queries should support up to ${MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS} data filters`, async () => {
+    const wrapper = mount(getMountWrapper(true, false));
+
+    for (let i = 0; i < MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS; i++) {
+      const newEntry = `cityName${i}`;
+      dataTypes.text.add(newEntry);
+      wrapper.find('[data-test-subj="addFilterButton"]').hostNodes().simulate('click');
+      wrapper
+        .find('[data-test-subj="comboBoxSearchInput"]')
+        .hostNodes()
+        .last()
+        .simulate('change', { target: { value: newEntry } })
+        .simulate('keyDown', { key: 'ArrowDown' })
+        .simulate('keyDown', { key: 'Enter' })
+        .simulate('blur');
+      wrapper.update();
+    }
+
+    const values = wrapper.find(WhereExpression).props().formik.values;
+    for (let i = 0; i < MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS; i++) {
+      expect(values.filters[i].fieldName).toEqual([{ label: `cityName${i}`, type: 'text' }]);
+      expect(values.filters[i].operator).toEqual(OPERATORS_MAP.IS);
+    }
+    expect(wrapper.find(FormikFieldText).length).toBe(MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS);
+    expect(wrapper.find(FormikFieldNumber).length).toBe(0);
+    expect(wrapper.find('euiButtonEmpty__text').exists()).toBe(false);
+  });
+
+  test(`bucket level triggers should support up to ${MAX_NUM_WHERE_EXPRESSION.KEYWORD_FILTERS} keyword filters`, async () => {
+    const wrapper = mount(getMountWrapper(true, true));
+
+    for (let i = 0; i < MAX_NUM_WHERE_EXPRESSION.KEYWORD_FILTERS; i++) {
+      const newEntry = `cityName${i}.keyword`;
+      dataTypes.keyword.add(newEntry);
+      wrapper.find('[data-test-subj="addFilterButton"]').hostNodes().simulate('click');
+      wrapper
+        .find('[data-test-subj="comboBoxSearchInput"]')
+        .hostNodes()
+        .last()
+        .simulate('change', { target: { value: newEntry } })
+        .simulate('keyDown', { key: 'ArrowDown' })
+        .simulate('keyDown', { key: 'Enter' })
+        .simulate('blur');
+      wrapper.update();
+    }
+
+    const values = wrapper.find(WhereExpression).props().formik.values;
+    for (let i = 0; i < MAX_NUM_WHERE_EXPRESSION.KEYWORD_FILTERS; i++) {
+      expect(values.filters[i].fieldName).toEqual([
+        { label: `cityName${i}.keyword`, type: 'keyword' },
+      ]);
+      expect(values.filters[i].operator).toEqual(TRIGGER_OPERATORS_MAP.INCLUDE);
+    }
+    expect(wrapper.find(FormikFieldText).length).toBe(MAX_NUM_WHERE_EXPRESSION.KEYWORD_FILTERS);
+    expect(wrapper.find(FormikFieldNumber).length).toBe(0);
+    expect(wrapper.find('.euiButtonEmpty__text').exists()).toBe(false);
   });
 });

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WhereExpression.test.js
@@ -104,7 +104,7 @@ describe('WhereExpression', () => {
     const values = wrapper.find(WhereExpression).props().formik.values;
     for (let i = 0; i < MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS; i++) {
       expect(values.filters[i].fieldName).toEqual([{ label: `cityName${i}`, type: 'text' }]);
-      expect(values.filters[i].operator).toEqual(OPERATORS_MAP.IS);
+      expect(values.filters[i].operator).toEqual(OPERATORS_MAP.IS.value);
     }
     expect(wrapper.find(FormikFieldText).length).toBe(MAX_NUM_WHERE_EXPRESSION.DATA_FILTERS);
     expect(wrapper.find(FormikFieldNumber).length).toBe(0);

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
@@ -5,35 +5,38 @@
 
 import React, { Component } from 'react';
 import {
+  EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
   EuiPopoverTitle,
   EuiText,
-  EuiBadge,
 } from '@elastic/eui';
 import _ from 'lodash';
-import { POPOVER_STYLE, EXPRESSION_STYLE, WHERE_BOOLEAN_FILTERS } from './utils/constants';
 import {
-  getOperators,
+  WHERE_FILTER_ALLOWED_TYPES,
+  EXPRESSION_STYLE,
+  POPOVER_STYLE,
+  WHERE_BOOLEAN_FILTERS,
+} from './utils/constants';
+import {
   displayText,
-  validateRange,
+  getOperators,
   isNullOperator,
   isRangeOperator,
+  validateRange,
   validateWhereFilter,
 } from './utils/whereHelpers';
 import { hasError, isInvalid } from '../../../../../utils/validate';
 import {
   FormikComboBox,
-  FormikSelect,
   FormikFieldNumber,
   FormikFieldText,
+  FormikSelect,
 } from '../../../../../components/FormControls';
 import { getFilteredIndexFields, getIndexFields } from './utils/dataTypes';
 import { TRIGGER_COMPARISON_OPERATORS } from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
 import { DATA_TYPES } from '../../../../../utils/constants';
-
-export const ALLOWED_TYPES = ['number', 'text', 'keyword', 'boolean'];
 
 export default class WherePopover extends Component {
   constructor(props) {
@@ -187,8 +190,8 @@ export default class WherePopover extends Component {
 
     const indexFields =
       indexFieldFilters !== undefined
-        ? getFilteredIndexFields(dataTypes, ALLOWED_TYPES, indexFieldFilters)
-        : getIndexFields(dataTypes, ALLOWED_TYPES);
+        ? getFilteredIndexFields(dataTypes, WHERE_FILTER_ALLOWED_TYPES, indexFieldFilters)
+        : getIndexFields(dataTypes, WHERE_FILTER_ALLOWED_TYPES);
     const fieldType = _.get(values, `fieldName[0].type`, 'number');
     const fieldOperator = _.get(values, `operator`, 'is');
     const fieldOperators = useTriggerFieldOperators

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
@@ -49,7 +49,6 @@ export default class WherePopover extends Component {
 
   handleFieldChange = (option, field, form) => {
     this.props.onMadeChanges();
-    // this.resetValues();
     form.setFieldValue(field.name, option);
     // User can remove where condition
     if (option.length === 0) {
@@ -77,9 +76,13 @@ export default class WherePopover extends Component {
           <FormikFieldNumber
             name={`${fieldPath}fieldRangeStart`}
             fieldProps={{
-              validate: (value) => validateRange(value, _.get(values, fieldPath)),
+              validate: (value) => validateRange(value, values),
             }}
-            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+            inputProps={{
+              placeholder: 'Enter a value',
+              onChange: this.handleChangeWrapper,
+              isInvalid,
+            }}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -89,9 +92,13 @@ export default class WherePopover extends Component {
           <FormikFieldNumber
             name={`${fieldPath}fieldRangeEnd`}
             fieldProps={{
-              validate: (value) => validateRange(value, _.get(values, fieldPath)),
+              validate: (value) => validateRange(value, values),
             }}
-            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+            inputProps={{
+              placeholder: 'Enter a value',
+              onChange: this.handleChangeWrapper,
+              isInvalid,
+            }}
           />
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -106,7 +113,10 @@ export default class WherePopover extends Component {
       ) : (
         <FormikFieldNumber
           name={`${fieldPath}fieldValue`}
-          inputProps={{ onChange: this.handleChangeWrapper }}
+          inputProps={{
+            placeholder: 'Enter a value',
+            onChange: this.handleChangeWrapper,
+          }}
           formRow
           rowProps={{ isInvalid, error: hasError }}
         />
@@ -126,7 +136,11 @@ export default class WherePopover extends Component {
       return (
         <FormikFieldText
           name={`${fieldPath}fieldValue`}
-          inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+          inputProps={{
+            placeholder: 'Enter a value',
+            onChange: this.handleChangeWrapper,
+            isInvalid,
+          }}
         />
       );
     }

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
@@ -39,12 +39,8 @@ export default class WherePopover extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      isOpen: false,
+      isOpen: props.openedState || false,
     };
-  }
-
-  componentDidMount() {
-    this.setState({ isOpen: this.props.openedState });
   }
 
   handleFieldChange = (option, field, form) => {
@@ -78,10 +74,14 @@ export default class WherePopover extends Component {
             fieldProps={{
               validate: (value) => validateRange(value, values),
             }}
+            formRow
+            rowProps={{
+              isInvalid,
+              error: hasError,
+            }}
             inputProps={{
               placeholder: 'Enter a value',
               onChange: this.handleChangeWrapper,
-              isInvalid,
             }}
           />
         </EuiFlexItem>
@@ -94,10 +94,14 @@ export default class WherePopover extends Component {
             fieldProps={{
               validate: (value) => validateRange(value, values),
             }}
+            formRow
+            rowProps={{
+              isInvalid,
+              error: hasError,
+            }}
             inputProps={{
               placeholder: 'Enter a value',
               onChange: this.handleChangeWrapper,
-              isInvalid,
             }}
           />
         </EuiFlexItem>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/WherePopover.js
@@ -1,0 +1,236 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { Component } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiText,
+  EuiBadge,
+} from '@elastic/eui';
+import _ from 'lodash';
+import { POPOVER_STYLE, EXPRESSION_STYLE, WHERE_BOOLEAN_FILTERS } from './utils/constants';
+import {
+  getOperators,
+  displayText,
+  validateRange,
+  isNullOperator,
+  isRangeOperator,
+  validateWhereFilter,
+} from './utils/whereHelpers';
+import { hasError, isInvalid } from '../../../../../utils/validate';
+import {
+  FormikComboBox,
+  FormikSelect,
+  FormikFieldNumber,
+  FormikFieldText,
+} from '../../../../../components/FormControls';
+import { getFilteredIndexFields, getIndexFields } from './utils/dataTypes';
+import { TRIGGER_COMPARISON_OPERATORS } from '../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
+import { DATA_TYPES } from '../../../../../utils/constants';
+
+export const ALLOWED_TYPES = ['number', 'text', 'keyword', 'boolean'];
+
+export default class WherePopover extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ isOpen: this.props.openedState });
+  }
+
+  handleFieldChange = (option, field, form) => {
+    this.props.onMadeChanges();
+    // this.resetValues();
+    form.setFieldValue(field.name, option);
+    // User can remove where condition
+    if (option.length === 0) {
+      this.resetValues();
+      form.setFieldError(this.props.fieldPath, undefined);
+    }
+  };
+
+  handleOperatorChange = (e, field, form) => {
+    this.props.onMadeChanges();
+    field.onChange(e);
+    form.setFieldError(this.props.fieldPath, undefined);
+  };
+
+  handleChangeWrapper = (e, field) => {
+    this.props.onMadeChanges();
+    field.onChange(e);
+  };
+
+  renderBetweenAnd = () => {
+    const { fieldPath = '', values } = this.props;
+    return (
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem>
+          <FormikFieldNumber
+            name={`${fieldPath}fieldRangeStart`}
+            fieldProps={{
+              validate: (value) => validateRange(value, _.get(values, fieldPath)),
+            }}
+            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText textAlign="center">TO</EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <FormikFieldNumber
+            name={`${fieldPath}fieldRangeEnd`}
+            fieldProps={{
+              validate: (value) => validateRange(value, _.get(values, fieldPath)),
+            }}
+            inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
+
+  renderValueField = (fieldType, fieldOperator) => {
+    const { fieldPath = '' } = this.props;
+    if (fieldType === DATA_TYPES.NUMBER) {
+      return isRangeOperator(fieldOperator) ? (
+        this.renderBetweenAnd()
+      ) : (
+        <FormikFieldNumber
+          name={`${fieldPath}fieldValue`}
+          inputProps={{ onChange: this.handleChangeWrapper }}
+          formRow
+          rowProps={{ isInvalid, error: hasError }}
+        />
+      );
+    } else if (fieldType === DATA_TYPES.BOOLEAN) {
+      return (
+        <FormikSelect
+          name={`${fieldPath}fieldValue`}
+          inputProps={{
+            onChange: this.handleChangeWrapper,
+            options: WHERE_BOOLEAN_FILTERS,
+            isInvalid,
+          }}
+        />
+      );
+    } else {
+      return (
+        <FormikFieldText
+          name={`${fieldPath}fieldValue`}
+          inputProps={{ onChange: this.handleChangeWrapper, isInvalid }}
+        />
+      );
+    }
+  };
+
+  resetValues = () => {
+    const { index, filtersArrayHelpers } = this.props;
+    filtersArrayHelpers.remove(index);
+  };
+
+  openPopover = () => {
+    this.props.openPopover();
+    this.setState({ isOpen: true });
+  };
+
+  closePopover = () => {
+    const { closePopover, formik, values } = this.props;
+    closePopover();
+    this.setState({ isOpen: false });
+
+    if (validateWhereFilter(values)) formik.validateForm();
+    else this.resetValues();
+  };
+
+  onCancel = () => {
+    this.closePopover();
+    this.resetValues();
+  };
+
+  render() {
+    const {
+      dataTypes,
+      fieldPath,
+      indexFieldFilters,
+      useTriggerFieldOperators = false,
+      values,
+      whereFilterHeader,
+    } = this.props;
+    const { isOpen } = this.state;
+
+    const indexFields =
+      indexFieldFilters !== undefined
+        ? getFilteredIndexFields(dataTypes, ALLOWED_TYPES, indexFieldFilters)
+        : getIndexFields(dataTypes, ALLOWED_TYPES);
+    const fieldType = _.get(values, `fieldName[0].type`, 'number');
+    const fieldOperator = _.get(values, `operator`, 'is');
+    const fieldOperators = useTriggerFieldOperators
+      ? TRIGGER_COMPARISON_OPERATORS
+      : getOperators(fieldType);
+
+    return (
+      <EuiPopover
+        id={`${whereFilterHeader}-${fieldPath}-badge-popover`}
+        button={
+          <div style={{ paddingBottom: '5px' }}>
+            <EuiBadge
+              color={'hollow'}
+              iconSide={'right'}
+              iconType={'cross'}
+              iconOnClick={this.onCancel}
+              iconOnClickAriaLabel={'Remove filter'}
+              onClick={this.openPopover}
+              onClickAriaLabel={'Edit where filter'}
+            >
+              {displayText(values)}
+            </EuiBadge>
+          </div>
+        }
+        isOpen={isOpen}
+        closePopover={this.closePopover}
+        panelPaddingSize={'none'}
+        ownFocus
+        anchorPosition={'downLeft'}
+      >
+        <EuiPopoverTitle> ADD {_.upperCase(whereFilterHeader)} </EuiPopoverTitle>
+        <div style={POPOVER_STYLE}>
+          <EuiFlexGroup style={{ ...EXPRESSION_STYLE }}>
+            <EuiFlexItem grow={false} style={{ width: 200 }}>
+              <FormikComboBox
+                name={`${fieldPath}fieldName`}
+                inputProps={{
+                  placeholder: 'Select a field',
+                  options: indexFields,
+                  onChange: this.handleFieldChange,
+                  isClearable: false,
+                  singleSelection: { asPlainText: true },
+                }}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <FormikSelect
+                name={`${fieldPath}operator`}
+                inputProps={{
+                  onChange: this.handleOperatorChange,
+                  options: fieldOperators,
+                }}
+              />
+            </EuiFlexItem>
+            {!isNullOperator(fieldOperator) && (
+              <EuiFlexItem>{this.renderValueField(fieldType, fieldOperator)}</EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </div>
+      </EuiPopover>
+    );
+  }
+}

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
@@ -28,31 +28,34 @@ exports[`WhereExpression renders 1`] = `
     >
       No filters defined.
     </div>
-  </div>
-  <button
-    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-    data-test-subj="where.addFilterButton"
-    style="padding-top:5px"
-    type="button"
-  >
-    <span
-      class="euiButtonContent euiButtonEmpty__content"
+    <div
+      class="euiSpacer euiSpacer--xs"
+    />
+    <button
+      class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+      data-test-subj="addFilterButton"
+      style="padding-top:5px"
+      type="button"
     >
       <span
-        class="euiButtonEmpty__text"
+        class="euiButtonContent euiButtonEmpty__content"
       >
-        + Add filter
+        <span
+          class="euiButtonEmpty__text"
+        >
+          + Add filter
+        </span>
       </span>
-    </span>
-  </button>
-  <div
-    class="euiText euiText--extraSmall"
-    style="padding-left:10px"
-  >
+    </button>
     <div
-      class="euiTextColor euiTextColor--subdued"
+      class="euiText euiText--extraSmall"
+      style="padding-left:10px"
     >
-      You can add up to 1  data filter.
+      <div
+        class="euiTextColor euiTextColor--subdued"
+      >
+        You can add up to 10 more data filters.
+      </div>
     </div>
   </div>
 </div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/constants.js
@@ -124,3 +124,4 @@ export const GROUP_BY_ERROR = 'Must specify at least 1 group by expression.';
 export const QUERY_TYPE_GROUP_BY_ERROR = 'Can have a maximum of 1 group by selections.';
 
 export const QUERY_TYPE_METRIC_ERROR = 'Can have a maximum of 1 metric selections.';
+export const WHERE_FILTER_ALLOWED_TYPES = ['number', 'text', 'keyword', 'boolean'];

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import { OPERATORS_MAP } from './constants';
 import { TRIGGER_COMPARISON_OPERATORS } from '../../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
 import { DATA_TYPES } from '../../../../../../utils/constants';
+import { FORMIK_INITIAL_WHERE_EXPRESSION_VALUES } from '../../../../containers/CreateMonitor/utils/constants';
 
 export const DEFAULT_WHERE_EXPRESSION_TEXT = 'All fields are included';
 
@@ -59,4 +60,18 @@ export const validateRange = (value, whereFilters) => {
   if (value < whereFilters.fieldRangeStart) {
     return 'End should be greater than start range';
   }
+};
+
+export const validateWhereFilter = (filter = FORMIK_INITIAL_WHERE_EXPRESSION_VALUES) => {
+  const fieldName = _.get(filter, 'fieldName', '');
+  const fieldOperator = _.get(filter, 'operator', 'is');
+  const fieldValue = _.get(filter, 'fieldValue', '');
+  return !(
+    _.isEmpty(fieldName) ||
+    (!isNullOperator(fieldOperator) && _.isEmpty(fieldValue.toString()))
+  );
+};
+
+export const validateWhereFilters = (filters = []) => {
+  return filters.filter((filter) => validateWhereFilter(filter)).length === filters.length;
 };

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
@@ -32,17 +32,16 @@ export const displayText = (whereValues) => {
   const comparisonOperators = _.concat(Object.values(OPERATORS_MAP), TRIGGER_COMPARISON_OPERATORS);
 
   const whereFieldName = _.get(whereValues, 'fieldName[0].label', undefined);
-  if (!whereFieldName) {
-    return DEFAULT_WHERE_EXPRESSION_TEXT;
-  }
-  const selectedOperator = _.get(whereValues, 'operator', 'is');
+  if (!whereFieldName) return DEFAULT_WHERE_EXPRESSION_TEXT;
+
+  const selectedOperator = _.get(whereValues, 'operator', OPERATORS_MAP.IS);
   const operatorObj =
     comparisonOperators.find((operator) => operator.value === selectedOperator) || {};
   const initialText = `${whereFieldName} ${operatorObj.text || ''}`;
 
   if (isRangeOperator(selectedOperator)) {
-    const startRange = _.get(whereValues, 'fieldRangeStart', 0);
-    const endRange = _.get(whereValues, 'fieldRangeEnd', 0);
+    const startRange = _.get(whereValues, 'fieldRangeStart');
+    const endRange = _.get(whereValues, 'fieldRangeEnd');
     return `${initialText} from ${startRange} to ${endRange}`;
   } else if (isNullOperator(selectedOperator)) {
     return `${initialText}`;
@@ -52,24 +51,57 @@ export const displayText = (whereValues) => {
   }
 };
 
-export const validateRange = (value, whereFilters) => {
-  if (value === '') return 'Required';
-  if (whereFilters.fieldRangeEnd < value) {
-    return 'Start should be less than end range';
-  }
-  if (value < whereFilters.fieldRangeStart) {
-    return 'End should be greater than start range';
-  }
+export const validateRange = (value = '', filter = FORMIK_INITIAL_WHERE_EXPRESSION_VALUES) => {
+  if (_.isEmpty(value.toString())) return 'Required.';
+  if (filter.fieldRangeEnd < value) return 'Start should be less than end range.';
+  if (value < filter.fieldRangeStart) return 'End should be greater than start range.';
+  return undefined;
 };
 
 export const validateWhereFilter = (filter = FORMIK_INITIAL_WHERE_EXPRESSION_VALUES) => {
-  const fieldName = _.get(filter, 'fieldName', '');
-  const fieldOperator = _.get(filter, 'operator', 'is');
-  const fieldValue = _.get(filter, 'fieldValue', '');
-  return !(
-    _.isEmpty(fieldName) ||
-    (!isNullOperator(fieldOperator) && _.isEmpty(fieldValue.toString()))
+  const fieldName = _.get(
+    filter,
+    'fieldName[0]',
+    FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.fieldName[0]
   );
+  const fieldOperator = _.get(filter, 'operator', FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.operator);
+  let filterIsValid = !_.isEmpty(fieldName[0].label);
+  switch (fieldOperator) {
+    case OPERATORS_MAP.IS:
+    case OPERATORS_MAP.IS_NOT:
+    case OPERATORS_MAP.IS_GREATER:
+    case OPERATORS_MAP.IS_GREATER_EQUAL:
+    case OPERATORS_MAP.IS_LESS:
+    case OPERATORS_MAP.IS_LESS_EQUAL:
+    case OPERATORS_MAP.STARTS_WITH:
+    case OPERATORS_MAP.ENDS_WITH:
+    case OPERATORS_MAP.CONTAINS:
+    case OPERATORS_MAP.NOT_CONTAINS:
+      // These operators store the query value in the 'fieldValue'
+      // attribute of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.
+      // Validate that value.
+      filterIsValid = filterIsValid && !_.isEmpty(filter.fieldValue?.toString());
+      break;
+    case OPERATORS_MAP.IN_RANGE:
+    case OPERATORS_MAP.NOT_IN_RANGE:
+      // These operators store the query values in the 'fieldRangeStart' and 'fieldRangeEnd'
+      // attributes of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.
+      // Both of those values need to be validated.
+      filterIsValid =
+        filterIsValid &&
+        validateRange(filter.fieldRangeStart, filter) &&
+        validateRange(filter.fieldRangeEnd, filter);
+      break;
+    case OPERATORS_MAP.IS_NULL:
+    case OPERATORS_MAP.IS_NOT_NULL:
+      // These operators don't store a query value in the FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.
+      // No further validation needed.
+      break;
+    default:
+      console.log('Unknown query operator detected:', fieldOperator);
+      filterIsValid = false;
+  }
+  return filterIsValid;
 };
 
 export const validateWhereFilters = (filters = []) => {

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
@@ -52,8 +52,9 @@ export const displayText = (whereValues) => {
 };
 
 export const validateRange = (value = '', filter = FORMIK_INITIAL_WHERE_EXPRESSION_VALUES) => {
-  if (_.isEmpty(value.toString())) return 'Required.';
-  if (filter.fieldRangeEnd < value) return 'Start should be less than end range.';
+  if (_.isEmpty(value?.toString())) return 'Required.';
+  if (filter.fieldRangeEnd < value || filter.fieldRangeStart === filter.fieldRangeEnd)
+    return 'Start should be less than end range.';
   if (value < filter.fieldRangeStart) return 'End should be greater than start range.';
   return undefined;
 };
@@ -65,7 +66,7 @@ export const validateWhereFilter = (filter = FORMIK_INITIAL_WHERE_EXPRESSION_VAL
     FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.fieldName[0]
   );
   const fieldOperator = _.get(filter, 'operator', FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.operator);
-  let filterIsValid = !_.isEmpty(fieldName[0].label);
+  let filterIsValid = !_.isEmpty(fieldName.label);
   switch (fieldOperator) {
     case OPERATORS_MAP.IS:
     case OPERATORS_MAP.IS_NOT:
@@ -89,8 +90,8 @@ export const validateWhereFilter = (filter = FORMIK_INITIAL_WHERE_EXPRESSION_VAL
       // Both of those values need to be validated.
       filterIsValid =
         filterIsValid &&
-        validateRange(filter.fieldRangeStart, filter) &&
-        validateRange(filter.fieldRangeEnd, filter);
+        !validateRange(filter.fieldRangeStart, filter) &&
+        !validateRange(filter.fieldRangeEnd, filter);
       break;
     case OPERATORS_MAP.IS_NULL:
     case OPERATORS_MAP.IS_NOT_NULL:

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
@@ -170,18 +170,36 @@ describe('whereHelpers', () => {
   });
 
   describe('validateRange', () => {
-    test('should return validation error invalid StartRange', () => {
+    test('should return validation error invalid start range', () => {
       expect(validateRange(100, { fieldRangeStart: 100, fieldRangeEnd: 50 })).toBe(
         'Start should be less than end range.'
       );
     });
-    test('should return validation error invalid endRange', () => {
+
+    test('should return validation error equal start and end range', () => {
+      expect(validateRange(100, { fieldRangeStart: 100, fieldRangeEnd: 50 })).toBe(
+        'Start should be less than end range.'
+      );
+    });
+
+    test('should return validation error invalid end range', () => {
       expect(validateRange(200, { fieldRangeStart: 300, fieldRangeEnd: 200 })).toBe(
         'End should be greater than start range.'
       );
     });
-    test('should return Required for undefined/null values', () => {
+
+    test('should return Required for empty values', () => {
       expect(validateRange('', { fieldRangeStart: '', fieldRangeEnd: 200 })).toBe('Required.');
+    });
+
+    test('should return Required for undefined values', () => {
+      expect(validateRange(undefined, { fieldRangeStart: '', fieldRangeEnd: 200 })).toBe(
+        'Required.'
+      );
+    });
+
+    test('should return Required for null values', () => {
+      expect(validateRange(null, { fieldRangeStart: '', fieldRangeEnd: 200 })).toBe('Required.');
     });
 
     test('should return undefined for valid range', () => {

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.test.js
@@ -172,16 +172,16 @@ describe('whereHelpers', () => {
   describe('validateRange', () => {
     test('should return validation error invalid StartRange', () => {
       expect(validateRange(100, { fieldRangeStart: 100, fieldRangeEnd: 50 })).toBe(
-        'Start should be less than end range'
+        'Start should be less than end range.'
       );
     });
     test('should return validation error invalid endRange', () => {
       expect(validateRange(200, { fieldRangeStart: 300, fieldRangeEnd: 200 })).toBe(
-        'End should be greater than start range'
+        'End should be greater than start range.'
       );
     });
     test('should return Required for undefined/null values', () => {
-      expect(validateRange('', { fieldRangeStart: '', fieldRangeEnd: 200 })).toBe('Required');
+      expect(validateRange('', { fieldRangeStart: '', fieldRangeEnd: 200 })).toBe('Required.');
     });
 
     test('should return undefined for valid range', () => {

--- a/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
+++ b/public/pages/CreateMonitor/components/VisualGraph/VisualGraph.test.js
@@ -55,7 +55,7 @@ const bucketMonitorValues = {
   groupedOverFieldName: 'bytes',
   bucketValue: 1,
   bucketUnitOfTime: 'h',
-  where: { fieldName: [], operator: 'is', fieldValue: '', fieldRangeStart: 0, fieldRangeEnd: 0 },
+  filters: [],
   detectorId: '',
   triggerDefinitions: [],
 };

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -14,6 +14,7 @@ exports[`AnomalyDetectors renders 1`] = `
       "detectorId": "",
       "disabled": false,
       "fieldName": Array [],
+      "filters": Array [],
       "frequency": "interval",
       "groupBy": Array [],
       "groupByField": Array [
@@ -60,13 +61,6 @@ exports[`AnomalyDetectors renders 1`] = `
         "tue": false,
         "wed": false,
       },
-      "where": Object {
-        "fieldName": Array [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is",
-      },
     }
   }
 >
@@ -84,6 +78,7 @@ exports[`AnomalyDetectors renders 1`] = `
         "detectorId": "",
         "disabled": false,
         "fieldName": Array [],
+        "filters": Array [],
         "frequency": "interval",
         "groupBy": Array [],
         "groupByField": Array [
@@ -129,13 +124,6 @@ exports[`AnomalyDetectors renders 1`] = `
           "thur": false,
           "tue": false,
           "wed": false,
-        },
-        "where": Object {
-          "fieldName": Array [],
-          "fieldRangeEnd": 0,
-          "fieldRangeStart": 0,
-          "fieldValue": "",
-          "operator": "is",
         },
       }
     }
@@ -215,6 +203,7 @@ exports[`AnomalyDetectors renders 1`] = `
                     "detectorId": "",
                     "disabled": false,
                     "fieldName": Array [],
+                    "filters": Array [],
                     "frequency": "interval",
                     "groupBy": Array [],
                     "groupByField": Array [
@@ -260,13 +249,6 @@ exports[`AnomalyDetectors renders 1`] = `
                       "thur": false,
                       "tue": false,
                       "wed": false,
-                    },
-                    "where": Object {
-                      "fieldName": Array [],
-                      "fieldRangeEnd": 0,
-                      "fieldRangeStart": 0,
-                      "fieldValue": "",
-                      "operator": "is",
                     },
                   },
                   "isSubmitting": false,
@@ -304,6 +286,7 @@ exports[`AnomalyDetectors renders 1`] = `
                     "detectorId": "",
                     "disabled": false,
                     "fieldName": Array [],
+                    "filters": Array [],
                     "frequency": "interval",
                     "groupBy": Array [],
                     "groupByField": Array [
@@ -349,13 +332,6 @@ exports[`AnomalyDetectors renders 1`] = `
                       "thur": false,
                       "tue": false,
                       "wed": false,
-                    },
-                    "where": Object {
-                      "fieldName": Array [],
-                      "fieldRangeEnd": 0,
-                      "fieldRangeStart": 0,
-                      "fieldValue": "",
-                      "operator": "is",
                     },
                   },
                 }
@@ -441,6 +417,7 @@ exports[`AnomalyDetectors renders 1`] = `
                             "detectorId": "",
                             "disabled": false,
                             "fieldName": Array [],
+                            "filters": Array [],
                             "frequency": "interval",
                             "groupBy": Array [],
                             "groupByField": Array [
@@ -486,13 +463,6 @@ exports[`AnomalyDetectors renders 1`] = `
                               "thur": false,
                               "tue": false,
                               "wed": false,
-                            },
-                            "where": Object {
-                              "fieldName": Array [],
-                              "fieldRangeEnd": 0,
-                              "fieldRangeStart": 0,
-                              "fieldValue": "",
-                              "operator": "is",
                             },
                           },
                           "isSubmitting": false,
@@ -530,6 +500,7 @@ exports[`AnomalyDetectors renders 1`] = `
                             "detectorId": "",
                             "disabled": false,
                             "fieldName": Array [],
+                            "filters": Array [],
                             "frequency": "interval",
                             "groupBy": Array [],
                             "groupByField": Array [
@@ -575,13 +546,6 @@ exports[`AnomalyDetectors renders 1`] = `
                               "thur": false,
                               "tue": false,
                               "wed": false,
-                            },
-                            "where": Object {
-                              "fieldName": Array [],
-                              "fieldRangeEnd": 0,
-                              "fieldRangeStart": 0,
-                              "fieldValue": "",
-                              "operator": "is",
                             },
                           },
                         }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -22,6 +22,7 @@ exports[`CreateMonitor renders 1`] = `
         "detectorId": "",
         "disabled": false,
         "fieldName": Array [],
+        "filters": Array [],
         "frequency": "interval",
         "groupBy": Array [],
         "groupByField": Array [
@@ -67,13 +68,6 @@ exports[`CreateMonitor renders 1`] = `
           "thur": false,
           "tue": false,
           "wed": false,
-        },
-        "where": Object {
-          "fieldName": Array [],
-          "fieldRangeEnd": 0,
-          "fieldRangeStart": 0,
-          "fieldValue": "",
-          "operator": "is",
         },
       }
     }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
@@ -198,16 +198,10 @@ Object {
       "aggregations": Array [],
       "bucketUnitOfTime": "h",
       "bucketValue": 1,
+      "filters": Array [],
       "groupBy": Array [],
       "searchType": "graph",
       "timeField": "",
-      "where": Object {
-        "fieldName": Array [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is",
-      },
     },
   },
 }
@@ -328,16 +322,10 @@ Object {
   "aggregations": Array [],
   "bucketUnitOfTime": "h",
   "bucketValue": 1,
+  "filters": Array [],
   "groupBy": Array [],
   "searchType": "graph",
   "timeField": "@timestamp",
-  "where": Object {
-    "fieldName": Array [],
-    "fieldRangeEnd": 0,
-    "fieldRangeStart": 0,
-    "fieldValue": "",
-    "operator": "is",
-  },
 }
 `;
 
@@ -346,20 +334,10 @@ Object {
   "aggregations": Array [],
   "bucketUnitOfTime": "h",
   "bucketValue": 1,
+  "filters": Array [],
   "groupBy": Array [],
   "searchType": "graph",
   "timeField": "@timestamp",
-  "where": Object {
-    "fieldName": Array [
-      Object {
-        "label": "age",
-        "type": "number",
-      },
-    ],
-    "fieldRangeEnd": 40,
-    "fieldRangeStart": 20,
-    "operator": "in_range",
-  },
 }
 `;
 
@@ -368,19 +346,10 @@ Object {
   "aggregations": Array [],
   "bucketUnitOfTime": "h",
   "bucketValue": 1,
+  "filters": Array [],
   "groupBy": Array [],
   "searchType": "graph",
   "timeField": "@timestamp",
-  "where": Object {
-    "fieldName": Array [
-      Object {
-        "label": "age",
-        "type": "number",
-      },
-    ],
-    "fieldValue": 20,
-    "operator": "is_greater_equal",
-  },
 }
 `;
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -11,6 +11,14 @@ export const BUCKET_COUNT = 5;
 
 export const MATCH_ALL_QUERY = JSON.stringify({ size: 0, query: { match_all: {} } }, null, 4);
 
+export const FORMIK_INITIAL_WHERE_EXPRESSION_VALUES = {
+  fieldName: [{ label: '', type: ALLOWED_TYPES[0] }], // This is an array because the EuiCombobox returns an array of {label: string, type: string} objects.
+  operator: OPERATORS_MAP.IS,
+  fieldValue: '',
+  fieldRangeStart: 0,
+  fieldRangeEnd: 0,
+};
+
 export const FORMIK_INITIAL_VALUES = {
   /* CONFIGURE MONITOR */
   name: '',
@@ -47,13 +55,7 @@ export const FORMIK_INITIAL_VALUES = {
   groupedOverFieldName: 'bytes',
   bucketValue: 1,
   bucketUnitOfTime: 'h', // m = minute, h = hour, d = day
-  where: {
-    fieldName: [],
-    operator: OPERATORS_MAP.IS.value,
-    fieldValue: '',
-    fieldRangeStart: 0,
-    fieldRangeEnd: 0,
-  },
+  filters: [], // array of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES
   detectorId: '',
 };
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -3,16 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OPERATORS_MAP } from '../../../components/MonitorExpressions/expressions/utils/constants';
+import {
+  WHERE_FILTER_ALLOWED_TYPES,
+  OPERATORS_MAP,
+} from '../../../components/MonitorExpressions/expressions/utils/constants';
 import { MONITOR_TYPE } from '../../../../../utils/constants';
 import { SUPPORTED_DOC_LEVEL_QUERY_OPERATORS } from '../../../components/DocumentLevelMonitorQueries/utils/constants';
+import { QUERY_OPERATORS } from '../../../../Dashboard/components/FindingsDashboard/findingsUtils';
 
 export const BUCKET_COUNT = 5;
 
 export const MATCH_ALL_QUERY = JSON.stringify({ size: 0, query: { match_all: {} } }, null, 4);
 
 export const FORMIK_INITIAL_WHERE_EXPRESSION_VALUES = {
-  fieldName: [{ label: '', type: ALLOWED_TYPES[0] }], // This is an array because the EuiCombobox returns an array of {label: string, type: string} objects.
+  fieldName: [{ label: '', type: WHERE_FILTER_ALLOWED_TYPES[0] }], // This is an array because the EuiCombobox returns an array of {label: string, type: string} objects.
   operator: OPERATORS_MAP.IS,
   fieldValue: '',
   fieldRangeStart: undefined,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -15,8 +15,8 @@ export const FORMIK_INITIAL_WHERE_EXPRESSION_VALUES = {
   fieldName: [{ label: '', type: ALLOWED_TYPES[0] }], // This is an array because the EuiCombobox returns an array of {label: string, type: string} objects.
   operator: OPERATORS_MAP.IS,
   fieldValue: '',
-  fieldRangeStart: 0,
-  fieldRangeEnd: 0,
+  fieldRangeStart: undefined,
+  fieldRangeEnd: undefined,
 };
 
 export const FORMIK_INITIAL_VALUES = {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/constants.js
@@ -17,7 +17,7 @@ export const MATCH_ALL_QUERY = JSON.stringify({ size: 0, query: { match_all: {} 
 
 export const FORMIK_INITIAL_WHERE_EXPRESSION_VALUES = {
   fieldName: [{ label: '', type: WHERE_FILTER_ALLOWED_TYPES[0] }], // This is an array because the EuiCombobox returns an array of {label: string, type: string} objects.
-  operator: OPERATORS_MAP.IS,
+  operator: OPERATORS_MAP.IS.value,
   fieldValue: '',
   fieldRangeStart: undefined,
   fieldRangeEnd: undefined,

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -304,7 +304,7 @@ export function formikToCompositeAggregation(values) {
 
 // For aggregations of query-level monitor
 export function formikToAggregation(values) {
-  const { aggregations, filters, groupBy } = values;
+  const { aggregations, groupBy } = values;
 
   let aggs = {};
   aggregations.map((aggItem) => {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.js
@@ -151,7 +151,7 @@ export function formikToUiSearch(values) {
     groupBy,
     bucketValue,
     bucketUnitOfTime,
-    where,
+    filters,
   } = values;
   return {
     searchType,
@@ -160,7 +160,7 @@ export function formikToUiSearch(values) {
     groupBy,
     bucketValue,
     bucketUnitOfTime,
-    where,
+    filters,
   };
 }
 
@@ -196,9 +196,8 @@ export function formikToGraphQuery(values) {
         return formikToAggregation(values);
     }
   };
-
   const timeField = values.timeField;
-  const filters = [
+  let filters = [
     {
       range: {
         [timeField]: {
@@ -209,10 +208,8 @@ export function formikToGraphQuery(values) {
       },
     },
   ];
-  const whereClause = formikToWhereClause(values);
-  if (whereClause) {
-    filters.push({ ...whereClause });
-  }
+  const whereFilters = formikToWhereClause(values);
+  if (whereFilters.length) filters = filters.concat(whereFilters);
   return {
     size: 0,
     aggregations: aggregation(),
@@ -307,7 +304,7 @@ export function formikToCompositeAggregation(values) {
 
 // For aggregations of query-level monitor
 export function formikToAggregation(values) {
-  const { aggregations, groupBy } = values;
+  const { aggregations, filters, groupBy } = values;
 
   let aggs = {};
   aggregations.map((aggItem) => {
@@ -334,7 +331,7 @@ export function formikToUiGraphQuery(values) {
     ? formikToUiCompositeAggregation(values)
     : formikToUiOverAggregation(values);
   const timeField = values.timeField;
-  const filters = [
+  let filters = [
     {
       range: {
         [timeField]: {
@@ -345,10 +342,8 @@ export function formikToUiGraphQuery(values) {
       },
     },
   ];
-  const whereClause = formikToWhereClause(values);
-  if (whereClause) {
-    filters.push({ ...whereClause });
-  }
+  const whereFilters = formikToWhereClause(values);
+  if (whereFilters.length) filters = filters.concat(whereFilters);
   return {
     size: 0,
     aggregations: aggregation,
@@ -392,10 +387,8 @@ export function formikToUiOverAggregation(values) {
   };
 }
 
-export function formikToWhereClause({ where }) {
-  if (where.fieldName.length > 0) {
-    return OPERATORS_QUERY_MAP[where.operator].query(where);
-  }
+export function formikToWhereClause({ filters = [] }) {
+  return filters.map((filter) => OPERATORS_QUERY_MAP[filter.operator].query(filter));
 }
 
 // For query-level monitor single metric selection

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/formikToMonitor.test.js
@@ -253,6 +253,8 @@ describe('formikToWhereClause', () => {
       { bool: { must_not: { query_string: { query: `*Se*`, default_field: 'city' } } } },
     ],
   ])('.formikToWhereClause (%j,  %S)', (fieldName, operator, fieldValue, expected) => {
-    expect(formikToWhereClause({ where: { fieldName, operator, fieldValue } })).toEqual(expected);
+    expect(formikToWhereClause({ filters: [{ fieldName, operator, fieldValue }] })[0]).toEqual(
+      expected
+    );
   });
 });

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -30,6 +30,7 @@ import { API_TYPES } from '../../components/ClusterMetricsMonitor/utils/clusterM
 import ConfigureDocumentLevelQueries from '../../components/DocumentLevelMonitorQueries/ConfigureDocumentLevelQueries';
 import FindingsDashboard from '../../../Dashboard/containers/FindingsDashboard';
 import { validDocLevelGraphQueries } from '../../components/DocumentLevelMonitorQueries/utils/helpers';
+import { validateWhereFilters } from '../../components/MonitorExpressions/expressions/utils/whereHelpers';
 
 function renderEmptyMessage(message) {
   return (
@@ -105,7 +106,7 @@ class DefineMonitor extends Component {
       aggregations: prevAggregations,
       bucketValue: prevBucketValue,
       bucketUnitOfTime: prevBucketUnitOfTime,
-      where: prevWhere,
+      filters: prevFilters,
       queries: prevQueries,
     } = prevProps.values;
     const {
@@ -117,7 +118,7 @@ class DefineMonitor extends Component {
       aggregations,
       bucketValue,
       bucketUnitOfTime,
-      where,
+      filters,
       queries,
     } = this.props.values;
     const isGraph = searchType === SEARCH_TYPE.GRAPH;
@@ -155,7 +156,7 @@ class DefineMonitor extends Component {
       prevAggregations !== aggregations ||
       prevBucketValue !== bucketValue ||
       prevBucketUnitOfTime !== bucketUnitOfTime ||
-      prevWhere !== where ||
+      (prevFilters !== filters && validateWhereFilters(filters)) ||
       prevGroupBy !== groupBy
     )
       this.onRunQuery();
@@ -280,9 +281,9 @@ class DefineMonitor extends Component {
           <QueryPerformance response={performanceResponse} />
           <EuiSpacer size="m" />
 
-          {errors.where
+          {errors.filters
             ? renderEmptyMessage(
-                'Invalid input in data filter. Remove data filter or adjust filter '
+                'Invalid input in data filters. Remove data filter or adjust filters.'
               )
             : loadingResponse
             ? renderEmptyMessage()

--- a/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
@@ -19,6 +19,7 @@ exports[`DefineMonitor renders 1`] = `
           "detectorId": "",
           "disabled": false,
           "fieldName": Array [],
+          "filters": Array [],
           "frequency": "interval",
           "groupBy": Array [],
           "groupByField": Array [
@@ -64,13 +65,6 @@ exports[`DefineMonitor renders 1`] = `
             "thur": false,
             "tue": false,
             "wed": false,
-          },
-          "where": Object {
-            "fieldName": Array [],
-            "fieldRangeEnd": 0,
-            "fieldRangeStart": 0,
-            "fieldValue": "",
-            "operator": "is",
           },
         }
       }

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -14,6 +14,7 @@ exports[`MonitorIndex renders 1`] = `
       "detectorId": "",
       "disabled": false,
       "fieldName": Array [],
+      "filters": Array [],
       "frequency": "interval",
       "groupBy": Array [],
       "groupByField": Array [
@@ -59,13 +60,6 @@ exports[`MonitorIndex renders 1`] = `
         "thur": false,
         "tue": false,
         "wed": false,
-      },
-      "where": Object {
-        "fieldName": Array [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is",
       },
     }
   }
@@ -157,6 +151,7 @@ exports[`MonitorIndex renders 1`] = `
                   "detectorId": "",
                   "disabled": false,
                   "fieldName": Array [],
+                  "filters": Array [],
                   "frequency": "interval",
                   "groupBy": Array [],
                   "groupByField": Array [
@@ -202,13 +197,6 @@ exports[`MonitorIndex renders 1`] = `
                     "thur": false,
                     "tue": false,
                     "wed": false,
-                  },
-                  "where": Object {
-                    "fieldName": Array [],
-                    "fieldRangeEnd": 0,
-                    "fieldRangeStart": 0,
-                    "fieldValue": "",
-                    "operator": "is",
                   },
                 },
                 "isSubmitting": false,
@@ -246,6 +234,7 @@ exports[`MonitorIndex renders 1`] = `
                   "detectorId": "",
                   "disabled": false,
                   "fieldName": Array [],
+                  "filters": Array [],
                   "frequency": "interval",
                   "groupBy": Array [],
                   "groupByField": Array [
@@ -291,13 +280,6 @@ exports[`MonitorIndex renders 1`] = `
                     "thur": false,
                     "tue": false,
                     "wed": false,
-                  },
-                  "where": Object {
-                    "fieldName": Array [],
-                    "fieldRangeEnd": 0,
-                    "fieldRangeStart": 0,
-                    "fieldValue": "",
-                    "operator": "is",
                   },
                 },
               }
@@ -399,6 +381,7 @@ exports[`MonitorIndex renders 1`] = `
                           "detectorId": "",
                           "disabled": false,
                           "fieldName": Array [],
+                          "filters": Array [],
                           "frequency": "interval",
                           "groupBy": Array [],
                           "groupByField": Array [
@@ -444,13 +427,6 @@ exports[`MonitorIndex renders 1`] = `
                             "thur": false,
                             "tue": false,
                             "wed": false,
-                          },
-                          "where": Object {
-                            "fieldName": Array [],
-                            "fieldRangeEnd": 0,
-                            "fieldRangeStart": 0,
-                            "fieldValue": "",
-                            "operator": "is",
                           },
                         },
                         "isSubmitting": false,
@@ -488,6 +464,7 @@ exports[`MonitorIndex renders 1`] = `
                           "detectorId": "",
                           "disabled": false,
                           "fieldName": Array [],
+                          "filters": Array [],
                           "frequency": "interval",
                           "groupBy": Array [],
                           "groupByField": Array [
@@ -533,13 +510,6 @@ exports[`MonitorIndex renders 1`] = `
                             "thur": false,
                             "tue": false,
                             "wed": false,
-                          },
-                          "where": Object {
-                            "fieldName": Array [],
-                            "fieldRangeEnd": 0,
-                            "fieldRangeStart": 0,
-                            "fieldValue": "",
-                            "operator": "is",
                           },
                         },
                       }

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -63,13 +63,7 @@ export const FORMIK_INITIAL_TRIGGER_VALUES = {
     anomalyConfidenceThresholdValue: 0.7,
     anomalyConfidenceThresholdEnum: 'ABOVE',
   },
-  where: {
-    fieldName: [],
-    operator: 'includes',
-    fieldValue: '',
-    fieldRangeStart: 0,
-    fieldRangeEnd: 0,
-  },
+  filters: [], // array of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES with default 'operator' of 'include'
   actions: undefined,
 };
 

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/constants.js
@@ -63,7 +63,7 @@ export const FORMIK_INITIAL_TRIGGER_VALUES = {
     anomalyConfidenceThresholdValue: 0.7,
     anomalyConfidenceThresholdEnum: 'ABOVE',
   },
-  filters: [], // array of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES with default 'operator' of 'include'
+  filters: [], // array of FORMIK_INITIAL_WHERE_EXPRESSION_VALUES with default 'operator' of 'includes'
   actions: undefined,
 };
 

--- a/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/utils/formikToTrigger.js
@@ -16,6 +16,7 @@ import {
 import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../../utils/constants';
 import { NOTIFY_OPTIONS_VALUES } from '../../../components/Action/actions/Message';
 import { FORMIK_INITIAL_ACTION_VALUES } from '../../../utils/constants';
+import { FORMIK_INITIAL_WHERE_EXPRESSION_VALUES } from '../../../../CreateMonitor/containers/CreateMonitor/utils/constants';
 
 export function formikToTrigger(values, monitorUiMetadata = {}) {
   const triggerDefinitions = _.get(values, 'triggerDefinitions');
@@ -333,15 +334,17 @@ export function getResultsPath(isCount) {
   return isCount ? HITS_TOTAL_RESULTS_PATH : AGGREGATION_RESULTS_PATH;
 }
 
-export function getCompositeAggFilter({ where }) {
-  const fieldName = _.get(where, 'fieldName', FORMIK_INITIAL_TRIGGER_VALUES.where.fieldName);
+export function getCompositeAggFilter({ filters = [] }) {
   const composite_agg_filter = {};
-  if (fieldName.length > 0) {
-    composite_agg_filter[where.fieldName[0].label] = {
-      [where.operator]: where.fieldValue,
-    };
-    return composite_agg_filter;
-  }
+  filters.forEach((filter) => {
+    const fieldName = _.get(filter, 'fieldName', FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.fieldName);
+    if (fieldName.length > 0) {
+      composite_agg_filter[fieldName[0].label] = {
+        [filter.operator]: filter.fieldValue,
+      };
+    }
+  });
+  if (!_.isEmpty(composite_agg_filter)) return composite_agg_filter;
 }
 
 export function getRelationalOperator(thresholdEnum) {

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
@@ -43,6 +43,7 @@ exports[`AcknowledgeAlertsModal renders 1`] = `
       "detectorId": "",
       "disabled": false,
       "fieldName": Array [],
+      "filters": Array [],
       "frequency": "interval",
       "groupBy": Array [],
       "groupByField": Array [
@@ -88,13 +89,6 @@ exports[`AcknowledgeAlertsModal renders 1`] = `
         "thur": false,
         "tue": false,
         "wed": false,
-      },
-      "where": Object {
-        "fieldName": Array [],
-        "fieldRangeEnd": 0,
-        "fieldRangeStart": 0,
-        "fieldValue": "",
-        "operator": "is",
       },
     }
   }

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -46,3 +46,13 @@ export const inputLimitText = (
     </EuiText>
   );
 };
+
+// A helper function that recursively flattens objects to dot notation format.
+export function flattenObject(object = {}, prefix = '') {
+  return Object.keys(object).reduce((obj, key) => {
+    const pre = prefix.length ? prefix + '.' : '';
+    if (typeof object[key] === 'object') Object.assign(obj, flattenObject(object[key], pre + key));
+    else obj[pre + key] = object[key];
+    return obj;
+  }, {});
+}

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -46,13 +46,3 @@ export const inputLimitText = (
     </EuiText>
   );
 };
-
-// A helper function that recursively flattens objects to dot notation format.
-export function flattenObject(object = {}, prefix = '') {
-  return Object.keys(object).reduce((obj, key) => {
-    const pre = prefix.length ? prefix + '.' : '';
-    if (typeof object[key] === 'object') Object.assign(obj, flattenObject(object[key], pre + key));
-    else obj[pre + key] = object[key];
-    return obj;
-  }, {});
-}


### PR DESCRIPTION
### Description
Implemented support for configuring up to 10 data filters for query and bucket level monitors using the visual editor.
 
### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/432

### Screenshots
![Screenshot 2023-03-29 at 2 39 15 PM](https://user-images.githubusercontent.com/79280347/228673898-6c32d0c2-9e2c-444e-bc08-568f195f3797.png)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
