### PR TITLE
Fetching timezone from ui settings for Trigger context formatting

### DIFF
--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
@@ -36,6 +36,7 @@ import DefineBucketLevelTrigger from '../../DefineBucketLevelTrigger';
 import { getPathsPerDataType } from '../../../../CreateMonitor/containers/DefineMonitor/utils/mappings';
 import { MONITOR_TYPE } from '../../../../../utils/constants';
 import { buildClusterMetricsRequest } from '../../../../CreateMonitor/components/ClusterMetricsMonitor/utils/clusterMetricsMonitorHelpers';
+import { getTimeZone } from '../../../utils/helper';
 
 export const DEFAULT_CLOSED_STATES = {
   WHEN: false,
@@ -210,8 +211,8 @@ export default class CreateTrigger extends Component {
     const userTimeZone = getUISettings().get('dateFormat:tz', moment.tz.guess()) || moment().format('Z');
 
     return {
-      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(userTimeZone).format(),
-      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(userTimeZone).format(),
+      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(getTimeZone()).format(),
+      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(getTimeZone()).format(),
       results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
       trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
       alert: null,

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
@@ -5,7 +5,7 @@
 
 import React, { Component, Fragment } from 'react';
 import _ from 'lodash';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { Formik, FieldArray } from 'formik';
 import {
   EuiButton,
@@ -206,15 +206,19 @@ export default class CreateTrigger extends Component {
     else this.onCreate(trigger, triggerMetadata, formikBag);
   };
 
-  getTriggerContext = (executeResponse, monitor, values) => ({
-    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).format(),
-    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).format(),
-    results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
-    trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
-    alert: null,
-    error: null,
-    monitor: monitor,
-  });
+  getTriggerContext = (executeResponse, monitor, values) => {
+    const userTimeZone = getUISettings().get('dateFormat:tz', moment.tz.guess()) || moment().format('Z');
+
+    return {
+      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(userTimeZone).format(),
+      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(userTimeZone).format(),
+      results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
+      trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
+      alert: null,
+      error: null,
+      monitor: monitor,
+      }
+  };
 
   openExpression = (expression) => {
     this.setState({

--- a/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
+++ b/public/pages/CreateTrigger/containers/CreateTrigger/CreateTrigger/CreateTrigger.js
@@ -207,19 +207,15 @@ export default class CreateTrigger extends Component {
     else this.onCreate(trigger, triggerMetadata, formikBag);
   };
 
-  getTriggerContext = (executeResponse, monitor, values) => {
-    const userTimeZone = getUISettings().get('dateFormat:tz', moment.tz.guess()) || moment().format('Z');
-
-    return {
-      periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(getTimeZone()).format(),
-      periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(getTimeZone()).format(),
-      results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
-      trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
-      alert: null,
-      error: null,
-      monitor: monitor,
-      }
-  };
+  getTriggerContext = (executeResponse, monitor, values) => ({
+    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(getTimeZone()).format(),
+    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(getTimeZone()).format(),
+    results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
+    trigger: formikToTrigger(values, _.get(this.props.monitor, 'ui_metadata', {})),
+    alert: null,
+    error: null,
+    monitor: monitor,
+  });
 
   openExpression = (expression) => {
     this.setState({

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/NotificationConfigDialog.test.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/NotificationConfigDialog.test.js
@@ -9,9 +9,13 @@ import { render } from 'enzyme';
 import { Formik } from 'formik';
 import { FORMIK_INITIAL_VALUES } from '../../../CreateMonitor/containers/CreateMonitor/utils/constants';
 import NotificationConfigDialog from './NotificationConfigDialog';
+import { uiSettingsServiceMock } from '../../../../../../../src/core/public/mocks';
+import { setUISettings } from '../../../../services';
 
 describe('NotificationConfigDialog', () => {
   test('renders', () => {
+    const uiSettingsMock = uiSettingsServiceMock.createStartContract();
+    setUISettings(uiSettingsMock);
     const component = (
       <Formik initialValues={FORMIK_INITIAL_VALUES} onSubmit={() => {}}>
         <NotificationConfigDialog

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/NotificationConfigDialog.test.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/NotificationConfigDialog.test.js
@@ -15,6 +15,7 @@ import { setUISettings } from '../../../../services';
 describe('NotificationConfigDialog', () => {
   test('renders', () => {
     const uiSettingsMock = uiSettingsServiceMock.createStartContract();
+    uiSettingsMock.get.mockReturnValue('America/Toronto');
     setUISettings(uiSettingsMock);
     const component = (
       <Formik initialValues={FORMIK_INITIAL_VALUES} onSubmit={() => {}}>

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -15,8 +15,9 @@ import {
   FORMIK_INITIAL_DOC_LEVEL_SCRIPT,
   FORMIK_INITIAL_TRIGGER_VALUES,
 } from '../containers/CreateTrigger/utils/constants';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { formikToTrigger } from '../containers/CreateTrigger/utils/formikToTrigger';
+import { getUISettings } from '../../../services';
 
 export const getChannelOptions = (channels) =>
   channels.map((channel) => ({
@@ -55,9 +56,11 @@ export const getDefaultScript = (monitorValues) => {
 export const getTriggerContext = (executeResponse, monitor, values, triggerIndex) => {
   let trigger = formikToTrigger(values, _.get(monitor, 'ui_metadata', {}));
   if (_.isArray(trigger) && triggerIndex >= 0) trigger = trigger[triggerIndex];
+  const userTimeZone = getUISettings().get('dateFormat:tz', moment.tz.guess()) || moment().format('Z');
+
   return {
-    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).format(),
-    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).format(),
+    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(userTimeZone).format(),
+    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(userTimeZone).format(),
     results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
     trigger: trigger,
     alert: null,

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -56,11 +56,10 @@ export const getDefaultScript = (monitorValues) => {
 export const getTriggerContext = (executeResponse, monitor, values, triggerIndex) => {
   let trigger = formikToTrigger(values, _.get(monitor, 'ui_metadata', {}));
   if (_.isArray(trigger) && triggerIndex >= 0) trigger = trigger[triggerIndex];
-  const userTimeZone = getUISettings().get('dateFormat:tz', moment.tz.guess()) || moment().format('Z');
 
   return {
-    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(userTimeZone).format(),
-    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(userTimeZone).format(),
+    periodStart: moment.utc(_.get(executeResponse, 'period_start', Date.now())).tz(getTimeZone()).format(),
+    periodEnd: moment.utc(_.get(executeResponse, 'period_end', Date.now())).tz(getTimeZone()).format(),
     results: [_.get(executeResponse, 'input_results.results[0]')].filter((result) => !!result),
     trigger: trigger,
     alert: null,
@@ -105,3 +104,8 @@ export const conditionToExpressions = (condition = '', monitors) => {
 
   return expressions;
 };
+
+export function getTimeZone() {
+  const detectedTimeZone = getUISettings().get('dateFormat:tz', 'Browser');
+  return detectedTimeZone === 'Browser' ? (moment.tz.guess() || moment.format('Z')) : detectedTimeZone;
+}


### PR DESCRIPTION
### Description
The time periods in the monitor trigger context are formatted using the browsers timezone and we are not respecting the timezone set by the user in the UI settings under Dashboards management. This PR fetches the setting if it exists, else uses the timezone provided by browser. If that doesn't exist then UTC timezone is used.
 
### Issues Resolved
#839 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
