### PR TITLE
[Composite monitor] Fixed condition selection of first expression in visual editor

### DIFF
--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
@@ -20,11 +20,11 @@ export const conditionToExpressions = (condition = '', monitors) => {
     '||': 'OR',
     '!': 'NOT',
     '': '',
-    '&& !': 'AND_NOT',
-    '|| !': 'OR_NOT',
+    '&& !': 'AND NOT',
+    '|| !': 'OR NOT',
   };
   const queryToExpressionRegex = new RegExp(
-    /( && || \|\| || && \!|| \|\| \!)?(monitor\[id=(.*?)\])/,
+    /(!|| && || \|\| || && \!|| \|\| \!)?(monitor\[id=(.*?)\])/,
     'gm'
   );
   const matcher = condition.matchAll(queryToExpressionRegex);
@@ -74,12 +74,15 @@ const ExpressionBuilder = ({
     ...DEFAULT_EXPRESSION,
     description: DEFAULT_CONDITION,
   };
-  const FIRST_EXPRESSION_CONDITIONS_MAP = [{ description: 'NOT', label: 'NOT' }];
+  const FIRST_EXPRESSION_CONDITIONS_MAP = [
+    { description: '', label: '' },
+    { description: 'NOT', label: 'NOT' },
+  ];
   const EXPRESSION_CONDITIONS_MAP = [
     { description: 'AND', label: 'AND' },
     { description: 'OR', label: 'OR' },
-    { description: 'AND_NOT', label: 'AND NOT' },
-    { description: 'OR_NOT', label: 'OR NOT' },
+    { description: 'AND NOT', label: 'AND NOT' },
+    { description: 'OR NOT', label: 'OR NOT' },
   ];
 
   const [usedExpressions, setUsedExpressions] = useState([DEFAULT_EXPRESSION]);
@@ -144,8 +147,8 @@ const ExpressionBuilder = ({
       OR: '|| ',
       NOT: '!',
       '': '',
-      AND_NOT: '&& !',
-      OR_NOT: '|| !',
+      'AND NOT': '&& !',
+      'OR NOT': '|| !',
     };
 
     const condition = expressions.reduce((query, expression) => {

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/DefineCompositeLevelTrigger.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/DefineCompositeLevelTrigger.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { EuiSpacer, EuiText, EuiTitle, EuiAccordion, EuiButton } from '@elastic/eui';
 import { FormikFieldText, FormikSelect } from '../../../../components/FormControls';
-import { hasError, isInvalid } from '../../../../utils/validate';
+import { hasError, isInvalid, required } from '../../../../utils/validate';
 import { DEFAULT_TRIGGER_NAME, SEVERITY_OPTIONS } from '../../utils/constants';
 import CompositeTriggerCondition from '../../components/CompositeTriggerCondition/CompositeTriggerCondition';
 import TriggerNotifications from './TriggerNotifications';
@@ -110,7 +110,9 @@ class DefineCompositeLevelTrigger extends Component {
 
           <FormikFieldText
             name={`${formikFieldPath}name`}
-            fieldProps={{}}
+            fieldProps={{
+              validate: required,
+            }}
             formRow
             rowProps={{
               ...defaultRowProps,


### PR DESCRIPTION
### Description
When a condition is selected for the first expression of trigger condition it gets removed during conversion between expression object to the string condition. This PR fixes the regex matcher to account for the condition applied to the first expression.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
