### PR TITLE
[Composite monitor] Filtered associated alerts on the chained alerts details flyout

### DIFF
--- a/public/pages/Dashboard/components/ChainedAlertDetailsFlyout/ChainedAlertDetailsFlyout.tsx
+++ b/public/pages/Dashboard/components/ChainedAlertDetailsFlyout/ChainedAlertDetailsFlyout.tsx
@@ -22,7 +22,9 @@ export const ChainedAlertDetailsFlyout = ({ closeFlyout, alert, httpClient }) =>
     httpClient.get('../api/alerting/workflows/alerts', { query: { workflowIds: alert.workflow_id, getAssociatedAlerts: true }})
     .then((response: any) => {
       if (response.ok) {
-        setAssociatedAlerts(response.resp.associatedAlerts);
+        const associatedAlertIds = new Set(alert.associated_alert_ids);
+        const associatedAlerts = response.resp.associatedAlerts.filter(a => associatedAlertIds.has(a.id));
+        setAssociatedAlerts(associatedAlerts);
       }
     })
   }, []);


### PR DESCRIPTION
### Description
Currently all the underlying associated alerts for a workflow get displayed for a chained alert. This PR uses the associated alert ids inside a chained alert to filter the list of associated alerts.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
