### PR TITLE
bug fix for duplicate notification channels

### DIFF
--- a/public/pages/CreateTrigger/components/Action/Action.js
+++ b/public/pages/CreateTrigger/components/Action/Action.js
@@ -156,7 +156,7 @@ const Action = ({
                     </EuiText>
                   </React.Fragment>
                 ),
-                rowHeight: 45,
+                rowHeight: 30,
                 isLoading: !flyoutMode && loadingDestinations,
               }}
             />

--- a/public/pages/CreateTrigger/utils/helper.js
+++ b/public/pages/CreateTrigger/utils/helper.js
@@ -19,14 +19,30 @@ import moment from 'moment-timezone';
 import { formikToTrigger } from '../containers/CreateTrigger/utils/formikToTrigger';
 import { getUISettings } from '../../../services';
 
-export const getChannelOptions = (channels) =>
-  channels.map((channel) => ({
-    key: channel.type,
-    label: channel.type,
-    options: channels
-      .filter((local_channel) => local_channel.type === channel.type)
-      .map((option) => ({ key: option.value, ...option })),
-  }));
+export const getChannelOptions = (channels) => {
+  const channelMap = {};
+
+  // Iterate over channels to group options by channel type
+  channels.forEach(channel => {
+    if (!channelMap[channel.type]) {
+      channelMap[channel.type] = {
+        key: channel.type,
+        label: channel.type,
+        options: []
+      };
+    }
+    // Add the option to the corresponding channel type
+    channelMap[channel.type].options.push({
+      key: channel.value,
+      ...channel
+    });
+  });
+
+  // Convert the channelMap object to an array of values
+  const channelOptions = Object.values(channelMap);
+  
+  return channelOptions;
+};
 
 // Custom Webhooks for Destinations used `custom_webhook` for the type whereas Notification Channels use 'webhook'
 // This conversion ensures Notifications' nomenclature is used for the labeling for consistency


### PR DESCRIPTION
### Description
Notification Channels list shows objects multiple times while configuring a trigger when creating a monitor. This PR will fix that issue
 
### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/795

### Tests
![Image 6-25-24 at 6 55 PM](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/69919272/1265350f-a771-49f3-8e27-1eb4973ecf98)

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
