### PR TITLE
Alerting comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
     "cypress": "9.5.4",
     "husky": "^3.0.0",
-    "lint-staged": "^10.2.0"
+    "lint-staged": "^10.2.0",
+    "@types/react": "^16.14.23"
   },
   "dependencies": {
     "brace": "0.11.1",

--- a/public/components/Comments/AlertCommentsFlyout.tsx
+++ b/public/components/Comments/AlertCommentsFlyout.tsx
@@ -1,0 +1,238 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Comment } from "../../models/Comments";
+import { 
+  EuiFlyout, 
+  EuiFlyoutHeader, 
+  EuiFlyoutBody, 
+  EuiCommentList, 
+  EuiText, 
+  EuiButtonIcon, 
+  EuiContextMenuItem, 
+  EuiContextMenuPanel,
+  EuiPopover, 
+  EuiTitle, 
+  EuiSpacer,
+  EuiCallOut,
+  EuiLink
+} from "@elastic/eui";
+import { CommentEditor } from "./CommentEditor";
+import moment from "moment";
+import { getTimeZone } from "../../pages/CreateTrigger/utils/helper";
+import { title } from "vega-lite/src/channeldef";
+
+export interface AlertCommentsFlyoutProps {
+  alertId: string;
+  httpClient: any;
+  closeFlyout: () => void;
+}
+
+type CommentItem = Comment & { state: 'edit' | 'readonly', draft: string; };
+
+export const AlertCommentsFlyout: React.FC<AlertCommentsFlyoutProps> = ({ alertId, httpClient, closeFlyout }) => {
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [commentIdWithOpenActionMenu, setCommentIdWithOpenActionMenu] = useState<string | undefined>(undefined);
+  const [draftCommentContent, setDraftCommentContent] = useState('');
+  const [createPending, setCreatePending] = useState(false);
+  const [updatePending, setUpdatePending] = useState(false);
+  const toggleCommentActionMenu = (commentId: string) => {
+    setCommentIdWithOpenActionMenu(commentIdWithOpenActionMenu ? undefined : commentId);
+  };
+  const isACommentBeingEdited = comments.some(comment => comment.state === 'edit');
+
+  const loadComments = useCallback(async () => {
+    const getComments = async () => {
+      const res = await httpClient.post('../api/alerting/comments/_search', { body: JSON.stringify({
+          query: {
+            match: {
+              entity_id: alertId
+            }
+          }
+        })
+      });
+
+      if (res.ok) {
+        setComments(res.resp.comments.map((comment: Comment) => ({
+          ...comment,
+          state: 'readonly',
+          draft: comment.content
+        })).sort((a: Comment, b: Comment) => b.created_time - a.created_time));
+      }
+    }
+
+    getComments();
+  }, [httpClient, alertId]);
+
+  useEffect(() => {
+    loadComments();
+  }, [alertId]);
+
+  const closeCommentActionMenu = () => {
+    setCommentIdWithOpenActionMenu(undefined);
+  };
+
+  const createComment = async () => {
+    setCreatePending(true);
+    await httpClient.post(`../api/alerting/comments/${alertId}`, { body: JSON.stringify({ 
+      content: draftCommentContent
+    })});
+
+    setDraftCommentContent('');
+    loadComments();
+    setCreatePending(false);
+  }
+
+  const updateComment = async (commentId: string, content: string) => {
+    setUpdatePending(true);
+    await httpClient.put(`../api/alerting/comments/${commentId}`, { body: JSON.stringify({ content })});
+    loadComments();
+    setUpdatePending(false);
+  }
+
+  const deleteComment = async (commentId: string) => {
+    await httpClient.delete(`../api/alerting/comments/${commentId}`);
+    loadComments();
+  }
+
+  const onCommentContentChange = (comment: CommentItem, commentIdx: number, newContent: string) => {
+    setComments([
+      ...comments.slice(0, commentIdx),
+      {
+        ...comment,
+        draft: newContent
+      },
+      ...comments.slice(commentIdx + 1)
+    ]);
+  }
+
+  const onEditClick = (comment: CommentItem, idx: number) => {
+    setComments([
+      ...comments.slice(0, idx),
+      {
+        ...comment,
+        state: 'edit'
+      },
+      ...comments.slice(idx + 1)
+    ]);
+    setCommentIdWithOpenActionMenu(undefined);
+  }
+
+  const onEditCancel = (comment: CommentItem, idx: number) => {
+    setComments([
+      ...comments.slice(0, idx),
+      {
+        ...comment,
+        state: 'readonly'
+      },
+      ...comments.slice(idx + 1)
+    ]);
+  }
+
+  const commentListItems = comments.map((comment, idx) => {
+    const content = comment.state === 'readonly' ? (
+      <EuiText size="s">
+        <p>
+          {comment.content}
+        </p>
+      </EuiText>
+    ) : (
+      <CommentEditor
+        isLoading={updatePending}
+        draftCommentContent={comment.draft}
+        onContentChange={(event) => {
+          onCommentContentChange(comment, idx, event.target.value);
+        }}
+        onSave={() => updateComment(comment.id, comment.draft)}
+        onCancel={() => onEditCancel(comment, idx)}
+      />
+    );
+  
+    const customActions = comment.state === 'readonly' && (
+      <EuiPopover
+        button={
+          <EuiButtonIcon
+            aria-label="Actions"
+            iconType="boxesHorizontal"
+            size="s"
+            color="text"
+            onClick={() => toggleCommentActionMenu(comment.id)}
+          />
+        }
+        isOpen={commentIdWithOpenActionMenu === comment.id}
+        closePopover={closeCommentActionMenu}
+        panelPaddingSize="none"
+        anchorPosition="leftCenter">
+        <EuiContextMenuPanel
+          items={[
+            <EuiContextMenuItem
+              key="A"
+              icon="pencil"
+              onClick={() => onEditClick(comment, idx)}>
+              Edit
+            </EuiContextMenuItem>,
+            <EuiContextMenuItem
+              key="B"
+              icon="trash"
+              onClick={() => {
+                deleteComment(comment.id);
+              }}>
+              Delete
+            </EuiContextMenuItem>
+          ]}
+        />
+      </EuiPopover>
+    );
+  
+    return {
+      username: comment.user || 'Unknown',
+      event: `${comment.last_updated_time ? 'edited' : 'added'} comment on`,
+      timestamp: moment.utc(comment.last_updated_time ?? comment.created_time).tz(getTimeZone()).format(),
+      children: content,
+      actions: customActions,
+    }
+  });
+
+  return (
+    <EuiFlyout onClose={closeFlyout}>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>Comments</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiCallOut 
+          iconType='iInCircle'
+          title='Experimental'>
+          <span>The feature is experimental and should not be used in a production environment. 
+            The posted comments will be impacted if the feature is deactivated.
+            For more information see <EuiLink href="https://opensearch.org/docs/latest/observing-your-data/alerting/index/" target="_blank">Documentation.</EuiLink> 
+          </span>
+        </EuiCallOut>
+        <EuiSpacer />
+        <EuiTitle size="xs">
+          <h4>Add comment</h4>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <CommentEditor
+          isLoading={createPending}
+          draftCommentContent={draftCommentContent}
+          onContentChange={(event) => {
+            setDraftCommentContent(event.target.value);
+          }}
+          onSave={createComment}
+          saveDisabled={isACommentBeingEdited}
+        />
+        <EuiSpacer />
+        <EuiTitle size="xs">
+          <h4>Comments ({comments.length})</h4>
+        </EuiTitle>
+        <EuiSpacer />
+        <EuiCommentList comments={commentListItems}/>
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  )
+}

