### PR TITLE
Fix: CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-@lezzago
-@AWSHurneyt
-@amsiglan
-@sbcd90
-@eirsep
-@getsaurabh02
-@praveensameneni
+# This should match the list in MAINTAINERS.md.
+* @lezzago @qreshi @bowenlan-amzn @getsaurabh02 @rishabhmaurya @sbcd90 @eirsep @AWSHurneyt @amsiglan 


### PR DESCRIPTION
### Description

The syntax is not what it seems to be. Synced the list with MAINTAINERS and actual permissions.
  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
