### PR TITLE
[Manual][Backport 2.16][Look&Feel] apply missing pattern guidance to Alerting experience (#1004)

### DIFF
--- a/cypress/integration/composite_level_monitor_spec.js
+++ b/cypress/integration/composite_level_monitor_spec.js
@@ -154,7 +154,7 @@ describe('CompositeLevelMonitor', () => {
 
       // Wait for monitor to be created
       cy.wait('@updateMonitorRequest').then(() => {
-        cy.get('.euiTitle--small').contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`);
+        cy.get('.euiText--small').contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`);
       });
     });
   });

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -21,15 +21,15 @@ Object {
     <EuiFlexItem
       className="eui-textTruncate"
     >
-      <EuiTitle
+      <EuiText
         className="eui-textTruncate"
         data-test-subj="alertsDashboardFlyout_header_undefined"
-        size="m"
+        size="s"
       >
-        <h3>
+        <h2>
           Alerts by undefined
-        </h3>
-      </EuiTitle>
+        </h2>
+      </EuiText>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}

--- a/public/components/Flyout/flyouts/alertsDashboard.js
+++ b/public/components/Flyout/flyouts/alertsDashboard.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiSmallButtonIcon, EuiTitle, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiText, EuiFlexItem, EuiSmallButtonIcon } from '@elastic/eui';
 import AlertsDashboardFlyoutComponent from './components/AlertsDashboardFlyoutComponent';
 
 const alertsDashboard = (payload) => {
@@ -20,13 +20,13 @@ const alertsDashboard = (payload) => {
     header: (
       <EuiFlexGroup justifyContent="flexStart" alignItems="center">
         <EuiFlexItem className="eui-textTruncate">
-          <EuiTitle
+          <EuiText
             className="eui-textTruncate"
-            size={'m'}
+            size={'s'}
             data-test-subj={`alertsDashboardFlyout_header_${trigger_name}`}
           >
-            <h3>{`Alerts by ${trigger_name}`}</h3>
-          </EuiTitle>
+            <h2>{`Alerts by ${trigger_name}`}</h2>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButtonIcon

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.js
@@ -103,7 +103,7 @@ export default class MonitorActions extends Component {
             panelPaddingSize="none"
             anchorPosition="downLeft"
           >
-            <EuiContextMenuPanel items={this.getActions()} />
+            <EuiContextMenuPanel items={this.getActions()} size="s" />
           </EuiPopover>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION

Manually backport #1004 to `2.16`

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
