### PR TITLE
remove last updated backported to 2.7

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -2,10 +2,10 @@ name: E2E Cypress tests
 on:
   pull_request:
     branches:
-      - "*"
+      - '*'
   push:
     branches:
-      - "*"
+      - '*'
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
   OPENSEARCH_VERSION: '2.7.0-SNAPSHOT'
@@ -67,7 +67,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          yarn start --no-base-path --no-watch &
+          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
           sleep 300
         # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601/api/status)" != "200" ]]; do sleep 5; done'
       - name: Run Cypress tests

--- a/cypress/integration/monitors_dashboard_spec.js
+++ b/cypress/integration/monitors_dashboard_spec.js
@@ -102,7 +102,7 @@ describe('Monitors dashboard page', () => {
 
   it('Displays expected number of alerts', () => {
     // Ensure the 'Monitor name' column is sorted in ascending order by sorting another column first
-    cy.contains('Last updated by').click({ force: true });
+    cy.contains('Last notification time').click({ force: true });
     cy.contains('Monitor name').click({ force: true });
 
     testMonitors.forEach((entry) => {

--- a/public/pages/Destinations/containers/DestinationsList/utils/constants.js
+++ b/public/pages/Destinations/containers/DestinationsList/utils/constants.js
@@ -42,13 +42,4 @@ export const staticColumns = [
       }
     },
   },
-  {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    width: '100px',
-    render: (value) => (value && value.name ? value.name : '-'),
-  },
 ];

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -143,20 +143,6 @@ exports[`MonitorOverview renders 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiText euiText--extraSmall"
-        >
-          <strong>
-            Last updated by
-          </strong>
-          <div>
-            -
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.js
@@ -115,15 +115,5 @@ export default function getOverviewStats(
       header: 'Monitor version number',
       value: monitorVersion,
     },
-    {
-      /* There are 3 cases:
-      1. Monitors created by older versions and never updated.
-         These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-      2. Monitors are created when security plugin is disabled, these will have empty User object.
-         (`monitor.user.name`, `monitor.user.roles` are empty )
-      3. Monitors are created when security plugin is enabled, these will have an User object. */
-      header: 'Last updated by',
-      value: monitor.user && monitor.user.name ? monitor.user.name : '-',
-    },
   ];
 }

--- a/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
+++ b/public/pages/MonitorDetails/components/MonitorOverview/utils/getOverviewStats.test.js
@@ -46,10 +46,6 @@ describe('getOverviewStats', () => {
         header: 'Monitor version number',
         value: monitorVersion,
       },
-      {
-        header: 'Last updated by',
-        value: monitor.user.name,
-      },
     ]);
   });
 });

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -42,14 +42,6 @@ exports[`Monitors renders 1`] = `
           "textOnly": true,
         },
         Object {
-          "field": "user",
-          "name": "Last updated by",
-          "render": [Function],
-          "sortable": true,
-          "textOnly": true,
-          "truncateText": true,
-        },
-        Object {
           "field": "latestAlert",
           "name": "Latest alert",
           "sortable": false,

--- a/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
+++ b/public/pages/Monitors/containers/Monitors/utils/tableUtils.js
@@ -28,21 +28,6 @@ export const columns = [
     ),
   },
   {
-    field: 'user',
-    name: 'Last updated by',
-    sortable: true,
-    truncateText: true,
-    textOnly: true,
-    /* There are 3 cases:
-    1. Monitors created by older versions and never updated.
-       These monitors won’t have User details in the monitor object. `monitor.user` will be null.
-    2. Monitors are created when security plugin is disabled, these will have empty User object.
-       (`monitor.user.name`, `monitor.user.roles` are empty )
-    3. Monitors are created when security plugin is enabled, these will have an User object. */
-    render: (_, item) =>
-      item.monitor.user && item.monitor.user.name ? item.monitor.user.name : '-',
-  },
-  {
     field: 'latestAlert',
     name: 'Latest alert',
     sortable: false,


### PR DESCRIPTION
### Description
Removed "last updated by" sections from the UI as the SearchMonitor API is no longer intended to return that info. See the issue below for more details.

I have backported for 2.7
 
### Issues Resolved
#763
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
