### PR TITLE
support date_nanos type when select time field for creating monitor

### DIFF
--- a/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.js
@@ -11,7 +11,9 @@ import { FormikComboBox } from '../../../../components/FormControls';
 
 const MonitorTimeField = ({ dataTypes }) => {
   // Default empty option + options from index mappings mapped to ui select form
-  const dateFields = Array.from(dataTypes.date || []);
+  const dateFields = Array.from(dataTypes.date || []).concat(
+    Array.from(dataTypes.date_nanos || [])
+  );
   const options = [].concat(dateFields).map((option) => ({ label: option }));
   return (
     <FormikComboBox

--- a/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.test.js
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/MonitorTimeField.test.js
@@ -20,23 +20,40 @@ describe('MonitorTimeField', () => {
     expect(render(component)).toMatchSnapshot();
   });
 
-  test.skip('displays no options', () => {
+  test('displays no options', () => {
     const wrapper = mount(
       <Formik initialValues={{}} onSubmit={() => {}}>
         <MonitorTimeField dataTypes={{}} />
       </Formik>
     );
     // Default blank option
-    expect(wrapper.find('select').props().children[1].length).toBe(1);
+    expect(wrapper.find('EuiComboBox').props().options.length).toBe(0);
   });
 
-  test.skip('displays options', () => {
+  test('displays options', () => {
     const wrapper = mount(
       <Formik initialValues={{}} onSubmit={() => {}}>
         <MonitorTimeField dataTypes={{ date: ['date1', 'date2', 'date3'] }} />
       </Formik>
     );
-    // 3 options + default blank option
-    expect(wrapper.find('select').props().children[1].length).toBe(4);
+    // 3 options
+    expect(wrapper.find('EuiComboBox').props().options.length).toBe(3);
+  });
+
+  test('displays options includes date_nanos', () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={() => {}}>
+        <MonitorTimeField
+          dataTypes={{ date: ['date1', 'date2', 'date3'], date_nanos: ['date_nanos1'] }}
+        />
+      </Formik>
+    );
+    expect(wrapper).toMatchSnapshot();
+
+    // 4 options
+    expect(wrapper.find('EuiComboBox').props().options.length).toBe(4);
+    expect(wrapper.find('EuiComboBox').props().options).toEqual(
+      expect.arrayContaining([{ label: 'date_nanos1' }])
+    );
   });
 });


### PR DESCRIPTION
### Description
Add date_nanos support for time field selection

test date_nanos field with range query which used in define the query condition in creating monitor, it works as expected without exception.

```
PUT my-index-000001
{
  "mappings": {
    "properties": {
      "date": {
        "type": "date_nanos" 
      }
    }
  }
}

PUT my-index-000001/_bulk?refresh
{ "index" : { "_id" : "1" } }
{ "date": "2015-01-01" } 
{ "index" : { "_id" : "2" } }
{ "date": "2015-01-01T12:10:30.123456789Z" } 
{ "index" : { "_id" : "3" } }
{ "date": 1420070400000 } 


GET my-index-000001/_search
{
  "query": {
    "bool": {
      "filter": [
        {
          "range": {
            "date": {
              "gte": "1420114200000||-1d",
              "lte": "1420114200000||+1d",
              "format": "epoch_millis"
            }
          }
        }
      ]
    }
  }
}
```

 
### Issues Resolved
#927 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
