### PR TITLE
Plugin Version decoupling for MDS support

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -16,5 +16,7 @@
     "opensearchDashboardsUtils"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "supportedOSDataSourceVersions": ">=2.3.0",
+  "requiredOSDataSourcePlugins": ["opensearch-alerting"]
 }

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -17,6 +17,6 @@
   ],
   "server": true,
   "ui": true,
-  "supportedOSDataSourceVersions": ">=2.3.0",
+  "supportedOSDataSourceVersions": ">=2.13.0",
   "requiredOSDataSourcePlugins": ["opensearch-alerting"]
 }

--- a/public/pages/Main/Main.js
+++ b/public/pages/Main/Main.js
@@ -103,11 +103,11 @@ class Main extends Component {
   };
 
   dataSourceFilterFn = (dataSource) => {
-    const engineVersion = dataSource?.attributes?.dataSourceVersion || "";
-    const availablePlugins = dataSource?.attributes?.installedPlugins || [];
+    const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || "";
+    const installedPlugins = dataSource?.attributes?.installedPlugins || [];
     return (
-      semver.satisfies(engineVersion, pluginManifest.supportedOSDataSourceVersions) &&
-      pluginManifest.requiredOSDataSourcePlugins.every((plugin) => availablePlugins.includes(plugin))
+      semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions) &&
+      pluginManifest.requiredOSDataSourcePlugins.every((plugin) => installedPlugins.includes(plugin))
     );
   };
 


### PR DESCRIPTION
### Description
This PR filters out the versions which are not supported when MDS support is enabled
 
### Issues Resolved
* The Cluster Metrics Monitor part in MDS doesn't work due to Version Compatibility issue.
Cluster Metrics Monitor creation encounters issues with other data sources <=2.11. This discrepancy arises from a version incompatibility. Specifically, a field was introduced in version 2.13 as part of the request payload of _monitors/_execute  API is expected to be absent in version 2.11 data source request payloads. Therefore, we get parsing exception for _monitors/_execute  API from Alerting Backend when we are connected with dataSource versions <= 2.11. Therefore the support range for MDS is >=2.13 for alerting Plugin
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