--- a/public/components/Comments/AlertCommentsFlyout.tsx
+++ b/public/components/Comments/AlertCommentsFlyout.tsx
@@ -210,6 +210,7 @@ export const AlertCommentsFlyout: React.FC<AlertCommentsFlyoutProps> = ({ alertI
           <span>The feature is experimental and should not be used in a production environment. 
             The posted comments will be impacted if the feature is deactivated.
             For more information see <EuiLink href="https://opensearch.org/docs/latest/observing-your-data/alerting/index/" target="_blank">Documentation.</EuiLink> 
+            To leave feedback, visit <EuiLink href="https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6999" target="_blank">github.com</EuiLink>.
           </span>
         </EuiCallOut>
         <EuiSpacer />

--- a/public/components/Comments/CommentEditor.tsx
+++ b/public/components/Comments/CommentEditor.tsx
@@ -1,0 +1,51 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import React from "react";
+import { 
+  EuiFlexGroup, 
+  EuiFlexItem, 
+  EuiButton 
+} from "@elastic/eui";
+
+export interface CommentEditorProps {
+  isLoading: boolean;
+  saveDisabled?: boolean;
+  draftCommentContent: string;
+  onSave: React.MouseEventHandler;
+  onCancel?: React.MouseEventHandler;
+  onContentChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+}
+
+export const CommentEditor: React.FC<CommentEditorProps> = ({ 
+  isLoading, 
+  draftCommentContent,
+  saveDisabled,
+  onSave, 
+  onCancel,
+  onContentChange, 
+}) => (
+  <EuiFlexGroup gutterSize="s" direction="column" >
+    <EuiFlexItem>
+      <textarea style={{ resize: 'vertical', fontSize: 14, minHeight: 45 }} value={draftCommentContent} onChange={onContentChange}/>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false} style={{ alignSelf: 'flex-end' }}>
+      <EuiFlexGroup gutterSize="s">
+        {onCancel && (
+          <EuiFlexItem grow={false}>
+            <EuiButton onClick={onCancel}>
+              Cancel
+            </EuiButton>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={onSave} color="primary" isLoading={isLoading} disabled={saveDisabled} fill>
+            Save
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+)

--- a/public/components/Comments/ShowAlertComments.tsx
+++ b/public/components/Comments/ShowAlertComments.tsx
@@ -1,0 +1,40 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Comment } from "../../models/Comments";
+import { EuiButtonIcon, EuiToolTip } from "@elastic/eui";
+import { AlertCommentsFlyout } from "./AlertCommentsFlyout";
+
+export interface ShowAlertCommentsProps {
+  alert: any;
+  httpClient: any;
+}
+
+export const ShowAlertComments: React.FC<ShowAlertCommentsProps> = ({ alert, httpClient }) => {
+  const [commentsFlyout, setCommentsFlyout] = useState<React.ReactNode | null>(null);
+  
+  const showCommentsFlyout = useCallback(() => { 
+    setCommentsFlyout(<AlertCommentsFlyout
+      alertId={alert.id}
+      httpClient={httpClient}
+      closeFlyout={() => setCommentsFlyout(null)} 
+    />);
+  }, [setCommentsFlyout]);
+
+  return (
+    <>
+      <EuiToolTip content={'Show comments'}>
+        <EuiButtonIcon
+          aria-label={'Show comments'}
+          data-test-subj={`show-comments-icon`}
+          iconType={'editorComment'}
+          onClick={showCommentsFlyout}
+        />
+      </EuiToolTip>
+      {commentsFlyout}
+    </>
+  )
+}

--- a/public/models/Comments.ts
+++ b/public/models/Comments.ts
@@ -1,0 +1,13 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+export interface Comment {
+  id: string;
+  entity_id: string;
+  content: string
+  created_time: number;
+  last_updated_time: number | null;
+  user: string | null;
+}

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -1,0 +1,6 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+export const COMMENTS_ENABLED_SETTING = "plugins.alerting.comments_enabled";

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -1,5 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
 import { getDataSourceEnabled, getDataSource } from '../../services/services';
 import _ from 'lodash';
+import { ShowAlertComments } from '../../components/Comments/ShowAlertComments';
+import { COMMENTS_ENABLED_SETTING } from './constants';
 
 export function dataSourceEnabled() {
   return getDataSourceEnabled()?.enabled;
@@ -39,4 +47,56 @@ export function parseQueryStringAndGetDataSource(queryString) {
 
 export function constructUrlFromDataSource(url) {
   return dataSourceEnabled() ? `${url}&dataSourceId=${getDataSource()?.dataSourceId}` : url;
+}
+
+export const appendCommentsAction = (columns, httpClient) => {
+  const actionsColumn = columns.find(({ name }) => name === 'Actions');
+  const showCommentsAction = {
+    render: (alert) => <ShowAlertComments alert={alert} httpClient={httpClient} />,
+  };
+
+  if (actionsColumn) {
+    actionsColumn.actions.push(showCommentsAction);
+  } else {
+    columns.push({
+      name: 'Actions',
+      sortable: false,
+      actions: [showCommentsAction],
+    });
+  }
+
+  return columns;
+};
+
+export async function getIsCommentsEnabled(httpClient) {
+  let alertCommentsEnabled = false;
+
+  try {
+    const dataSourceQuery = getDataSourceQueryObj();
+    const response = await httpClient.get('../api/alerting/_settings', dataSourceQuery);
+    if (response.ok) {
+      const { defaults, transient, persistent } = response.resp;
+      alertCommentsEnabled = _.get(
+        // If present, take the 'transient' setting.
+        transient,
+        COMMENTS_ENABLED_SETTING,
+        // Else take the 'persistent' setting.
+        _.get(
+          persistent,
+          COMMENTS_ENABLED_SETTING,
+          // Else take the 'default' setting.
+          _.get(defaults, COMMENTS_ENABLED_SETTING, false)
+        )
+      );
+
+      // Boolean settings can be returned as strings (e.g., `"true"`, and `"false"`). Constructing boolean value from the string.
+      if (typeof alertCommentsEnabled === 'string') {
+        alertCommentsEnabled = JSON.parse(alertCommentsEnabled);
+      }
+    }
+  } catch (e) {
+    console.log('Error while retrieving settings:', e);
+  }
+
+  return alertCommentsEnabled;
 }

--- a/server/clusters/alerting/alertingPlugin.js
+++ b/server/clusters/alerting/alertingPlugin.js
@@ -11,6 +11,7 @@ import {
   EMAIL_GROUP_BASE_API,
   WORKFLOW_BASE_API,
   CROSS_CLUSTER_BASE_API,
+  COMMENTS_BASE_API,
 } from '../../services/utils/constants';
 
 export default function alertingPlugin(Client, config, components) {
@@ -438,5 +439,56 @@ export default function alertingPlugin(Client, config, components) {
     },
     needBody: true,
     method: 'GET',
+  });
+
+  // Comments
+  alerting.createComment = ca({
+    url: {
+      fmt: `${COMMENTS_BASE_API}/<%=alertId%>`,
+      req: {
+        alertId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: 'POST',
+  });
+
+  alerting.updateComment = ca({
+    url: {
+      fmt: `${COMMENTS_BASE_API}/<%=commentId%>`,
+      req: {
+        commentId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: 'PUT',
+  });
+
+  alerting.searchComments = ca({
+    url: {
+      fmt: `${COMMENTS_BASE_API}/_search`,
+    },
+    needBody: true,
+    method: 'POST',
+  });
+
+  alerting.deleteComment = ca({
+    url: {
+      fmt: `${COMMENTS_BASE_API}/<%=commentId%>`,
+      req: {
+        commentId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    needBody: false,
+    method: 'DELETE',
   });
 }

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -13,6 +13,7 @@ import {
   AnomalyDetectorService,
   FindingService,
   CrossClusterService,
+  CommentsService,
 } from './services';
 import {
   alerts,
@@ -22,6 +23,7 @@ import {
   detectors,
   findings,
   crossCluster,
+  comments,
 } from '../server/routes';
 
 export class AlertingPlugin {
@@ -53,6 +55,7 @@ export class AlertingPlugin {
     const anomalyDetectorService = new AnomalyDetectorService(adESClient, dataSourceEnabled);
     const findingService = new FindingService(alertingESClient, dataSourceEnabled);
     const crossClusterService = new CrossClusterService(alertingESClient, dataSourceEnabled);
+    const commentsService = new CommentsService(alertingESClient, dataSourceEnabled);
     const services = {
       alertService,
       destinationsService,
@@ -61,6 +64,7 @@ export class AlertingPlugin {
       anomalyDetectorService,
       findingService,
       crossClusterService,
+      commentsService,
     };
 
     // Create router
@@ -73,6 +77,7 @@ export class AlertingPlugin {
     detectors(services, router, dataSourceEnabled);
     findings(services, router, dataSourceEnabled);
     crossCluster(services, router, dataSourceEnabled);
+    comments(services, router, dataSourceEnabled);
 
     return {};
   }

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import { createValidateQuerySchema } from '../services/utils/helpers';
+
+export default function (services, router, dataSourceEnabled) {
+  const { commentsService } = services;
+
+  router.post(
+    {
+      path: '/api/alerting/comments/_search',
+      validate: {
+        body: schema.any(),
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
+    },
+    commentsService.searchComments
+  );
+
+  router.post(
+    {
+      path: '/api/alerting/comments/{alertId}',
+      validate: {
+        body: schema.any(),
+        params: schema.object({
+          alertId: schema.string(),
+        }),
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
+    },
+    commentsService.createComment
+  );
+
+  router.put(
+    {
+      path: '/api/alerting/comments/{commentId}',
+      validate: {
+        body: schema.any(),
+        params: schema.object({
+          commentId: schema.string(),
+        }),
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
+    },
+    commentsService.updateComment
+  );
+
+  router.delete(
+    {
+      path: '/api/alerting/comments/{commentId}',
+      validate: {
+        params: schema.object({
+          commentId: schema.string(),
+        }),
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
+    },
+    commentsService.deleteComment
+  );
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -10,5 +10,6 @@ import monitors from './monitors';
 import detectors from './anomalyDetector';
 import findings from './findings';
 import crossCluster from './crossCluster';
+import comments from './comments';
 
-export { alerts, destinations, opensearch, monitors, detectors, findings, crossCluster };
+export { alerts, destinations, opensearch, monitors, detectors, findings, crossCluster, comments };

--- a/server/services/CommentsService.ts
+++ b/server/services/CommentsService.ts
@@ -1,0 +1,106 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Comment } from "../../public/models/Comments";
+import { MDSEnabledClientService } from "./MDSEnabledClientService";
+
+export default class CommentsService extends MDSEnabledClientService {
+  createComment = async (context, req, res) => {
+    const client = this.getClientBasedOnDataSource(context, req);
+    try {
+      const resp = await client('alerting.createComment', { alertId: req.params.alertId, body: req.body });
+
+      return res.ok({
+        body: {
+          ok: true,
+          resp,
+        },
+      });
+    } catch (err) {
+      console.error(err.message);
+      return res.ok({
+        body: {
+          ok: false,
+          err: err.message,
+        },
+      });
+    }
+  };
+
+  updateComment = async (context, req, res) => {
+    const client = this.getClientBasedOnDataSource(context, req);
+    try {
+      const resp = await client('alerting.updateComment', { commentId: req.params.commentId, body: req.body });
+
+      return res.ok({
+        body: {
+          ok: true,
+          resp,
+        },
+      });
+    } catch (err) {
+      console.error(err.message);
+      return res.ok({
+        body: {
+          ok: false,
+          err: err.message,
+        },
+      });
+    }
+  };
+
+  searchComments = async (context, req, res) => {
+    const client = this.getClientBasedOnDataSource(context, req);
+    try {
+      const resp = await client('alerting.searchComments', { body: req.body });
+
+      const comments: Comment[] = resp.hits.hits.map(({ _id, _source: { entity_id, content, created_time, last_updated_time, user } }) => ({
+        id: _id,
+        entity_id,
+        content,
+        created_time,
+        last_updated_time,
+        user,
+      }));
+
+      return res.ok({
+        body: {
+          ok: true,
+          resp: { comments },
+        },
+      });
+    } catch (err) {
+      console.error(err.message);
+      return res.ok({
+        body: {
+          ok: false,
+          err: err.message,
+        },
+      });
+    }
+  };
+
+  deleteComment = async (context, req, res) => {
+    const client = this.getClientBasedOnDataSource(context, req);
+    try {
+      const resp = await client('alerting.deleteComment', { commentId: req.params.commentId });
+
+      return res.ok({
+        body: {
+          ok: true,
+          resp,
+        },
+      });
+    } catch (err) {
+      console.error(err.message);
+      return res.ok({
+        body: {
+          ok: false,
+          err: err.message,
+        },
+      });
+    }
+  };
+}

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -10,6 +10,7 @@ import MonitorService from './MonitorService';
 import AnomalyDetectorService from './AnomalyDetectorService';
 import FindingService from './FindingService';
 import CrossClusterService from './CrossClusterService';
+import CommentsService from './CommentsService';
 
 export {
   AlertService,
@@ -19,4 +20,5 @@ export {
   AnomalyDetectorService,
   FindingService,
   CrossClusterService,
+  CommentsService,
 };

--- a/server/services/utils/constants.js
+++ b/server/services/utils/constants.js
@@ -5,6 +5,7 @@
 
 export const API_ROUTE_PREFIX = '/_plugins/_alerting';
 export const MONITOR_BASE_API = `${API_ROUTE_PREFIX}/monitors`;
+export const COMMENTS_BASE_API = `${API_ROUTE_PREFIX}/comments`;
 export const WORKFLOW_BASE_API = `${API_ROUTE_PREFIX}/workflows`;
 export const CROSS_CLUSTER_BASE_API = `${API_ROUTE_PREFIX}/remote`;
 export const AD_BASE_API = `/_plugins/_anomaly_detection/detectors`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,7 +300,16 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/scheduler@*":
+"@types/react@^16.14.23":
+  version "16.14.60"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.60.tgz#f7ab62a329b82826f12d02bc8031d4ef4b5e0d81"
+  integrity sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
+    csstype "^3.0.2"
+
+"@types/scheduler@*", "@types/scheduler@^0.16":
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
   integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==


### PR DESCRIPTION
### Description
This PR adds the ability to comment on alerts which will help users during their investigations.

- Entry point is `Show comments` action in the alerts table
<img width="1451" alt="image" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/114732919/22ed2fb4-1c31-4dbe-8dba-3dde6e9d8ae3">

- Comments flyout without comments
<img width="758" alt="image" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/114732919/1fc51d7a-c709-4a7c-898e-81bea3243ec0">

- Comments list
<img width="1214" alt="image" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/114732919/54cc4371-de8d-450d-8a8a-6a84e921f02c">



 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
