### PR TITLE
version changed back to 2.x

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.13.0'
-  ALERTING_PLUGIN_BRANCH: '2.13'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  ALERTING_PLUGIN_BRANCH: '2.x'
 jobs:
   tests:
     name: Run Cypress E2E tests


### PR DESCRIPTION
### Description
Version changed to 2.x to E2E cypress takes the latest changes from Alerting and Opensearch 2.x branches
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
