### PR TITLE
[Look&Feel] use standard paragraph size

### DIFF
--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/CreateNew.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/CreateNew.tsx
@@ -149,7 +149,7 @@ function CreateNew({ embeddable, flyoutMode, formikProps, history, setFlyout, de
           title: values.name,
           subTitle: values.frequency === 'interval' && (
             <>
-              <EuiText size="m" className="create-monitor__frequency">
+              <EuiText size="s" className="create-monitor__frequency">
                 <p>
                   Runs every {values.period.interval} <span>{unitToLabel[values.period.unit]}</span>
                 </p>

--- a/public/components/Flyout/__snapshots__/Flyout.test.js.snap
+++ b/public/components/Flyout/__snapshots__/Flyout.test.js.snap
@@ -33,11 +33,7 @@ exports[`Flyout renders 1`] = `
   </EuiFlyoutHeader>
   <EuiFlyoutBody>
     <EuiText
-      style={
-        Object {
-          "fontSize": "14px",
-        }
-      }
+      size="s"
     >
       <p>
         You have access to a "ctx" variable in your painless scripts and action mustache templates.

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -51,11 +51,7 @@ Object {
 exports[`Flyouts.message generates message JSON 1`] = `
 Object {
   "body": <EuiText
-    style={
-      Object {
-        "fontSize": "14px",
-      }
-    }
+    size="s"
   >
     <p>
       You have access to a "ctx" variable in your painless scripts and action mustache templates.
@@ -103,11 +99,7 @@ Object {
 exports[`Flyouts.messageFrequency generates message JSON 1`] = `
 Object {
   "body": <EuiText
-    style={
-      Object {
-        "fontSize": "14px",
-      }
-    }
+    size="s"
   >
     <p>
       Specify message frequency to limit the number of notifications you receive within a given span of time. This setting is especially useful for low severity trigger conditions.
@@ -159,11 +151,7 @@ exports[`Flyouts.triggerCondition generates message JSON 1`] = `
 Object {
   "body": <div>
     <EuiText
-      style={
-        Object {
-          "fontSize": "14px",
-        }
-      }
+      size="s"
     >
       <p>
         You have access to a "ctx" variable in your painless scripts

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -594,16 +594,13 @@ export default class AlertsDashboardFlyoutComponent extends Component {
       <div>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiText
-              size={'m'}
-              data-test-subj={`alertsDashboardFlyout_triggerName_${trigger_name}`}
-            >
+            <EuiText size="s" data-test-subj={`alertsDashboardFlyout_triggerName_${trigger_name}`}>
               <strong>Trigger name</strong>
               <p>{trigger_name}</p>
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_severity_${trigger_name}`}>
+            <EuiText size="s" data-test-subj={`alertsDashboardFlyout_severity_${trigger_name}`}>
               <strong>Severity</strong>
               <p>{this.getSeverityText(severity) || severity || DEFAULT_EMPTY_DATA}</p>
             </EuiText>
@@ -614,13 +611,13 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiText size={'m'}>
+            <EuiText size="s">
               <strong>Trigger start time</strong>
               <p>{getTime(start_time)}</p>
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText size={'m'}>
+            <EuiText size="s">
               <strong>Trigger last updated</strong>
               <p>{getTime(last_notification_time)}</p>
             </EuiText>
@@ -631,7 +628,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_monitor_${trigger_name}`}>
+            <EuiText size="s" data-test-subj={`alertsDashboardFlyout_monitor_${trigger_name}`}>
               <strong>Monitor</strong>
               <p>
                 <EuiLink href={monitorUrl}>{monitor_name}</EuiLink>
@@ -639,7 +636,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText size={'m'}>
+            <EuiText size="s">
               <strong>Monitor data sources</strong>
               <p style={{ whiteSpace: 'pre-wrap' }}>{dataSources}</p>
             </EuiText>
@@ -650,7 +647,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiText size={'m'} data-test-subj={`alertsDashboardFlyout_conditions_${trigger_name}`}>
+            <EuiText size="s" data-test-subj={`alertsDashboardFlyout_conditions_${trigger_name}`}>
               <strong>{displayMultipleConditions ? 'Conditions' : 'Condition'}</strong>
               <p style={{ whiteSpace: 'pre-wrap' }}>
                 {loadingMonitors || loading ? 'Loading conditions...' : condition}
@@ -660,10 +657,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
           {![MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) && (
             <EuiFlexItem>
-              <EuiText
-                size={'m'}
-                data-test-subj={`alertsDashboardFlyout_timeRange_${trigger_name}`}
-              >
+              <EuiText size="s" data-test-subj={`alertsDashboardFlyout_timeRange_${trigger_name}`}>
                 <strong>Time range for the last</strong>
                 <p>{timeRangeForLast}</p>
               </EuiText>
@@ -677,19 +671,13 @@ export default class AlertsDashboardFlyoutComponent extends Component {
 
             <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiText
-                  size={'m'}
-                  data-test-subj={`alertsDashboardFlyout_filters_${trigger_name}`}
-                >
+                <EuiText size="s" data-test-subj={`alertsDashboardFlyout_filters_${trigger_name}`}>
                   <strong>Filters</strong>
                   <p>{loadingMonitors || loading ? 'Loading filters...' : filters}</p>
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiText
-                  size={'m'}
-                  data-test-subj={`alertsDashboardFlyout_groupBy_${trigger_name}`}
-                >
+                <EuiText size="s" data-test-subj={`alertsDashboardFlyout_groupBy_${trigger_name}`}>
                   <strong>Group by</strong>
                   <p>
                     {loadingMonitors || loading

--- a/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
+++ b/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
@@ -6,7 +6,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <EuiFlexItem>
       <EuiText
         data-test-subj="alertsDashboardFlyout_triggerName_undefined"
-        size="m"
+        size="s"
       >
         <strong>
           Trigger name
@@ -17,7 +17,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <EuiFlexItem>
       <EuiText
         data-test-subj="alertsDashboardFlyout_severity_undefined"
-        size="m"
+        size="s"
       >
         <strong>
           Severity
@@ -34,7 +34,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
   <EuiFlexGroup>
     <EuiFlexItem>
       <EuiText
-        size="m"
+        size="s"
       >
         <strong>
           Trigger start time
@@ -46,7 +46,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     </EuiFlexItem>
     <EuiFlexItem>
       <EuiText
-        size="m"
+        size="s"
       >
         <strong>
           Trigger last updated
@@ -64,7 +64,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <EuiFlexItem>
       <EuiText
         data-test-subj="alertsDashboardFlyout_monitor_undefined"
-        size="m"
+        size="s"
       >
         <strong>
           Monitor
@@ -78,7 +78,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     </EuiFlexItem>
     <EuiFlexItem>
       <EuiText
-        size="m"
+        size="s"
       >
         <strong>
           Monitor data sources
@@ -102,7 +102,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <EuiFlexItem>
       <EuiText
         data-test-subj="alertsDashboardFlyout_conditions_undefined"
-        size="m"
+        size="s"
       >
         <strong>
           Condition
@@ -121,7 +121,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
     <EuiFlexItem>
       <EuiText
         data-test-subj="alertsDashboardFlyout_timeRange_undefined"
-        size="m"
+        size="s"
       >
         <strong>
           Time range for the last
@@ -140,7 +140,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
       <EuiFlexItem>
         <EuiText
           data-test-subj="alertsDashboardFlyout_filters_undefined"
-          size="m"
+          size="s"
         >
           <strong>
             Filters
@@ -153,7 +153,7 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
       <EuiFlexItem>
         <EuiText
           data-test-subj="alertsDashboardFlyout_groupBy_undefined"
-          size="m"
+          size="s"
         >
           <strong>
             Group by

--- a/public/components/Flyout/flyouts/message.js
+++ b/public/components/Flyout/flyouts/message.js
@@ -22,7 +22,7 @@ const message = () => ({
     </EuiTitle>
   ),
   body: (
-    <EuiText style={{ fontSize: '14px' }}>
+    <EuiText size="s">
       <p>
         {`You have access to a "ctx" variable in your painless scripts and action mustache templates.`}
       </p>

--- a/public/components/Flyout/flyouts/messageFrequency.js
+++ b/public/components/Flyout/flyouts/messageFrequency.js
@@ -21,7 +21,7 @@ const messageFrequency = () => ({
     </EuiTitle>
   ),
   body: (
-    <EuiText style={{ fontSize: '14px' }}>
+    <EuiText size="s">
       <p>
         Specify message frequency to limit the number of notifications you receive within a given
         span of time. This setting is especially useful for low severity trigger conditions.

--- a/public/components/Flyout/flyouts/triggerCondition.js
+++ b/public/components/Flyout/flyouts/triggerCondition.js
@@ -36,7 +36,7 @@ const triggerCondition = (context) => ({
   ),
   body: (
     <div>
-      <EuiText style={{ fontSize: '14px' }}>
+      <EuiText size="s">
         <p>You have access to a "ctx" variable in your painless scripts</p>
         <p>
           Below shows a quick JSON example of what's available under the "ctx" variable along with

--- a/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
@@ -69,7 +69,7 @@ export const getPerformanceModal = ({ edit, onClose, onSubmit, values }) => {
       </EuiModalHeader>
 
       <EuiModalBody>
-        <EuiText>
+        <EuiText size="s">
           <p>The following use cases may impact this monitor's performance.</p>
           <ul>
             {hasRemoteClusters && <li>One or more remote indexes may affect monitor accuracy</li>}

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/ActionEmptyPrompt.js
@@ -25,7 +25,7 @@ const ActionEmptyPrompt = ({
     <EuiEmptyPrompt
       style={{ maxWidth: '45em' }}
       body={
-        <EuiText>
+        <EuiText size="s">
           <p>{hasDestinations ? actionEmptyText : destinationEmptyText}</p>
         </EuiText>
       }

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
@@ -14,7 +14,9 @@ exports[`ActionEmptyPrompt renders 1`] = `
     </EuiButton>
   }
   body={
-    <EuiText>
+    <EuiText
+      size="s"
+    >
       <p>
         There are no existing channels. Add a channel to create an action.
       </p>

--- a/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
+++ b/public/pages/CreateTrigger/components/TriggerEmptyPrompt/TriggerEmptyPrompt.js
@@ -20,7 +20,7 @@ const TriggerEmptyPrompt = ({
   <EuiEmptyPrompt
     style={{ maxWidth: '45em' }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <h4>No triggers</h4>
         <p>Add a trigger to define conditions and actions.</p>
       </EuiText>

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/DashboardEmptyPrompt.js
@@ -42,7 +42,7 @@ const DashboardEmptyPrompt = ({ onCreateTrigger, isModal = false }) => {
     <EuiEmptyPrompt
       style={{ maxWidth: '45em' }}
       body={
-        <EuiText>
+        <EuiText size="s">
           <p>{displayText}</p>
         </EuiText>
       }

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/__snapshots__/DashboardEmptyPrompt.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/__snapshots__/DashboardEmptyPrompt.test.js.snap
@@ -12,7 +12,7 @@ exports[`DashboardEmptyPrompt renders 1`] = `
       class="euiText euiText--medium"
     >
       <div
-        class="euiText euiText--medium"
+        class="euiText euiText--small"
       >
         <p>
           There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.

--- a/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
+++ b/public/pages/Dashboard/components/FindingsDashboard/FindingFlyout.js
@@ -126,7 +126,7 @@ export default class FindingFlyout extends Component {
         <EuiFlyoutBody>
           <EuiFlexGrid columns={2} direction={'column'} gutterSize={'m'}>
             <EuiFlexItem grow={false}>
-              <EuiText size={'m'}>
+              <EuiText size="s">
                 <strong>Document ID</strong>
                 <p>{docId}</p>
               </EuiText>
@@ -135,7 +135,7 @@ export default class FindingFlyout extends Component {
             {/*TODO FIXME: ExecuteMonitor API currently only returns a list of query names/IDs and the relevant docIds */}
             {!_.isEmpty(findingId) && (
               <EuiFlexItem grow={false}>
-                <EuiText size={'m'}>
+                <EuiText size="s">
                   <strong>Finding ID</strong>
                   <p>{findingId}</p>
                 </EuiText>
@@ -143,7 +143,7 @@ export default class FindingFlyout extends Component {
             )}
 
             <EuiFlexItem grow={false}>
-              <EuiText size={'m'}>
+              <EuiText size="s">
                 <strong>Index</strong>
                 <p>{index}</p>
               </EuiText>
@@ -152,14 +152,14 @@ export default class FindingFlyout extends Component {
 
           <EuiHorizontalRule margin={'l'} />
 
-          <EuiText size={'m'}>
+          <EuiText size="s">
             <strong>Queries</strong>
             {queriesDisplay}
           </EuiText>
 
           <EuiHorizontalRule margin={'l'} />
 
-          <EuiText size={'m'}>
+          <EuiText size="s">
             <strong>Document</strong>
           </EuiText>
           <EuiCodeBlock

--- a/public/pages/Dashboard/containers/FindingsDashboard.js
+++ b/public/pages/Dashboard/containers/FindingsDashboard.js
@@ -247,7 +247,7 @@ export default class FindingsDashboard extends Component {
               <EuiEmptyPrompt
                 style={{ maxWidth: '45em' }}
                 body={
-                  <EuiText>
+                  <EuiText size="s">
                     <p>{NO_FINDINGS_TEXT}</p>
                   </EuiText>
                 }

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -1459,7 +1459,9 @@ exports[`Dashboard renders in flyout 1`] = `
                                           </EuiButton>
                                         }
                                         body={
-                                          <EuiText>
+                                          <EuiText
+                                            size="s"
+                                          >
                                             <p>
                                               There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
                                             </p>
@@ -1489,9 +1491,11 @@ exports[`Dashboard renders in flyout 1`] = `
                                                 <div
                                                   className="euiText euiText--medium"
                                                 >
-                                                  <EuiText>
+                                                  <EuiText
+                                                    size="s"
+                                                  >
                                                     <div
-                                                      className="euiText euiText--medium"
+                                                      className="euiText euiText--small"
                                                     >
                                                       <p>
                                                         There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
@@ -3413,7 +3417,9 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                           </EuiButton>
                                         }
                                         body={
-                                          <EuiText>
+                                          <EuiText
+                                            size="s"
+                                          >
                                             <p>
                                               There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
                                             </p>
@@ -3443,9 +3449,11 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                                                 <div
                                                   className="euiText euiText--medium"
                                                 >
-                                                  <EuiText>
+                                                  <EuiText
+                                                    size="s"
+                                                  >
                                                     <div
-                                                      className="euiText euiText--medium"
+                                                      className="euiText euiText--small"
                                                     >
                                                       <p>
                                                         There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
@@ -5089,7 +5097,9 @@ exports[`Dashboard renders with per alert view 1`] = `
                                           </EuiButton>
                                         }
                                         body={
-                                          <EuiText>
+                                          <EuiText
+                                            size="s"
+                                          >
                                             <p>
                                               There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.
                                             </p>
@@ -5119,9 +5129,11 @@ exports[`Dashboard renders with per alert view 1`] = `
                                                 <div
                                                   className="euiText euiText--medium"
                                                 >
-                                                  <EuiText>
+                                                  <EuiText
+                                                    size="s"
+                                                  >
                                                     <div
-                                                      className="euiText euiText--medium"
+                                                      className="euiText euiText--small"
                                                     >
                                                       <p>
                                                         There are no existing alerts. Create a monitor to add triggers and actions. Once an alarm is triggered, the state will show in this table.

--- a/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/FullPageNotificationsInfoCallOut.js
+++ b/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/FullPageNotificationsInfoCallOut.js
@@ -30,7 +30,7 @@ const noNotificationsButton = (
 
 const hasNotificationsTitle = 'Destinations have become channels in Notifications';
 const hasNotificationsText = (
-  <EuiText>
+  <EuiText size="s">
     <p>
       Your destinations have been migrated as channels in Notifications, a new centralized place to
       manage your notification channels. Destinations will be deprecated going forward.&nbsp;
@@ -47,7 +47,7 @@ const FullPageNotificationsInfoCallOut = ({ hasNotificationPlugin }) => {
       View in Notifications
     </EuiButton>
   );
-  
+
   return (
     <EuiPanel>
       <EuiEmptyPrompt
@@ -57,6 +57,6 @@ const FullPageNotificationsInfoCallOut = ({ hasNotificationPlugin }) => {
       />
     </EuiPanel>
   );
-}
+};
 
 export default FullPageNotificationsInfoCallOut;

--- a/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/__snapshots__/FullPageNotificationsInfoCallOut.test.js.snap
+++ b/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/__snapshots__/FullPageNotificationsInfoCallOut.test.js.snap
@@ -22,7 +22,7 @@ exports[`FullPageNotificationsInfoCallOut renders when Notifications plugin is i
         class="euiText euiText--medium"
       >
         <div
-          class="euiText euiText--medium"
+          class="euiText euiText--small"
         >
           <p>
             Your destinations have been migrated as channels in Notifications, a new centralized place to manage your notification channels. Destinations will be deprecated going forward. 

--- a/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.js
+++ b/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/EmptyHistory.js
@@ -11,7 +11,7 @@ const EmptyHistory = ({ onShowTrigger }) => (
   <EuiEmptyPrompt
     style={{ maxWidth: '45em' }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <p>
           There are no triggers. Create a trigger to start alerting. Once an alarm is triggered, the
           state will be displayed in time series.

--- a/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/__snapshots__/EmptyHistory.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/__snapshots__/EmptyHistory.test.js.snap
@@ -12,7 +12,7 @@ exports[`<EmptyHistory/> renders 1`] = `
       class="euiText euiText--medium"
     >
       <div
-        class="euiText euiText--medium"
+        class="euiText euiText--small"
       >
         <p>
           There are no triggers. Create a trigger to start alerting. Once an alarm is triggered, the state will be displayed in time series.

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.js
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/MonitorEmptyPrompt.js
@@ -41,7 +41,7 @@ const MonitorEmptyPrompt = (props) => (
   <EuiEmptyPrompt
     style={{ maxWidth: '45em' }}
     body={
-      <EuiText>
+      <EuiText size="s">
         <p>{getMessagePrompt(props)}</p>
       </EuiText>
     }

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/__snapshots__/MonitorEmptyPrompt.test.js.snap
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/__snapshots__/MonitorEmptyPrompt.test.js.snap
@@ -12,7 +12,7 @@ exports[`MonitorEmptyPrompt renders 1`] = `
       class="euiText euiText--medium"
     >
       <div
-        class="euiText euiText--medium"
+        class="euiText euiText--small"
       >
         <p>
           There are no existing monitors. Create a monitor to add triggers and actions.


### PR DESCRIPTION
### Description
- update some instances where it's using inline styling for fonts, to use <EuiText size="s">, so it will work with different themes
- update existing paragraph/freeform text to have denser look by using `EuiText size="s".  For those which are already using `size="xs"`, remain unchanged.

![image](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/32652829/dcf750b3-fd34-4184-8c26-c0bc2a774df4)

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
