### PR TITLE
Re-render alerts table on comment setting update

### DIFF
--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -121,7 +121,7 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     });
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     const prevQuery = getQueryObjectFromState(prevState);
     const currQuery = getQueryObjectFromState(this.state);
     if (!_.isEqual(prevQuery, currQuery)) {
@@ -146,10 +146,11 @@ export default class AlertsDashboardFlyoutComponent extends Component {
         monitorIds
       );
     }
-    const { monitorType } = this.state;
+    const { monitorType, commentsEnabled, tabId } = this.state;
     if (
-      [MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) &&
-      !_.isEqual(prevState.selectedItems, this.state.selectedItems)
+      ([MONITOR_TYPE.DOC_LEVEL, MONITOR_TYPE.COMPOSITE_LEVEL].includes(monitorType) &&
+        !_.isEqual(prevState.selectedItems, this.state.selectedItems)) ||
+      (tabId === TABLE_TAB_IDS.ALERTS.id && commentsEnabled !== prevState.commentsEnabled)
     )
       this.setState({ tabContent: this.renderAlertsTable() });
   }


### PR DESCRIPTION
### Description
If the call to fetch comments cluster settings take longer, the UI does not update after it finishes, this PR adds the check to re-render the alerts table.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
