### PR TITLE
Include server.basepath config in the manage notifications channel Url

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -14,6 +14,7 @@ import './app.scss';
 import Main from './pages/Main';
 import { CoreContext } from './utils/CoreContext';
 import { ServicesContext, NotificationService } from './services';
+import { initManageChannelsUrl } from './utils/helpers';
 
 export function renderApp(coreStart, params) {
   const isDarkMode = coreStart.uiSettings.get('theme:darkMode') || false;
@@ -28,6 +29,8 @@ export function renderApp(coreStart, params) {
   } else {
     require('@elastic/charts/dist/theme_only_light.css');
   }
+
+  initManageChannelsUrl(coreStart.http);
 
   // render react to DOM
   ReactDOM.render(

--- a/public/pages/CreateTrigger/components/Action/Action.js
+++ b/public/pages/CreateTrigger/components/Action/Action.js
@@ -28,12 +28,12 @@ import { isInvalid, hasError, validateActionName } from '../../../../utils/valid
 import { validateDestination } from './utils/validate';
 import {
   DEFAULT_ACTION_TYPE,
-  MANAGE_CHANNELS_PATH,
   webhookNotificationActionMessageComponent,
   defaultNotificationActionMessageComponent,
 } from '../../utils/constants';
 import NotificationsCallOut from '../NotificationsCallOut';
 import MinimalAccordion from '../../../../components/FeatureAnywhereContextMenu/MinimalAccordion';
+import { MANAGE_CHANNELS_URL } from '../../../../utils/constants';
 
 const Action = ({
   action,
@@ -45,7 +45,6 @@ const Action = ({
   onDelete,
   sendTestMessage,
   setFlyout,
-  httpClient,
   fieldPath,
   values,
   hasNotificationPlugin,
@@ -72,7 +71,6 @@ const Action = ({
     ActionComponent = defaultNotificationActionMessageComponent;
   }
 
-  const manageChannelsUrl = httpClient.basePath.prepend(MANAGE_CHANNELS_PATH);
   const isFirstAction = index !== undefined && index === 0;
   const refreshDestinations = useMemo(() => {
     const refresh = async () => {
@@ -169,7 +167,7 @@ const Action = ({
               disabled={!hasNotificationPlugin}
               iconType="popout"
               iconSide="right"
-              onClick={() => window.open(manageChannelsUrl)}
+              onClick={() => window.open(MANAGE_CHANNELS_URL)}
             >
               Manage channels
             </ManageButton>

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import AddActionButton from '../AddActionButton';
-import { MANAGE_CHANNELS_PATH } from '../../utils/constants';
+import { MANAGE_CHANNELS_URL } from '../../../../utils/constants';
 
 const actionEmptyText = 'Add an action to perform when this trigger is triggered.';
 const destinationEmptyText = 'There are no existing channels. Add a channel to create an action.';
@@ -14,7 +14,6 @@ const destinationEmptyText = 'There are no existing channels. Add a channel to c
 const ActionEmptyPrompt = ({
   arrayHelpers,
   hasDestinations,
-  httpClient,
   hasNotificationPlugin,
   flyoutMode,
   onPostAdd,
@@ -39,7 +38,7 @@ const ActionEmptyPrompt = ({
             disabled={!hasNotificationPlugin}
             iconType="popout"
             iconSide="right"
-            onClick={() => window.open(httpClient.basePath.prepend(MANAGE_CHANNELS_PATH))}
+            onClick={() => window.open(MANAGE_CHANNELS_URL)}
           >
             Manage channels
           </EuiButton>

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -338,7 +338,6 @@ class ConfigureActions extends React.Component {
             }}
             sendTestMessage={this.sendTestMessage}
             setFlyout={setFlyout}
-            httpClient={httpClient}
             fieldPath={fieldPath}
             values={values}
             hasNotificationPlugin={hasNotificationPlugin}
@@ -356,7 +355,6 @@ class ConfigureActions extends React.Component {
       <ActionEmptyPrompt
         arrayHelpers={arrayHelpers}
         hasDestinations={hasDestinations}
-        httpClient={httpClient}
         hasNotificationPlugin={hasNotificationPlugin}
         flyoutMode={flyoutMode}
         onPostAdd={(initialValues) => this.onAccordionToggle(initialValues.id)}

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotificationsContent.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotificationsContent.js
@@ -8,9 +8,10 @@ import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty, EuiSpacer } from '
 import { FormikComboBox } from '../../../../components/FormControls';
 import NotificationConfigDialog from './NotificationConfigDialog';
 import _ from 'lodash';
-import { FORMIK_INITIAL_ACTION_VALUES, MANAGE_CHANNELS_PATH } from '../../utils/constants';
+import { FORMIK_INITIAL_ACTION_VALUES } from '../../utils/constants';
 import { NOTIFY_OPTIONS_VALUES } from '../../components/Action/actions/Message';
 import { required } from '../../../../utils/validate';
+import { MANAGE_CHANNELS_URL } from '../../../../utils/constants';
 
 const TriggerNotificationsContent = ({
   action,
@@ -97,7 +98,7 @@ const TriggerNotificationsContent = ({
               iconType={'popout'}
               style={{ marginTop: '22px' }}
               disabled={!hasNotifications}
-              onClick={() => window.open(httpClient.basePath.prepend(MANAGE_CHANNELS_PATH))}
+              onClick={() => window.open(MANAGE_CHANNELS_URL)}
             >
               Manage channels
             </EuiButtonEmpty>

--- a/public/pages/CreateTrigger/utils/constants.js
+++ b/public/pages/CreateTrigger/utils/constants.js
@@ -79,8 +79,6 @@ export const AND_OR_CONDITION_OPTIONS = [
 export const DEFAULT_TRIGGER_NAME = 'New trigger';
 export const DEFAULT_ACTION_TYPE = 'slack';
 
-export const MANAGE_CHANNELS_PATH = `/app/notifications-dashboards#/channels`;
-
 export const webhookNotificationActionMessageComponent = (props) => (
   <Message isSubjectDisabled {...props} />
 );

--- a/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.js
+++ b/public/pages/Destinations/components/DestinationsList/EmptyDestinations/EmptyDestinations.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { EuiButton, EuiEmptyPrompt, EuiLink, EuiText } from '@elastic/eui';
-import { MANAGE_CHANNELS_PATH } from '../../../../CreateTrigger/utils/constants';
+import { MANAGE_CHANNELS_URL } from '../../../../../utils/constants';
 
 const filterText = (hasNotificationPlugin) =>
   hasNotificationPlugin ? (
@@ -17,7 +17,7 @@ const filterText = (hasNotificationPlugin) =>
       </p>
       <p>
         Migrated destinations can be found in&nbsp;
-        {<EuiLink href={MANAGE_CHANNELS_PATH}>Notifications</EuiLink>}
+        {<EuiLink href={MANAGE_CHANNELS_URL}>Notifications</EuiLink>}
       </p>
     </>
   ) : (

--- a/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/FullPageNotificationsInfoCallOut.js
+++ b/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/FullPageNotificationsInfoCallOut.js
@@ -5,8 +5,8 @@
 
 import React from 'react';
 import { EuiButton, EuiEmptyPrompt, EuiLink, EuiPanel, EuiText } from '@elastic/eui';
-import { MANAGE_CHANNELS_PATH } from '../../../CreateTrigger/utils/constants';
 import { NOTIFICATIONS_LEARN_MORE_HREF } from '../../utils/constants';
+import { MANAGE_CHANNELS_URL } from '../../../../utils/constants';
 
 const noNotificationsTitle = 'Destinations will become channels in Notifications';
 const noNotificationsText = (
@@ -41,7 +41,7 @@ const hasNotificationsText = (
   </EuiText>
 );
 const hasNotificationsButton = (
-  <EuiButton fill href={MANAGE_CHANNELS_PATH}>
+  <EuiButton fill href={MANAGE_CHANNELS_URL}>
     View in Notifications
   </EuiButton>
 );

--- a/public/pages/Destinations/components/NotificationsInfoCallOut/NotificationsInfoCallOut.js
+++ b/public/pages/Destinations/components/NotificationsInfoCallOut/NotificationsInfoCallOut.js
@@ -5,8 +5,8 @@
 
 import React from 'react';
 import { EuiCallOut, EuiButton, EuiLink, EuiSpacer } from '@elastic/eui';
-import { MANAGE_CHANNELS_PATH } from '../../../CreateTrigger/utils/constants';
 import { NOTIFICATIONS_LEARN_MORE_HREF } from '../../utils/constants';
+import { MANAGE_CHANNELS_URL } from '../../../../utils/constants';
 
 const noNotificationsTitle = 'Unable to send notifications. Notifications plugin is required.';
 const noNotificationsBodyText = (
@@ -43,7 +43,7 @@ const hasNotificationsBodyText = (
   </p>
 );
 const hasNotificationsButton = (
-  <EuiButton href={MANAGE_CHANNELS_PATH}>View in Notifications</EuiButton>
+  <EuiButton href={MANAGE_CHANNELS_URL}>View in Notifications</EuiButton>
 );
 
 const NotificationsInfoCallOut = ({ hasNotificationPlugin }) => {

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -107,3 +107,6 @@ export const PLUGIN_AUGMENTATION_ENABLE_SETTING = 'visualization:enablePluginAug
 
 export const PLUGIN_AUGMENTATION_MAX_OBJECTS_SETTING =
   'visualization:enablePluginAugmentation.maxPluginObjects';
+
+// This is updated to include the server.basepath during plugin's first render inside app.js using `initManageChannelsUrl` function
+export let MANAGE_CHANNELS_URL = '/app/notifications-dashboards#/channels';

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -11,6 +11,7 @@ import {
   filterActiveAlerts,
 } from '../pages/Dashboard/utils/helpers';
 import _ from 'lodash';
+import { MANAGE_CHANNELS_URL } from './constants';
 
 export const makeId = htmlIdGenerator();
 
@@ -136,3 +137,8 @@ export const titleTemplate = (title, subTitle) => (
     )}
   </>
 );
+
+export function initManageChannelsUrl(httpClient) {
+  const manageChannelsRelativePath = `/app/notifications-dashboards#/channels`;
+  MANAGE_CHANNELS_URL = httpClient.basePath.prepend(manageChannelsRelativePath);
+}


### PR DESCRIPTION
### Description
Users can set  [server.basepath](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml#L9) in opensearch_dashboards config. When opening links in new tab we need to ensure the href includes the base path else we end up in 404 page not found
 
### Issues Resolved
#884 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
