### PR TITLE
[Composite monitors] Check for selected monitors when validating trigger condition

### DIFF
--- a/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.js
+++ b/public/components/FormControls/FormikInputWrapper/FormikInputWrapper.js
@@ -15,7 +15,7 @@ const FormikInputWrapper = ({ name, fieldProps, render }) => (
 
 FormikInputWrapper.propTypes = {
   name: PropTypes.string.isRequired,
-  fieldProps: PropTypes.object.isRequired,
+  fieldProps: PropTypes.object,
   render: PropTypes.func.isRequired,
 };
 

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
@@ -228,7 +228,8 @@ const ExpressionBuilder = ({
   );
 
   const hasInvalidExpression = () =>
-    !!usedExpressions.filter((expression) => expression.monitor_id === '')?.length;
+    !!usedExpressions.filter((expression) => expression.monitor_id === '')?.length ||
+    options.length < usedExpressions.length;
 
   const isValid = () => options.length > 1 && usedExpressions.length > 1 && !hasInvalidExpression();
 
@@ -236,6 +237,9 @@ const ExpressionBuilder = ({
     if (options.length < 2) return 'Trigger condition requires at least two associated monitors.';
     if (usedExpressions.length < 2)
       return 'Trigger condition requires at least two monitors selected.';
+    if (options.length < usedExpressions.length) {
+      return 'Trigger condition is using unselected Delegate monitor.';
+    }
     if (hasInvalidExpression()) return 'Invalid expressions.';
   };
 
@@ -307,7 +311,7 @@ const ExpressionBuilder = ({
     <FormikInputWrapper
       name={formikFullFieldValue}
       fieldProps={{
-        validate: () => validate(),
+        validate,
       }}
       render={({ form }) => (
         <FormikFormRow


### PR DESCRIPTION
### Description
When a monitor that is used in trigger condition is deleted from the Delegate monitor list, it makes the trigger condition invalid. Added a check to ensure creation is blocked until the trigger condition is updated
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
