### PR TITLE
fix error to disblay monitors with disable/enable state

### DIFF
--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -318,6 +318,7 @@ export default class MonitorService {
           query: {
             bool: {
               should,
+              minimum_should_match: state !== 'all' ? 1 : 0,
               must: mustList,
             },
           },


### PR DESCRIPTION
### Description
 Fix the `state` filter on their Alerting -> Monitors page
 
### Issues Resolved

All States
![Image 1-31-24 at 6 09 PM (1)](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/69919272/1aad7361-9b40-4141-b5bc-f4dc77d2f237)

Disabled State
![Image 1-31-24 at 6 10 PM (1)](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/69919272/5d6c1bbc-b0c3-4a88-a328-af913337d0f1)

Enabled State
![Image 1-31-24 at 6 10 PM](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/69919272/db790bcf-8486-4472-9d77-61b7a79c236d)




 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
