### PR TITLE
Fix monitor parse and alerts table

### DIFF
--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -493,7 +493,9 @@ export default class MonitorDetails extends Component {
             ) : null}
             {this.state.tabContent}
           </div>
-        ) : null}
+        ) : (
+          this.renderAlertsTable()
+        )}
 
         {isJsonModalOpen && (
           <EuiOverlayMask>

--- a/public/utils/contextMenu/monitors.ts
+++ b/public/utils/contextMenu/monitors.ts
@@ -22,7 +22,7 @@ const getMonitors = async (params) => {
 
 const parseMonitor = (monitor) => {
   const state = monitor.monitor.enabled ? 'enabled' : 'disabled';
-  const latestAlert = monitor.latestAlert === "--" ? undefined : monitor.latestAlert;
+  const latestAlert = monitor.lastNotificationTime === "--" ? undefined : monitor.lastNotificationTime;
   return {
     name: monitor.name,
     state: state,


### PR DESCRIPTION
### Description
Fix retrieving the correct latest alert time for the Alerts on Dashboards visualization feature.
Fix showing the alerts table on monitor details page. The issue was introduced in #611
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
