### PR TITLE
[Backport 2.10] Removed "last updated by" sections from the UI. (#767)

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.10'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.10.0'
   ALERTING_PLUGIN_BRANCH: '2.10'
 jobs:
   tests:

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.10.0'
-  ALERTING_PLUGIN_BRANCH: '2.10.0.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.10'
+  ALERTING_PLUGIN_BRANCH: '2.10'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  ALERTING_PLUGIN_BRANCH: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.11.0'
+  ALERTING_PLUGIN_BRANCH: '2.11.0.0'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -66,7 +66,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          yarn start --no-base-path --no-watch &
+          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
           sleep 300
         # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601/api/status)" != "200" ]]; do sleep 5; done'
       - name: Run Cypress tests

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.11.0'
-  ALERTING_PLUGIN_BRANCH: '2.11.0.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.10.0'
+  ALERTING_PLUGIN_BRANCH: '2.10.0.0'
 jobs:
   tests:
     name: Run Cypress E2E tests

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.10.0'
 jobs:
   tests:
     name: Run unit tests

--- a/cypress/integration/monitors_dashboard_spec.js
+++ b/cypress/integration/monitors_dashboard_spec.js
@@ -102,7 +102,7 @@ describe('Monitors dashboard page', () => {
 
   it('Displays expected number of alerts', () => {
     // Ensure the 'Monitor name' column is sorted in ascending order by sorting another column first
-    cy.contains('Last updated by').click({ force: true });
+    cy.contains('Last notification time').click({ force: true });
     cy.contains('Monitor name').click({ force: true });
 
     testMonitors.forEach((entry) => {

--- a/public/pages/Destinations/containers/DestinationsList/utils/constants.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/constants.js
@@ -42,13 +42,4 @@ export const staticColumns = [
       }
     },
   },
-  {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    width: '100px',
-    render: (value) => (value && value.name ? value.name : '-'),
-  },
 ];

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -143,20 +143,6 @@ exports[`MonitorOverview renders 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiText euiText--extraSmall"
-        >
-          <strong>
-            Last updated by
-          </strong>
-          <div>
-            -
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -120,16 +120,6 @@ export default function getOverviewStats(
       header: 'Monitor version number',
       value: monitorVersion,
     },
-    {
-      /* There are 3 cases:
-      1. Monitors created by older versions and never updated.
-         These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-      2. Monitors are created when security plugin is disabled, these will have empty User object.
-         (`monitor.user.name`, `monitor.user.roles` are empty )
-      3. Monitors are created when security plugin is enabled, these will have an User object. */
-      header: 'Last updated by',
-      value: monitor.user && monitor.user.name ? monitor.user.name : '-',
-    },
   ];
 
   return overviewStats;

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
@@ -46,10 +46,6 @@ describe('getOverviewStats', () => {
         header: 'Monitor version number',
         value: monitorVersion,
       },
-      {
-        header: 'Last updated by',
-        value: monitor.user.name,
-      },
     ]);
   });
 });

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -58,14 +58,6 @@ exports[`Monitors renders 1`] = `
             "truncateText": false,
           },
           Object {
-            "field": "user",
-            "name": "Last updated by",
-            "render": [Function],
-            "sortable": true,
-            "textOnly": true,
-            "truncateText": true,
-          },
-          Object {
             "field": "latestAlert",
             "name": "Latest alert",
             "sortable": false,

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -46,20 +46,6 @@ export const columns = [
     render: (item_type) => getItemLevelType(item_type),
   },
   {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    /* There are 3 cases:
-    1. Monitors created by older versions and never updated.
-       These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-    2. Monitors are created when security plugin is disabled, these will have empty User object.
-       (`monitor.user.name`, `monitor.user.roles` are empty )
-    3. Monitors are created when security plugin is enabled, these will have an User object. */
-    render: (_, item) => (item.user && item.user.name ? item.user.name : '-'),
-  },
-  {
     field: 'latestAlert',
     name: 'Latest alert',
     sortable: false,

--- a/release-notes/opensearch-alerting-dashboards-plugin.release-notes-2.10.0.0.md
+++ b/release-notes/opensearch-alerting-dashboards-plugin.release-notes-2.10.0.0.md
@@ -1,0 +1,13 @@
+## Version 2.10.0.0 2023-09-06
+Compatible with OpenSearch Dashboards 2.10.0
+
+### Maintenance
+* Incremented version to 2.10 ([#703](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/703))
+* bump @cypress/request to 3.0.0 due to CVE-2023-28155 ([#704](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/704))
+
+### Features
+* Updates for dark mode theme ([#695](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/695))
+* Add default Notification subject  ([#701](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/701))
+
+### Documentation
+* Add 2.10.0 release notes ([#707](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/707))


### PR DESCRIPTION
### Description
1. Manual backport of PR #767. 
2. Adjusted cypress workflow references for v2.10.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
