### PR TITLE
[Look&Feel] use semantic header with correct size for page, modal and flyout

### DIFF
--- a/cypress/integration/composite_level_monitor_spec.js
+++ b/cypress/integration/composite_level_monitor_spec.js
@@ -154,7 +154,7 @@ describe('CompositeLevelMonitor', () => {
 
       // Wait for monitor to be created
       cy.wait('@updateMonitorRequest').then(() => {
-        cy.get('.euiTitle--large').contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`);
+        cy.get('.euiTitle--small').contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`);
       });
     });
   });

--- a/public/components/ContentPanel/ContentPanel.js
+++ b/public/components/ContentPanel/ContentPanel.js
@@ -5,18 +5,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiPanel,
-  EuiTitle,
-  EuiText,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiPanel, EuiText } from '@elastic/eui';
 
 const ContentPanel = ({
   title = '',
-  titleSize = 'l',
+  titleSize = 's',
   description = '',
   descriptionSize = 'xs',
   bodyStyles = {},
@@ -28,9 +21,9 @@ const ContentPanel = ({
   <EuiPanel style={{ paddingLeft: '0px', paddingRight: '0px', ...panelStyles }}>
     <EuiFlexGroup style={{ padding: '0px 10px' }} justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem>
-        <EuiTitle size={titleSize}>
-          <h3>{title}</h3>
-        </EuiTitle>
+        <EuiText size={titleSize}>
+          <h2>{title}</h2>
+        </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
@@ -12,11 +12,13 @@ exports[`ContentPanel renders 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--large"
+      <div
+        class="euiText euiText--small"
       >
-        Test Content Panel
-      </h3>
+        <h2>
+          Test Content Panel
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/AddAlertingMonitor.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/AddAlertingMonitor.tsx
@@ -16,6 +16,7 @@ import {
   EuiButtonEmpty,
   EuiFormFieldset,
   EuiCheckableCard,
+  EuiText
 } from '@elastic/eui';
 import './styles.scss';
 import CreateNew from './CreateNew';
@@ -146,11 +147,11 @@ function AddAlertingMonitor({
           return (
             <>
               <EuiFlyoutHeader hasBorder>
-                <EuiTitle>
+                <EuiText size="s">
                   <h2 id="add-alerting-monitor__title">
                     {flyoutMode === 'adMonitor' ? 'Set up alerts' : 'Add alerting monitor'}
                   </h2>
-                </EuiTitle>
+                </EuiText>
               </EuiFlyoutHeader>
               <EuiFlyoutBody>
                 {!isAssociateAllowed && (

--- a/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/AssociatedMonitors.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/AssociatedMonitors.tsx
@@ -15,7 +15,6 @@ import {
   EuiLoadingSpinner,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import './styles.scss';
 import { useColumns } from './helpers';
@@ -109,9 +108,9 @@ const AssociatedMonitors = ({ embeddable, closeFlyout, setFlyoutMode, monitors, 
         />
       ) : null}
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle>
+        <EuiText size="s">
           <h2 id="associated-monitors__title">Associated monitors</h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       {!isAssociateAllowed && (
         <EuiFlyoutHeader>

--- a/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/__snapshots__/AssociatedMonitors.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/__snapshots__/AssociatedMonitors.test.js.snap
@@ -7,13 +7,15 @@ exports[`AssociatedMonitors renders 1`] = `
   <EuiFlyoutHeader
     hasBorder={true}
   >
-    <EuiTitle>
+    <EuiText
+      size="s"
+    >
       <h2
         id="associated-monitors__title"
       >
         Associated monitors
       </h2>
-    </EuiTitle>
+    </EuiText>
   </EuiFlyoutHeader>
   <EuiFlyoutHeader />
   <EuiFlyoutBody>

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -210,20 +210,15 @@ Object {
     "maxWidth": 500,
     "size": "m",
   },
-  "header": <EuiTitle
-    size="m"
-    style={
-      Object {
-        "fontSize": "25px",
-      }
-    }
+  "header": <EuiText
+    size="s"
   >
     <h2>
       <strong>
         Trigger condition
       </strong>
     </h2>
-  </EuiTitle>,
+  </EuiText>,
   "headerProps": Object {
     "hasBorder": true,
   },

--- a/public/components/Flyout/flyouts/triggerCondition.js
+++ b/public/components/Flyout/flyouts/triggerCondition.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiCodeBlock, EuiCodeEditor, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { EuiCodeBlock, EuiCodeEditor, EuiSpacer, EuiText } from '@elastic/eui';
 
 const CONTEXT_VARIABLES = JSON.stringify(
   {
@@ -28,11 +28,11 @@ const triggerCondition = (context) => ({
   },
   headerProps: { hasBorder: true },
   header: (
-    <EuiTitle size="m" style={{ fontSize: '25px' }}>
+    <EuiText size="s">
       <h2>
         <strong>Trigger condition</strong>
       </h2>
-    </EuiTitle>
+    </EuiText>
   ),
   body: (
     <div>

--- a/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
+++ b/public/pages/CreateMonitor/components/QueryPerformance/QueryPerformance.js
@@ -64,7 +64,9 @@ export const getPerformanceModal = ({ edit, onClose, onSubmit, values }) => {
     <EuiModal onClose={onClose}>
       <EuiModalHeader>
         <EuiModalHeaderTitle>
-          <h1>Monitor is not optimized</h1>
+          <EuiText size="s">
+            <h2>Monitor is not optimized</h2>
+          </EuiText>
         </EuiModalHeaderTitle>
       </EuiModalHeader>
 

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -12,11 +12,13 @@ exports[`QueryPerformance renders 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Monitor performance
-      </h3>
+        <h2>
+          Monitor performance
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
+++ b/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
@@ -12,11 +12,13 @@ exports[`VisualGraph renders 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        COUNT of documents
-      </h3>
+        <h2>
+          COUNT of documents
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -551,11 +553,13 @@ exports[`VisualGraph renders with bucket level monitor 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        COUNT of documents
-      </h3>
+        <h2>
+          COUNT of documents
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -12,7 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import DefineMonitor from '../DefineMonitor';
 import { FORMIK_INITIAL_VALUES } from './utils/constants';
@@ -157,11 +157,11 @@ export default class CreateMonitor extends Component {
       this.setState({
         initialValues: {
           ...this.state.initialValues,
-          dataSourceId: this.props.landingDataSourceId
-        }
+          dataSourceId: this.props.landingDataSourceId,
+        },
       });
     }
-  }  
+  }
 
   render() {
     const {
@@ -187,9 +187,9 @@ export default class CreateMonitor extends Component {
             const isComposite = values.monitor_type === MONITOR_TYPE.COMPOSITE_LEVEL;
             return (
               <Fragment>
-                <EuiTitle size="l">
+                <EuiText size="s">
                   <h1>{edit ? 'Edit' : 'Create'} monitor</h1>
-                </EuiTitle>
+                </EuiText>
                 <EuiSpacer />
 
                 <MonitorDetails

--- a/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
+++ b/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
@@ -12,11 +12,13 @@ exports[`WorkflowDetails renders 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Workflow
-      </h3>
+        <h2>
+          Workflow
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -539,7 +539,7 @@ export default class Dashboard extends Component {
         )}
         <ContentPanel
           title={perAlertView ? 'Alerts' : 'Alerts by triggers'}
-          titleSize={monitorIds.length ? 's' : 'l'}
+          titleSize={'s'}
           bodyStyles={{ padding: 'initial' }}
           actions={actions()}
         >

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -109,7 +109,7 @@ exports[`Dashboard renders in flyout 1`] = `
       }
     }
     title="Alerts"
-    titleSize="l"
+    titleSize="s"
   >
     <EuiPanel
       style={
@@ -149,15 +149,17 @@ exports[`Dashboard renders in flyout 1`] = `
               <div
                 className="euiFlexItem"
               >
-                <EuiTitle
-                  size="l"
+                <EuiText
+                  size="s"
                 >
-                  <h3
-                    className="euiTitle euiTitle--large"
+                  <div
+                    className="euiText euiText--small"
                   >
-                    Alerts
-                  </h3>
-                </EuiTitle>
+                    <h2>
+                      Alerts
+                    </h2>
+                  </div>
+                </EuiText>
               </div>
             </EuiFlexItem>
             <EuiFlexItem
@@ -1651,7 +1653,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
       }
     }
     title="Alerts by triggers"
-    titleSize="l"
+    titleSize="s"
   >
     <EuiPanel
       style={
@@ -1691,15 +1693,17 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
               <div
                 className="euiFlexItem"
               >
-                <EuiTitle
-                  size="l"
+                <EuiText
+                  size="s"
                 >
-                  <h3
-                    className="euiTitle euiTitle--large"
+                  <div
+                    className="euiText euiText--small"
                   >
-                    Alerts by triggers
-                  </h3>
-                </EuiTitle>
+                    <h2>
+                      Alerts by triggers
+                    </h2>
+                  </div>
+                </EuiText>
               </div>
             </EuiFlexItem>
             <EuiFlexItem
@@ -3599,7 +3603,7 @@ exports[`Dashboard renders with per alert view 1`] = `
       }
     }
     title="Alerts"
-    titleSize="l"
+    titleSize="s"
   >
     <EuiPanel
       style={
@@ -3639,15 +3643,17 @@ exports[`Dashboard renders with per alert view 1`] = `
               <div
                 className="euiFlexItem"
               >
-                <EuiTitle
-                  size="l"
+                <EuiText
+                  size="s"
                 >
-                  <h3
-                    className="euiTitle euiTitle--large"
+                  <div
+                    className="euiText euiText--small"
                   >
-                    Alerts
-                  </h3>
-                </EuiTitle>
+                    <h2>
+                      Alerts
+                    </h2>
+                  </div>
+                </EuiText>
               </div>
             </EuiFlexItem>
             <EuiFlexItem

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -12,11 +12,13 @@ exports[`MonitorOverview renders 1`] = `
     <div
       class="euiFlexItem"
     >
-      <h3
-        class="euiTitle euiTitle--small"
+      <div
+        class="euiText euiText--small"
       >
-        Overview
-      </h3>
+        <h2>
+          Overview
+        </h2>
+      </div>
     </div>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -25,7 +25,7 @@ import {
   EuiSpacer,
   EuiTab,
   EuiTabs,
-  EuiTitle,
+  EuiText,
 } from '@elastic/eui';
 import CreateMonitor from '../../CreateMonitor';
 import MonitorOverview from '../components/MonitorOverview';
@@ -484,18 +484,9 @@ export default class MonitorDetails extends Component {
         {this.renderNoTriggersCallOut()}
         <EuiFlexGroup alignItems="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiTitle size="l" style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
-              <h1
-                style={{
-                  whiteSpace: 'nowrap',
-                  maxWidth: '90%',
-                  textOverflow: 'ellipsis',
-                  overflow: 'hidden',
-                }}
-              >
-                {monitor.name}
-              </h1>
-            </EuiTitle>
+            <EuiText size="s" style={{ whiteSpace: 'nowrap', overflow: 'hidden' }}>
+              <h1>{monitor.name}</h1>
+            </EuiText>
           </EuiFlexItem>
           <EuiFlexItem style={{ paddingBottom: '5px', marginLeft: '0px' }}>
             {monitor.enabled ? (


### PR DESCRIPTION
### Description

Use H1s on main pages and H2s on secondary experiences (modals/flyouts). These should be under <EuiText size=’s’> to make sure they’re the correct size.

[Done] Need to reproduce the behavior of alerting visualization flyout, and make change accordingly


![image](https://github.com/opensearch-project/alerting-dashboards-plugin/assets/32652829/ce7ec55d-86c0-45ce-a85d-931b5b867155)

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
