### PR TITLE
adjust embeddable rendering with context menu flyout

### DIFF
--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/CreateNew.js
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/CreateNew.js
@@ -5,7 +5,7 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
 import { EuiTitle, EuiIcon, EuiText, EuiSwitch, EuiSpacer, EuiCallOut } from '@elastic/eui';
-import { EmbeddablePanel } from '../../../../../../../src/plugins/embeddable/public';
+import { EmbeddableRenderer } from '../../../../../../../src/plugins/embeddable/public';
 import { NotificationService } from '../../../../services';
 import _ from 'lodash';
 import { FieldArray } from 'formik';
@@ -103,14 +103,7 @@ function CreateNew({ embeddable, core, flyoutMode, formikProps, history, setFlyo
       </div>
       <div className={`create-new__vis ${!isShowVis && 'create-new__vis--hidden'}`}>
         <EuiSpacer size="s" />
-        <EmbeddablePanel
-          embeddable={embeddable}
-          getActions={() => Promise.resolve([])}
-          inspector={{ isAvailable: () => false }}
-          hideHeader
-          isDestroyPrevented
-          isBorderless
-        />
+        <EmbeddableRenderer embeddable={embeddable} />
       </div>
       <EuiSpacer size="l" />
       <EuiTitle size="s">

--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/styles.scss
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/styles.scss
@@ -1,7 +1,5 @@
 .create-new {
   &__vis {
-    height: 400px;
-
     &--hidden {
       display: none;
     }
@@ -19,5 +17,6 @@
 
   .visualization {
     padding: 0;
+    height: 400px;
   }
 }


### PR DESCRIPTION
### Description
Adjusts the flyout to use the `EmbeddableRenderer`, because it displays the embeddable without a border as needed. Before, we were relying on props within the `EmbeddablePanel`, which required changes to OpenDashboards to work.
 
### Issues Resolved
Related to discoveries in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3924
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
