### PR TITLE
Refactored code to account for notifications server features API change

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -121,11 +121,12 @@ class ConfigureActions extends React.Component {
     let channels = [];
     let index = 0;
     const getChannels = async () => {
-      const config_types = await this.props.notificationService.getServerFeatures();
+      const serverFeatures = await this.props.notificationService.getServerFeatures();
+      const configTypes = Object.keys(serverFeatures.availableChannels);
       const getChannelsQuery = {
         from_index: index,
         max_items: MAX_CHANNELS_RESULT_SIZE,
-        config_type: config_types,
+        config_type: configTypes,
         sort_field: 'name',
         sort_order: 'asc',
       };

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotifications.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotifications.js
@@ -51,11 +51,12 @@ const TriggerNotifications = ({
     let channels = [];
     let index = 0;
     const getChannels = async () => {
-      const config_types = await notificationService.getServerFeatures();
+      const serverFeatures = await notificationService.getServerFeatures();
+      const configTypes = Object.keys(serverFeatures.availableChannels);
       const getChannelsQuery = {
         from_index: index,
         max_items: MAX_CHANNELS_RESULT_SIZE,
-        config_type: config_types,
+        config_type: configTypes,
         sort_field: 'name',
         sort_order: 'asc',
       };

--- a/public/services/NotificationService.ts
+++ b/public/services/NotificationService.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpFetchQuery, HttpSetup } from '../../../../src/core/public';
-import { ChannelItemType } from './models/interfaces';
+import { ChannelItemType, NotificationServerFeatures } from './models/interfaces';
 import { configListToChannels, configToChannel } from './utils/helper';
 
 interface ConfigsResponse {
@@ -26,15 +26,19 @@ export default class NotificationService {
     this.httpClient = httpClient;
   }
 
-  getServerFeatures = async (): Promise<Array<String>> => {
+  getServerFeatures = async (): Promise<NotificationServerFeatures> => {
     try {
       const response = await this.httpClient.get(
         NODE_API.GET_AVAILABLE_FEATURES
       );
-      return response.allowed_config_type_list as Array<String>;
+      return response as NotificationServerFeatures;
     } catch (error) {
       console.error('error fetching available features', error);
-      return [];
+      return {
+        availableChannels: {},
+        availableConfigTypes: [],
+        tooltipSupport: false
+      };
     }
   };
 

--- a/public/services/models/interfaces.ts
+++ b/public/services/models/interfaces.ts
@@ -37,3 +37,9 @@ export interface ChannelItemType extends ConfigType {
     };
   };
 }
+
+export interface NotificationServerFeatures {
+  availableChannels: Partial<typeof CHANNEL_TYPE>;
+  availableConfigTypes: string[]; // available backend config types
+  tooltipSupport: boolean; // if true, IAM role for SNS is optional and helper text should be available
+}


### PR DESCRIPTION
### Description
Notifications dashboards server route for fetching features (`/api/notifications/features`) was updated in PR https://github.com/opensearch-project/dashboards-notifications/pull/181 so that we can fetch the channel types for which the channels should be shown in options menu. This PR makes the required code changes in alerting to consume these updates in notification.

NOTE: The changes in the dashboards-notifications PR 181 are required for the changes in this PR, else it will break alerting.
 
### Issues Resolved
#795 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
