### PR TITLE
remove last updated backported to 2.1

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,10 +2,10 @@ name: E2E Cypress tests
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
-      - "*"
+      - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.1.0'
   OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
@@ -68,7 +68,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          yarn start --no-base-path --no-watch &
+          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
           sleep 300
         # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601/api/status)" != "200" ]]; do sleep 5; done'
       - name: Run Cypress tests

--- a/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
@@ -913,15 +913,6 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                   "width": "100px",
                 },
                 Object {
-                  "field": "user",
-                  "name": "Last updated by",
-                  "render": [Function],
-                  "sortable": true,
-                  "textOnly": true,
-                  "truncateText": true,
-                  "width": "100px",
-                },
-                Object {
                   "actions": Array [
                     Object {
                       "description": "View this destination.",
@@ -1012,13 +1003,6 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                                     "isSorted": false,
                                     "key": "_data_s_type_1",
                                     "name": "Destination type",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_user_2",
-                                    "name": "Last updated by",
                                     "onSort": [Function],
                                   },
                                 ]
@@ -1270,67 +1254,8 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                             </th>
                           </EuiTableHeaderCell>
                           <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_user_2"
-                            isSorted={false}
-                            key="_data_h_user_2"
-                            onSort={[Function]}
-                            width="100px"
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_user_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": "100px",
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Last updated by",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Last updated by"
-                                        >
-                                          Last updated by
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
                             align="right"
-                            key="_actions_h_3"
+                            key="_actions_h_2"
                             width="35px"
                           >
                             <th
@@ -1384,12 +1309,12 @@ exports[`DestinationsList renders when Notification plugin is installed 1`] = `
                           >
                             <EuiTableRowCell
                               align="center"
-                              colSpan={4}
+                              colSpan={3}
                               isMobileFullWidth={true}
                             >
                               <td
                                 className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                                colSpan={4}
+                                colSpan={3}
                                 style={
                                   Object {
                                     "width": undefined,
@@ -2245,15 +2170,6 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                   "width": "100px",
                 },
                 Object {
-                  "field": "user",
-                  "name": "Last updated by",
-                  "render": [Function],
-                  "sortable": true,
-                  "textOnly": true,
-                  "truncateText": true,
-                  "width": "100px",
-                },
-                Object {
                   "actions": Array [
                     Object {
                       "description": "View this destination.",
@@ -2344,13 +2260,6 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                                     "isSorted": false,
                                     "key": "_data_s_type_1",
                                     "name": "Destination type",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_user_2",
-                                    "name": "Last updated by",
                                     "onSort": [Function],
                                   },
                                 ]
@@ -2602,67 +2511,8 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                             </th>
                           </EuiTableHeaderCell>
                           <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_user_2"
-                            isSorted={false}
-                            key="_data_h_user_2"
-                            onSort={[Function]}
-                            width="100px"
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_user_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": "100px",
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Last updated by",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Last updated by"
-                                        >
-                                          Last updated by
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
                             align="right"
-                            key="_actions_h_3"
+                            key="_actions_h_2"
                             width="35px"
                           >
                             <th
@@ -2716,12 +2566,12 @@ exports[`DestinationsList renders when Notification plugin is not installed 1`] 
                           >
                             <EuiTableRowCell
                               align="center"
-                              colSpan={4}
+                              colSpan={3}
                               isMobileFullWidth={true}
                             >
                               <td
                                 className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                                colSpan={4}
+                                colSpan={3}
                                 style={
                                   Object {
                                     "width": undefined,
@@ -3613,15 +3463,6 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                   "width": "100px",
                 },
                 Object {
-                  "field": "user",
-                  "name": "Last updated by",
-                  "render": [Function],
-                  "sortable": true,
-                  "textOnly": true,
-                  "truncateText": true,
-                  "width": "100px",
-                },
-                Object {
                   "actions": Array [
                     Object {
                       "description": "View this destination.",
@@ -3712,13 +3553,6 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                                     "isSorted": false,
                                     "key": "_data_s_type_1",
                                     "name": "Destination type",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_user_2",
-                                    "name": "Last updated by",
                                     "onSort": [Function],
                                   },
                                 ]
@@ -3970,67 +3804,8 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                             </th>
                           </EuiTableHeaderCell>
                           <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_user_2"
-                            isSorted={false}
-                            key="_data_h_user_2"
-                            onSort={[Function]}
-                            width="100px"
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_user_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": "100px",
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Last updated by",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Last updated by"
-                                        >
-                                          Last updated by
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
                             align="right"
-                            key="_actions_h_3"
+                            key="_actions_h_2"
                             width="35px"
                           >
                             <th
@@ -4084,12 +3859,12 @@ exports[`DestinationsList renders when email is disallowed 1`] = `
                           >
                             <EuiTableRowCell
                               align="center"
-                              colSpan={4}
+                              colSpan={3}
                               isMobileFullWidth={true}
                             >
                               <td
                                 className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                                colSpan={4}
+                                colSpan={3}
                                 style={
                                   Object {
                                     "width": undefined,

--- a/public/pages/Destinations/containers/DestinationsList/utils/constants.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/constants.js
@@ -42,13 +42,4 @@ export const staticColumns = [
       }
     },
   },
-  {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    width: '100px',
-    render: (value) => (value && value.name ? value.name : '-'),
-  },
 ];

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -143,20 +143,6 @@ exports[`MonitorOverview renders 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiText euiText--extraSmall"
-        >
-          <strong>
-            Last updated by
-          </strong>
-          <div>
-            -
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -115,15 +115,5 @@ export default function getOverviewStats(
       header: 'Monitor version number',
       value: monitorVersion,
     },
-    {
-      /* There are 3 cases:
-      1. Monitors created by older versions and never updated.
-         These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-      2. Monitors are created when security plugin is disabled, these will have empty User object.
-         (`monitor.user.name`, `monitor.user.roles` are empty )
-      3. Monitors are created when security plugin is enabled, these will have an User object. */
-      header: 'Last updated by',
-      value: monitor.user && monitor.user.name ? monitor.user.name : '-',
-    },
   ];
 }

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
@@ -46,10 +46,6 @@ describe('getOverviewStats', () => {
         header: 'Monitor version number',
         value: monitorVersion,
       },
-      {
-        header: 'Last updated by',
-        value: monitor.user.name,
-      },
     ]);
   });
 });

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -44,15 +44,6 @@ exports[`Monitors renders 1`] = `
           "width": "150px",
         },
         Object {
-          "field": "user",
-          "name": "Last updated by",
-          "render": [Function],
-          "sortable": true,
-          "textOnly": true,
-          "truncateText": true,
-          "width": "100px",
-        },
-        Object {
           "field": "latestAlert",
           "name": "Latest alert",
           "sortable": false,

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -26,22 +26,6 @@ export const columns = [
     render: (name, item) => <EuiLink href={`${PLUGIN_NAME}#/monitors/${item.id}`}>{name}</EuiLink>,
   },
   {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    width: '100px',
-    /* There are 3 cases:
-    1. Monitors created by older versions and never updated.
-       These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-    2. Monitors are created when security plugin is disabled, these will have empty User object.
-       (`monitor.user.name`, `monitor.user.roles` are empty )
-    3. Monitors are created when security plugin is enabled, these will have an User object. */
-    render: (_, item) =>
-      item.monitor.user && item.monitor.user.name ? item.monitor.user.name : '-',
-  },
-  {
     field: 'latestAlert',
     name: 'Latest alert',
     sortable: false,


### PR DESCRIPTION
### Description
Removed "last updated by" sections from the UI as the SearchMonitor API is no longer intended to return that info. See the issue below for more details.

I have backported for 2.1
 
### Issues Resolved
#763
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
