### PR TITLE
Optimize fetching of augment-vis saved objects

### DIFF
--- a/public/utils/savedObjectHelper.tsx
+++ b/public/utils/savedObjectHelper.tsx
@@ -51,14 +51,14 @@ export const validateAssociationIsAllow = async (visId, sendDangerToast = false)
 export const getCountOfAssociatedObjects = async (visId) => {
   const loader = getSavedAugmentVisLoader();
 
-  return await loader.findAll().then(async (resp) => {
+  return await loader.findAll('', 100, [], {
+      type: 'visualization',
+      id: visId,
+    }
+  ).then(async (resp) => {
     if (resp !== undefined) {
       const savedAugmentObjects = get(resp, 'hits', []);
-      // gets all the saved object for this visualization
-      const savedObjectsForThisVisualization = savedAugmentObjects.filter(
-        (savedObj) => get(savedObj, 'visId', '') === visId
-      );
-      return savedObjectsForThisVisualization.length;
+      return savedAugmentObjects.length;
     }
   });
 };
@@ -119,7 +119,11 @@ export const deleteAlertingAugmentVisSavedObj = async (
   monitorId: string
 ): Promise<void> => {
   const savedObjectLoader = getSavedAugmentVisLoader();
-  await savedObjectLoader.findAll().then(async (resp) => {
+  await savedObjectLoader.findAll('', 100, [], {
+      type: 'visualization',
+      id: visId,
+    }
+  ).then(async (resp) => {
     if (resp !== undefined) {
       const savedAugmentObjects = get(resp, 'hits', []);
       // gets all the saved object for this visualization

--- a/public/utils/savedObjectHelper.tsx
+++ b/public/utils/savedObjectHelper.tsx
@@ -126,14 +126,9 @@ export const deleteAlertingAugmentVisSavedObj = async (
   ).then(async (resp) => {
     if (resp !== undefined) {
       const savedAugmentObjects = get(resp, 'hits', []);
-      // gets all the saved object for this visualization
-      const savedAugmentForThisVisualization = savedAugmentObjects.filter(
-        (savedObj) => get(savedObj, 'visId', '') === visId
-      );
-
       // find saved Augment object matching detector we want to unlink
       // There should only be one detector and vis pairing
-      const savedAugmentToUnlink = savedAugmentForThisVisualization.find(
+      const savedAugmentToUnlink = savedAugmentObjects.find(
         (savedObject) => get(savedObject, 'pluginResource.id', '') === monitorId
       );
       const savedObjectToUnlinkId = get(savedAugmentToUnlink, 'id', '');


### PR DESCRIPTION
### Description
Updates saved object loader findAll() calls to include a hasReference argument so only objects that include the desired vis ID as a reference will be fetched. Part of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595.

Tested against cluster with the change in OSD, works as expected.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
