### PR TITLE
do not create Message component on every text change

### DIFF
--- a/public/pages/CreateTrigger/components/Action/Action.js
+++ b/public/pages/CreateTrigger/components/Action/Action.js
@@ -26,10 +26,14 @@ import {
 import { FormikFieldText, FormikComboBox } from '../../../../components/FormControls';
 import { isInvalid, hasError, validateActionName } from '../../../../utils/validate';
 import { validateDestination } from './utils/validate';
-import { DEFAULT_ACTION_TYPE, MANAGE_CHANNELS_PATH } from '../../utils/constants';
+import {
+  DEFAULT_ACTION_TYPE,
+  MANAGE_CHANNELS_PATH,
+  webhookNotificationActionMessageComponent,
+  defaultNotificationActionMessageComponent,
+} from '../../utils/constants';
 import NotificationsCallOut from '../NotificationsCallOut';
 import MinimalAccordion from '../../../../components/FeatureAnywhereContextMenu/MinimalAccordion';
-import Message from './actions';
 
 const Action = ({
   action,
@@ -63,9 +67,9 @@ const Action = ({
   let ActionComponent;
   const actionLabel = 'Notification';
   if (type === 'webhook') {
-    ActionComponent = (props) => <Message isSubjectDisabled {...props} />;
+    ActionComponent = webhookNotificationActionMessageComponent;
   } else {
-    ActionComponent = (props) => <Message {...props} />;
+    ActionComponent = defaultNotificationActionMessageComponent;
   }
 
   const manageChannelsUrl = httpClient.basePath.prepend(MANAGE_CHANNELS_PATH);

--- a/public/pages/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/utils/constants.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
+import Message from '../components/Action/actions';
+
 export const DEFAULT_MESSAGE_SOURCE = {
   BUCKET_LEVEL_MONITOR: `
   Monitor {{ctx.monitor.name}} just entered alert status. Please investigate the issue.
@@ -77,3 +80,8 @@ export const DEFAULT_TRIGGER_NAME = 'New trigger';
 export const DEFAULT_ACTION_TYPE = 'slack';
 
 export const MANAGE_CHANNELS_PATH = `/app/notifications-dashboards#/channels`;
+
+export const webhookNotificationActionMessageComponent = (props) => (
+  <Message isSubjectDisabled {...props} />
+);
+export const defaultNotificationActionMessageComponent = (props) => <Message {...props} />;


### PR DESCRIPTION
### Description
In this PR we ensure that the Message component does not get re-created every time there is a change made to the message template.
 
### Issues Resolved
#853
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
