### PR TITLE
[Look&Feel] Consistency of Plus Icons

### DIFF
--- a/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.js
+++ b/public/pages/CreateTrigger/components/AddActionButton/AddActionButton.js
@@ -36,7 +36,7 @@ const AddActionButton = ({
     <EuiPanel paddingSize="none">
       <EuiButtonEmpty
         onClick={onClick}
-        iconType="plusInCircle"
+        iconType="plus"
         className="add-action-button__flyout-button"
       >
         Add notification

--- a/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/AddTriggerButton.js
@@ -44,7 +44,7 @@ const AddTriggerButton = ({
           id: 'addTrigger',
           isOpen: false,
           isButton: true,
-          iconType: 'plusInCircle',
+          iconType: 'plus',
           onToggle: onClick,
           title: 'Add trigger',
         }}

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
@@ -349,7 +349,7 @@ const ExpressionBuilder = ({
                       setUsedExpressions(expressions);
                     }}
                     color={'primary'}
-                    iconType="plus"
+                    iconType="plusInCircleFilled"
                     aria-label={'Add one more condition'}
                     data-test-subj={`condition-add-options-btn_${triggerIndex}`}
                     style={{ marginTop: '1px' }}

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/ExpressionBuilder.js
@@ -349,7 +349,7 @@ const ExpressionBuilder = ({
                       setUsedExpressions(expressions);
                     }}
                     color={'primary'}
-                    iconType="plusInCircleFilled"
+                    iconType="plus"
                     aria-label={'Add one more condition'}
                     data-test-subj={`condition-add-options-btn_${triggerIndex}`}
                     style={{ marginTop: '1px' }}

--- a/public/utils/contextMenu/actions.tsx
+++ b/public/utils/contextMenu/actions.tsx
@@ -39,12 +39,12 @@ export const openContainerInFlyout = async ({
   embeddable: any;
   detectorId?: string;
 }) => {
-  
+
   if (dataSourceEnabled()) {
     const indexPattern = embeddable.vis.data.indexPattern;
     setDataSourceIdFromSavedObject(indexPattern);
   }
-  
+
   const clonedEmbeddable = await _.cloneDeep(embeddable);
   const overlayService = getOverlays();
   const openFlyout = overlayService.openFlyout;
@@ -81,7 +81,7 @@ export const getActions = () =>
       title: i18n.translate('dashboard.actions.alertingMenuItem.addAlertingMonitor.displayName', {
         defaultMessage: 'Add alerting monitor',
       }),
-      icon: 'plusInCircle' as EuiIconType,
+      icon: 'plus' as EuiIconType,
       order: 100,
       onExecute: ({ embeddable }) =>
         openContainerInFlyout({ embeddable, defaultFlyoutMode: 'create' }),
@@ -129,7 +129,7 @@ export const getAdAction = () =>
 function setDataSourceIdFromSavedObject(indexPattern: any) {
   try {
     const foundRef = indexPattern.dataSourceRef
-    const dataSourceId = foundRef ? foundRef.id : ''; 
+    const dataSourceId = foundRef ? foundRef.id : '';
     setDataSource({ dataSourceId });
   } catch (error) {
     console.error("Error fetching index pattern:", error);


### PR DESCRIPTION
### Description
Updated plus icon over plusInCircle for add/create use cases. Did not change instances of other use cases, or when minusInCircle was attached.

| Scope | Before (v7light) | After (v7light) | Before (v8dark) | After (v8dark) |
| ----- | ----- | ----- | ----- | ----- |
| Dashboards: Add Alert Monitor | <img width="231" alt="Dashboards Add Monitor v7 Light Before" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/8130d722-3de6-4d61-8551-07c58e1892a8"> | <img width="231" alt="Dashboards Add Monitor v7 Light Post" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/3166196f-3f22-4c12-a0d3-1d904d9c2fb3"> | <img width="231" alt="Dashboards Add Monitor v8 Dark Before" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/3c45ec53-bcec-4cae-b38d-e5dddf200c42"> | <img width="231" alt="Dashboards Add Monitor v8 Dark Post" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/6035b6ca-494b-469c-b7fb-2eea5926b13b"> | 
| Add Action / Trigger | <img width="177" alt="Add v7 Light Before" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/bede2ec6-eae1-4f27-8282-3eb12003a058"> | <img width="165" alt="Add v7 Light Post" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/77f4a172-73b7-42e9-b397-87bf1a275a0f"> | <img width="198" alt="Add v8 Dark Before" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/5ff656ef-df39-42f4-a36b-9cabae44a3dc"> | <img width="191" alt="Add v8 Dark Post" src="https://github.com/opensearch-project/alerting-dashboards-plugin/assets/58446449/fe4f9746-c52f-4a38-81ad-3b33c1b0434f"> |


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
