### PR TITLE
Disable selector in ad flyout

### DIFF
--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/AnomalyDetectors.js
@@ -96,6 +96,7 @@ class AnomalyDetectors extends React.Component {
             singleSelection: { asPlaintext: true },
             isClearable: false,
             selectedOptions,
+            isDisabled: flyoutMode === 'adMonitor',
           }}
         />
       </div>


### PR DESCRIPTION
### Description
Disable selector in ad flyout. This selector input field is automatically selected, based on the detector the AD plugin provides when launching the alerting flyout.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
