### PR TITLE
add group category and order for context menu

### DIFF
--- a/public/utils/contextMenu/actions.tsx
+++ b/public/utils/contextMenu/actions.tsx
@@ -66,6 +66,8 @@ const grouping: Action['grouping'] = [
     id: ALERTING_ACTION_CONTEXT_GROUP_ID,
     getDisplayName: () => 'Alerting',
     getIconType: () => 'bell',
+    category: 'vis_augmenter',
+    order: 30,
   },
 ];
 


### PR DESCRIPTION
### Description
Adds a category and order to the context menu group for the dashboard integration. This allows the context menu to be grouped with Anomalies and View Event.
 
### Issues Resolved
https://github.com/opensearch-project/ux/issues/66
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
