### PR TITLE
[Composite monitor] Add item_type field to monitor response

### DIFF
--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -351,8 +351,8 @@ export default class MonitorService {
         } = result;
         const monitor = _source.monitor ? _source.monitor : _source;
         monitor['item_type'] = monitor.workflow_type || monitor.monitor_type;
-        const { name, enabled } = monitor;
-        return [id, { id, version, ifSeqNo, ifPrimaryTerm, name, enabled, monitor }];
+        const { name, enabled, item_type } = monitor;
+        return [id, { id, version, ifSeqNo, ifPrimaryTerm, name, enabled, item_type, monitor }];
       }, {});
       const monitorMap = new Map(monitorKeyValueTuples);
       const associatedCompositeMonitorCountMap = {};


### PR DESCRIPTION
### Description
We need to display the type of a monitor in the Monitors list table for which the item_type field needs to be populated in the `getMonitors` response.

<img width="696" alt="image" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/114732919/0cc1818e-cfea-4fca-a62b-5dcdd3ff1f67">

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
