### PR TITLE
Fit and Finish UX Fixes

### DIFF
--- a/cypress/integration/bucket_level_monitor_spec.js
+++ b/cypress/integration/bucket_level_monitor_spec.js
@@ -338,8 +338,8 @@ describe('Bucket-Level Monitors', () => {
         // Add a trigger
         addTriggerToVisualEditorMonitor(SAMPLE_TRIGGER, 0, SAMPLE_ACTION, true);
 
-        // Click update button to save monitor changes
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click save to save monitor changes
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we can see only one row in the trigger list by checking <caption> element
         cy.contains('This table contains 1 row');
@@ -375,8 +375,8 @@ describe('Bucket-Level Monitors', () => {
           timeout: 25000,
         });
 
-        // Click the update button
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click the save button
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we're on the Monitor Details page by searching for the History element
         cy.contains('History', { timeout: 20000 });

--- a/cypress/integration/cluster_metrics_monitor_spec.js
+++ b/cypress/integration/cluster_metrics_monitor_spec.js
@@ -369,8 +369,8 @@ describe('ClusterMetricsMonitor', () => {
           'ctx.results[0].number_of_pending_tasks >= 0'
         );
 
-        // Click update button to save monitor changes
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click save button to save monitor changes
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we can see only one row in the trigger list by checking <caption> element
         cy.contains('This table contains 1 row');

--- a/cypress/integration/composite_level_monitor_spec.js
+++ b/cypress/integration/composite_level_monitor_spec.js
@@ -130,6 +130,7 @@ describe('CompositeLevelMonitor', () => {
 
     it('by visual editor', () => {
       // Verify edit page
+      cy.contains('Edit').click({ force: true });
       cy.contains('Edit monitor', { timeout: 20000 });
       cy.get('input[name="name"]').type('_edited');
 
@@ -150,7 +151,7 @@ describe('CompositeLevelMonitor', () => {
         .type('{enter}');
 
       cy.intercept('api/alerting/workflows/*').as('updateMonitorRequest');
-      cy.get('button').contains('Update').click({ force: true });
+      cy.get('button').contains('Save').click({ force: true });
 
       // Wait for monitor to be created
       cy.wait('@updateMonitorRequest').then(() => {

--- a/cypress/integration/document_level_monitor_spec.js
+++ b/cypress/integration/document_level_monitor_spec.js
@@ -380,8 +380,8 @@ describe('DocumentLevelMonitor', () => {
 
         // TODO: Test with Notifications plugin
 
-        // Click the update button
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click the save button
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we can see only one row in the trigger list by checking <caption> element
         cy.contains('This table contains 2 rows');
@@ -446,8 +446,8 @@ describe('DocumentLevelMonitor', () => {
 
         // TODO: Test with Notifications plugin
 
-        // Click the create button
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click the save button
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we can see only one row in the trigger list by checking <caption> element
         cy.contains('This table contains 1 row');
@@ -489,8 +489,8 @@ describe('DocumentLevelMonitor', () => {
         cy.get('[data-test-subj="indicesComboBox"]').should('not.have.text', TESTING_INDEX_A);
         cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_B, { timeout: 20000 });
 
-        // Click the update button
-        cy.get('button').contains('Update').last().click({ force: true });
+        // Click the save button
+        cy.get('button').contains('Save').last().click({ force: true });
 
         // Confirm we're on the Monitor Details page by searching for the History element
         cy.contains('History', { timeout: 20000 });

--- a/cypress/integration/query_level_monitor_spec.js
+++ b/cypress/integration/query_level_monitor_spec.js
@@ -178,8 +178,8 @@ describe('Query-Level Monitors', () => {
         .clear()
         .type(UPDATED_MONITOR, { force: true });
 
-      // Click Update button
-      cy.get('button').contains('Update').last().click({ force: true });
+      // Click save button
+      cy.get('button').contains('Save').last().click({ force: true });
 
       // Confirm the update process is done and the page loaded
       cy.contains('Edit monitor');
@@ -222,8 +222,8 @@ describe('Query-Level Monitors', () => {
         timeout: 25000,
       });
 
-      // Click the update button
-      cy.get('button').contains('Update').last().click();
+      // Click the save button
+      cy.get('button').contains('Save').last().click();
 
       // Confirm we're on the Monitor Details page by searching for the History element
       cy.contains('History', { timeout: 25000 });
@@ -339,8 +339,8 @@ describe('Query-Level Monitors', () => {
         addVisualQueryLevelTrigger(trigger.name, i, true, `IS ${trigger.enum}`, `${i}`);
       }
 
-      // Click Update button
-      cy.get('button').contains('Update').last().click({ force: true });
+      // Click save button
+      cy.get('button').contains('Save').last().click({ force: true });
 
       // Confirm we can see the correct number of rows in the trigger list by checking <caption> element
       cy.contains(`This table contains ${triggers.length} rows`, { timeout: 25000 });

--- a/public/components/Breadcrumbs/Breadcrumbs.js
+++ b/public/components/Breadcrumbs/Breadcrumbs.js
@@ -82,8 +82,8 @@ export async function getBreadcrumb(route, routeState, httpClient) {
           console.error(err);
         }
         const breadcrumbs = [{ text: monitorName, href: `/monitors/${base}` }];
-        if (action === MONITOR_ACTIONS.UPDATE_MONITOR)
-          breadcrumbs.push({ text: 'Update monitor', href: '/' });
+        if (action === MONITOR_ACTIONS.EDIT_MONITOR)
+          breadcrumbs.push({ text: 'Edit monitor', href: '/' });
         if (action === TRIGGER_ACTIONS.CREATE_TRIGGER)
           breadcrumbs.push({ text: 'Create trigger', href: '/' });
         if (action === TRIGGER_ACTIONS.UPDATE_TRIGGER)

--- a/public/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/public/components/Breadcrumbs/Breadcrumbs.test.js
@@ -102,7 +102,7 @@ describe('getBreadcrumb', () => {
       httpClientMock.get.mockResolvedValue({ ok: true, resp: { name: 'random_name' } });
       expect(
         await getBreadcrumb(
-          `${monitorId}?action=${MONITOR_ACTIONS.UPDATE_MONITOR}`,
+          `${monitorId}?action=${MONITOR_ACTIONS.EDIT_MONITOR}`,
           {},
           httpClientMock
         )

--- a/public/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/public/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -70,7 +70,7 @@ Array [
   },
   Object {
     "href": "/",
-    "text": "Update monitor",
+    "text": "Edit monitor",
   },
 ]
 `;

--- a/public/components/ContentPanel/ContentPanel.js
+++ b/public/components/ContentPanel/ContentPanel.js
@@ -19,7 +19,7 @@ const ContentPanel = ({
   children,
   panelOptions = {},
 }) => (
-  <EuiPanel style={{ paddingLeft: '0px', paddingRight: '0px', ...panelStyles }}>
+  <EuiPanel style={{ padding: '16px', ...panelStyles }}>
     <EuiFlexGroup style={{ padding: '0px 10px' }} justifyContent="spaceBetween" alignItems="center">
       <EuiFlexItem>
         <EuiText size={titleSize}>

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ContentPanel renders 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:0px;padding-right:0px"
+  style="padding:16px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -27,13 +27,13 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
 
   useEffect(() => {
     setLoading(true);
-    getClient().get('../api/alerting/alerts', { 
+    getClient().get('../api/alerting/alerts', {
       query: {
         size: 25,
         sortField: 'start_time',
         dataSourceId: dataSource?.id || '',
         sortDirection: 'desc'
-      } 
+      }
     }).then(res => {
       if (res.ok) {
         setAlerts(res.alerts);
@@ -53,7 +53,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   const createAlertDetailsHeader = useCallback((alert) => {
     const severityColor = getSeverityColor(alert.severity);
     const triggerName = alert.trigger_name ?? DEFAULT_EMPTY_DATA;
-    
+
     return (
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
         <EuiFlexItem grow={false}>
@@ -147,7 +147,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiLink href={getApplication().getUrlForApp(ALERTS_NAV_ID, { path: '#/dashboard' })} target="_blank"><EuiText size="s" className="eui-displayInline">View all</EuiText></EuiLink>
+          <EuiLink href={getApplication().getUrlForApp(ALERTS_NAV_ID, { path: '#/dashboard' })}><EuiText size="s" className="eui-displayInline">View all</EuiText></EuiLink>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -455,8 +455,8 @@ export default class AlertsDashboardFlyoutComponent extends Component {
           onPageChange={this.onPageClick}
           isAlertsFlyout={true}
           monitorType={monitorType}
+          panelStyles={{ padding: '8px 0px 16px' }}
         />
-        <EuiHorizontalRule margin="xs" />
         <EuiBasicTable
           items={loading ? [] : trimmedAlerts}
           /*

--- a/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
+++ b/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
@@ -202,12 +202,14 @@ exports[`AlertsDashboardFlyoutComponent renders 1`] = `
       onSearchChange={[Function]}
       onStateChange={[Function]}
       pageCount={1}
+      panelStyles={
+        Object {
+          "padding": "8px 0px 16px",
+        }
+      }
       search=""
       severity="ALL"
       state="ALL"
-    />
-    <EuiHorizontalRule
-      margin="xs"
     />
     <EuiBasicTable
       columns={

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -3,7 +3,7 @@
 exports[`QueryPerformance renders 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:10px;padding-right:10px"
+  style="padding:16px;padding-left:10px;padding-right:10px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"

--- a/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
+++ b/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
@@ -3,7 +3,7 @@
 exports[`VisualGraph renders 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:10px;padding-right:0px"
+  style="padding:16px;padding-left:10px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -544,7 +544,7 @@ exports[`VisualGraph renders 1`] = `
 exports[`VisualGraph renders with bucket level monitor 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:10px;padding-right:0px"
+  style="padding:16px;padding-left:10px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"

--- a/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/CreateMonitor.js
@@ -177,7 +177,7 @@ export default class CreateMonitor extends Component {
     } = this.props;
     const { createModalOpen, initialValues, plugins } = this.state;
     return (
-      <div style={{ padding: '25px 50px' }}>
+      <div style={{ padding: '16px' }}>
         <Formik
           initialValues={initialValues}
           onSubmit={this.evaluateSubmission}
@@ -268,7 +268,7 @@ export default class CreateMonitor extends Component {
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiSmallButton fill onClick={handleSubmit} isLoading={isSubmitting}>
-                          {edit ? 'Update' : 'Create'}
+                          {edit ? 'Save' : 'Create'}
                         </EuiSmallButton>
                       </EuiFlexItem>
                     </EuiFlexGroup>

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -4,7 +4,7 @@ exports[`CreateMonitor renders 1`] = `
 <div
   style={
     Object {
-      "padding": "25px 50px",
+      "padding": "16px",
     }
   }
 >

--- a/public/pages/CreateMonitor/containers/DataSource/DataSource.js
+++ b/public/pages/CreateMonitor/containers/DataSource/DataSource.js
@@ -65,7 +65,6 @@ class DataSource extends Component {
       <ContentPanel
         title="Select data"
         titleSize="s"
-        panelStyles={{ paddingLeft: '10px', paddingRight: '10px' }}
         bodyStyles={{ padding: 'initial' }}
       >
         {monitorIndexDisplay}

--- a/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
@@ -7,12 +7,6 @@ exports[`DataSource renders 1`] = `
       "padding": "initial",
     }
   }
-  panelStyles={
-    Object {
-      "paddingLeft": "10px",
-      "paddingRight": "10px",
-    }
-  }
   title="Select data"
   titleSize="s"
 >

--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -702,10 +702,6 @@ class DefineMonitor extends Component {
         <PanelComponent
           title="Query"
           titleSize="s"
-          panelStyles={{
-            paddingLeft: '10px',
-            paddingRight: '10px',
-          }}
           bodyStyles={{ padding: 'initial' }}
           actions={monitorContent.actions}
         >

--- a/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
@@ -91,12 +91,6 @@ exports[`DefineMonitor renders 1`] = `
         "padding": "initial",
       }
     }
-    panelStyles={
-      Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
-      }
-    }
     title="Query"
     titleSize="s"
   >
@@ -142,12 +136,6 @@ exports[`DefineMonitor should show warning in case of Ad monitor and plugin is n
     bodyStyles={
       Object {
         "padding": "initial",
-      }
-    }
-    panelStyles={
-      Object {
-        "paddingLeft": "10px",
-        "paddingRight": "10px",
       }
     }
     title="Query"

--- a/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
@@ -64,10 +64,10 @@ const MonitorDetails = ({
       title="Monitor details"
       titleSize="s"
       panelStyles={{
-        paddingBottom: '20px',
+        paddingBottom: '16px',
         paddingLeft: '10px',
         paddingRight: '10px',
-        paddingTop: '20px',
+        paddingTop: '16px',
       }}
       actions={anomalyDetectorContent.actions}
     >

--- a/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
+++ b/public/pages/CreateMonitor/containers/MonitorDetails/MonitorDetails.js
@@ -63,12 +63,7 @@ const MonitorDetails = ({
     <Container
       title="Monitor details"
       titleSize="s"
-      panelStyles={{
-        paddingBottom: '16px',
-        paddingLeft: '10px',
-        paddingRight: '10px',
-        paddingTop: '16px',
-      }}
+      panelStyles={{ padding: '16px' }}
       actions={anomalyDetectorContent.actions}
     >
       {!flyoutMode && <EuiSpacer size="s" />}

--- a/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
+++ b/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
@@ -3,7 +3,7 @@
 exports[`WorkflowDetails renders 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:10px;padding-right:10px;padding-bottom:20px;padding-top:20px"
+  style="padding:16px;padding-bottom:20px;padding-left:10px;padding-right:10px;padding-top:20px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -453,7 +453,7 @@ class ConfigureTriggers extends React.Component {
             ? 'Triggers define the conditions that determine when a composite monitor should generate its own alert.'
             : undefined
         }
-        panelStyles={{ paddingBottom: '0px', paddingLeft: '20px', paddingRight: '20px' }}
+        panelStyles={{ padding: '16px' }}
         bodyStyles={{ paddingLeft: '0px', padding: '10px' }}
         horizontalRuleClassName={'accordion-horizontal-rule'}
       >

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/AcknowledgeAlertsModal.js
@@ -227,7 +227,7 @@ export default class AcknowledgeAlertsModal extends Component {
   onCreateTrigger = () => {
     const { history, monitorId, onClose } = this.props;
     onClose();
-    history.push(`/monitors/${monitorId}?action=${MONITOR_ACTIONS.UPDATE_MONITOR}`);
+    history.push(`/monitors/${monitorId}?action=${MONITOR_ACTIONS.EDIT_MONITOR}`);
   };
 
   render() {

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -45,7 +45,7 @@ const DashboardControls = ({
   isAlertsFlyout = false,
   monitorType,
   alertActions = [],
-  controlsStyle = {},
+  panelStyles = {},
 }) => {
   let supportedStateOptions = stateOptions;
   switch (monitorType) {
@@ -57,7 +57,7 @@ const DashboardControls = ({
       break;
   }
   return (
-    <EuiFlexGroup style={{ padding: '0px 0px 16px', ...controlsStyle }} gutterSize="s">
+    <EuiFlexGroup style={{ padding: '0px 0px 16px', ...panelStyles }} gutterSize="s">
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -45,6 +45,7 @@ const DashboardControls = ({
   isAlertsFlyout = false,
   monitorType,
   alertActions = [],
+  controlsStyle = {},
 }) => {
   let supportedStateOptions = stateOptions;
   switch (monitorType) {
@@ -56,7 +57,7 @@ const DashboardControls = ({
       break;
   }
   return (
-    <EuiFlexGroup style={{ padding: '0px 0px 16px' }} gutterSize="s">
+    <EuiFlexGroup style={{ padding: '0px 0px 16px', ...controlsStyle }} gutterSize="s">
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -56,7 +56,7 @@ const DashboardControls = ({
       break;
   }
   return (
-    <EuiFlexGroup style={{ padding: '0px 16px 16px' }} gutterSize="s">
+    <EuiFlexGroup style={{ padding: '0px 0px 16px' }} gutterSize="s">
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -87,9 +87,6 @@ const DashboardControls = ({
       {alertActions.map((action, idx) => (
         <EuiFlexItem grow={false}>{action}</EuiFlexItem>
       ))}
-      <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
-        <EuiPagination pageCount={pageCount} activePage={activePage} onPageClick={onPageChange} />
-      </EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
+++ b/public/pages/Dashboard/components/DashboardControls/DashboardControls.js
@@ -56,7 +56,7 @@ const DashboardControls = ({
       break;
   }
   return (
-    <EuiFlexGroup style={{ padding: '0px 5px' }} gutterSize="s">
+    <EuiFlexGroup style={{ padding: '0px 16px 16px' }} gutterSize="s">
       <EuiFlexItem>
         <EuiCompressedFieldSearch
           fullWidth={true}

--- a/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
@@ -3,7 +3,7 @@
 exports[`DashboardControls renders 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-  style="padding:0px 5px"
+  style="padding:0px 0px 16px"
 >
   <div
     class="euiFlexItem"
@@ -150,82 +150,6 @@ exports[`DashboardControls renders 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="euiFlexItem euiFlexItem--flexGrowZero"
-    style="justify-content:center"
-  >
-    <nav
-      class="euiPagination"
-    >
-      <button
-        aria-label="Previous page, 1"
-        class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-        data-test-subj="pagination-button-previous"
-        type="button"
-      >
-        <div>
-          EuiIconMock
-        </div>
-      </button>
-      <ul
-        class="euiPagination__list"
-      >
-        <li
-          class="euiPagination__item"
-        >
-          <button
-            aria-label="Page 1 of 2"
-            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiPaginationButton euiPaginationButton--hideOnMobile"
-            data-test-subj="pagination-button-0"
-            type="button"
-          >
-            <span
-              class="euiButtonContent euiButtonEmpty__content"
-            >
-              <span
-                class="euiButtonEmpty__text"
-              >
-                1
-              </span>
-            </span>
-          </button>
-        </li>
-        <li
-          class="euiPagination__item"
-        >
-          <button
-            aria-current="true"
-            aria-label="Page 2 of 2"
-            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-            data-test-subj="pagination-button-1"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="euiButtonContent euiButtonEmpty__content"
-            >
-              <span
-                class="euiButtonEmpty__text"
-              >
-                2
-              </span>
-            </span>
-          </button>
-        </li>
-      </ul>
-      <button
-        aria-label="Next page"
-        class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-        data-test-subj="pagination-button-next"
-        disabled=""
-        type="button"
-      >
-        <div>
-          EuiIconMock
-        </div>
-      </button>
-    </nav>
   </div>
 </div>
 `;

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -9,7 +9,6 @@ import queryString from 'query-string';
 import {
   EuiBasicTable,
   EuiSmallButton,
-  EuiHorizontalRule,
   EuiIcon,
   EuiToolTip,
   EuiSmallButtonIcon, EuiFlexItem, EuiPagination, EuiFlexGroup

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -561,6 +561,7 @@ export default class Dashboard extends Component {
             isAlertsFlyout={isAlertsFlyout}
             monitorType={monitorType}
             alertActions={useUpdatedUx ? actions() : undefined}
+            controlsStyle={{ padding: perAlertView ? '8px 0px 16px' : '0px 0px 16px' }}
           />
 
           <EuiBasicTable

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -578,7 +578,6 @@ export default class Dashboard extends Component {
             onChange={this.onTableChange}
             noItemsMessage={<DashboardEmptyPrompt onCreateTrigger={onCreateTrigger} />}
             data-test-subj={'alertsDashboard_table'}
-            style={{ padding: '0px 16px 0px' }}
           />
 
           {this.state.showAlertsModal && this.renderModal()}

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -11,8 +11,11 @@ import {
   EuiSmallButton,
   EuiIcon,
   EuiToolTip,
-  EuiSmallButtonIcon, EuiFlexItem, EuiPagination, EuiFlexGroup
-} from "@elastic/eui";
+  EuiSmallButtonIcon,
+  EuiFlexItem,
+  EuiPagination,
+  EuiFlexGroup,
+} from '@elastic/eui';
 import ContentPanel from '../../../components/ContentPanel';
 import DashboardEmptyPrompt from '../components/DashboardEmptyPrompt';
 import DashboardControls from '../components/DashboardControls';

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -12,8 +12,8 @@ import {
   EuiHorizontalRule,
   EuiIcon,
   EuiToolTip,
-  EuiSmallButtonIcon,
-} from '@elastic/eui';
+  EuiSmallButtonIcon, EuiFlexItem, EuiPagination, EuiFlexGroup
+} from "@elastic/eui";
 import ContentPanel from '../../../components/ContentPanel';
 import DashboardEmptyPrompt from '../components/DashboardEmptyPrompt';
 import DashboardControls from '../components/DashboardControls';
@@ -530,6 +530,7 @@ export default class Dashboard extends Component {
     };
 
     const useUpdatedUx = !perAlertView && getUseUpdatedUx();
+    const shouldShowPagination = !perAlertView && totalAlerts > 0;
 
     return (
       <>
@@ -581,6 +582,18 @@ export default class Dashboard extends Component {
             noItemsMessage={<DashboardEmptyPrompt onCreateTrigger={onCreateTrigger} />}
             data-test-subj={'alertsDashboard_table'}
           />
+
+          {shouldShowPagination && (
+            <EuiFlexGroup justifyContent="flexEnd" style={{ padding: '8px 0px 0px' }}>
+              <EuiFlexItem grow={false}>
+                <EuiPagination
+                  pageCount={Math.ceil(totalItems / size) || 1}
+                  activePage={page}
+                  onPageClick={this.onPageClick}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
 
           {this.state.showAlertsModal && this.renderModal()}
         </ContentPanel>

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -562,8 +562,6 @@ export default class Dashboard extends Component {
             alertActions={useUpdatedUx ? actions() : undefined}
           />
 
-          <EuiHorizontalRule margin="xs" />
-
           <EuiBasicTable
             items={perAlertView ? alerts : alertsByTriggers}
             /*

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -578,6 +578,7 @@ export default class Dashboard extends Component {
             onChange={this.onTableChange}
             noItemsMessage={<DashboardEmptyPrompt onCreateTrigger={onCreateTrigger} />}
             data-test-subj={'alertsDashboard_table'}
+            style={{ padding: '0px 16px 0px' }}
           />
 
           {this.state.showAlertsModal && this.renderModal()}

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -546,6 +546,7 @@ export default class Dashboard extends Component {
           bodyStyles={{ padding: 'initial' }}
           actions={useUpdatedUx ? undefined : actions()}
           panelOptions={{ hideTitleBorder: useUpdatedUx }}
+          panelStyles={{ padding: useUpdatedUx && totalAlerts < 1 ? '16px 16px 0px' : '16px' }}
         >
           <DashboardControls
             activePage={page}

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -561,7 +561,7 @@ export default class Dashboard extends Component {
             isAlertsFlyout={isAlertsFlyout}
             monitorType={monitorType}
             alertActions={useUpdatedUx ? actions() : undefined}
-            controlsStyle={{ padding: perAlertView ? '8px 0px 16px' : '0px 0px 16px' }}
+            panelStyles={{ padding: perAlertView ? '8px 0px 16px' : '0px 0px 16px' }}
           />
 
           <EuiBasicTable

--- a/public/pages/Dashboard/containers/FindingsDashboard.js
+++ b/public/pages/Dashboard/containers/FindingsDashboard.js
@@ -229,8 +229,6 @@ export default class FindingsDashboard extends Component {
           </EuiFlexGroup>
         )}
 
-        <EuiHorizontalRule margin={'xs'} />
-
         <EuiBasicTable
           items={loadingFindings ? [] : paginatedFindings}
           itemId={getItemId}

--- a/public/pages/Dashboard/containers/FindingsDashboard.js
+++ b/public/pages/Dashboard/containers/FindingsDashboard.js
@@ -206,7 +206,7 @@ export default class FindingsDashboard extends Component {
         bodyStyles={{ padding: 'initial' }}
       >
         {!isPreview && (
-          <EuiFlexGroup style={{ padding: '0px 5px' }}>
+          <EuiFlexGroup style={{ padding: '8px 0px 16px' }}>
             <EuiFlexItem>
               <EuiCompressedFieldSearch
                 fullWidth={true}

--- a/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
+++ b/public/pages/Dashboard/containers/__snapshots__/Dashboard.test.js.snap
@@ -113,14 +113,18 @@ exports[`Dashboard renders in flyout 1`] = `
         "hideTitleBorder": false,
       }
     }
+    panelStyles={
+      Object {
+        "padding": "16px",
+      }
+    }
     title="Alerts"
     titleSize="s"
   >
     <EuiPanel
       style={
         Object {
-          "paddingLeft": "0px",
-          "paddingRight": "0px",
+          "padding": "16px",
         }
       }
     >
@@ -128,8 +132,7 @@ exports[`Dashboard renders in flyout 1`] = `
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -301,6 +304,11 @@ exports[`Dashboard renders in flyout 1`] = `
             onSeverityChange={[Function]}
             onStateChange={[Function]}
             pageCount={1}
+            panelStyles={
+              Object {
+                "padding": "8px 0px 16px",
+              }
+            }
             search=""
             severity="ALL"
             state="ALL"
@@ -309,7 +317,7 @@ exports[`Dashboard renders in flyout 1`] = `
               gutterSize="s"
               style={
                 Object {
-                  "padding": "0px 5px",
+                  "padding": "8px 0px 16px",
                 }
               }
             >
@@ -317,7 +325,7 @@ exports[`Dashboard renders in flyout 1`] = `
                 className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
                 style={
                   Object {
-                    "padding": "0px 5px",
+                    "padding": "8px 0px 16px",
                   }
                 }
               >
@@ -569,216 +577,9 @@ exports[`Dashboard renders in flyout 1`] = `
                     </EuiCompressedSelect>
                   </div>
                 </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                  style={
-                    Object {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                    style={
-                      Object {
-                        "justifyContent": "center",
-                      }
-                    }
-                  >
-                    <EuiPagination
-                      activePage={0}
-                      onPageClick={[Function]}
-                      pageCount={1}
-                    >
-                      <nav
-                        className="euiPagination"
-                      >
-                        <EuiI18n
-                          default="Previous page, {page}"
-                          token="euiPagination.previousPage"
-                          values={
-                            Object {
-                              "page": 0,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Previous page"
-                            token="euiPagination.disabledPreviousPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Previous page"
-                              color="text"
-                              data-test-subj="pagination-button-previous"
-                              disabled={true}
-                              iconType="arrowLeft"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Previous page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-previous"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowLeft"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                        <ul
-                          className="euiPagination__list"
-                        >
-                          <PaginationButton
-                            key="0"
-                            pageIndex={0}
-                          >
-                            <li
-                              className="euiPagination__item"
-                            >
-                              <EuiPaginationButton
-                                hideOnMobile={true}
-                                isActive={true}
-                                onClick={[Function]}
-                                pageIndex={0}
-                                totalPages={1}
-                              >
-                                <EuiI18n
-                                  default="Page {page} of {totalPages}"
-                                  token="euiPaginationButton.longPageString"
-                                  values={
-                                    Object {
-                                      "page": 1,
-                                      "totalPages": 1,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Page {page}"
-                                    token="euiPaginationButton.shortPageString"
-                                    values={
-                                      Object {
-                                        "page": 1,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-current={true}
-                                      aria-label="Page 1 of 1"
-                                      className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                      color="text"
-                                      data-test-subj="pagination-button-0"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      size="s"
-                                    >
-                                      <button
-                                        aria-current={true}
-                                        aria-label="Page 1 of 1"
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                        data-test-subj="pagination-button-0"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconGap="m"
-                                          iconSide="left"
-                                          iconSize="m"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonEmpty__content"
-                                          >
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              1
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </EuiI18n>
-                                </EuiI18n>
-                              </EuiPaginationButton>
-                            </li>
-                          </PaginationButton>
-                        </ul>
-                        <EuiI18n
-                          default="Next page, {page}"
-                          token="euiPagination.nextPage"
-                          values={
-                            Object {
-                              "page": 2,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Next page"
-                            token="euiPagination.disabledNextPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Next page"
-                              color="text"
-                              data-test-subj="pagination-button-next"
-                              disabled={true}
-                              iconType="arrowRight"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Next page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-next"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowRight"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                      </nav>
-                    </EuiPagination>
-                  </div>
-                </EuiFlexItem>
               </div>
             </EuiFlexGroup>
           </DashboardControls>
-          <EuiHorizontalRule
-            margin="xs"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-            />
-          </EuiHorizontalRule>
           <EuiBasicTable
             columns={
               Array [
@@ -1721,14 +1522,18 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
         "hideTitleBorder": undefined,
       }
     }
+    panelStyles={
+      Object {
+        "padding": "16px",
+      }
+    }
     title="Alerts by triggers"
     titleSize="s"
   >
     <EuiPanel
       style={
         Object {
-          "paddingLeft": "0px",
-          "paddingRight": "0px",
+          "padding": "16px",
         }
       }
     >
@@ -1736,8 +1541,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -1970,6 +1774,11 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
             onSeverityChange={[Function]}
             onStateChange={[Function]}
             pageCount={1}
+            panelStyles={
+              Object {
+                "padding": "0px 0px 16px",
+              }
+            }
             search=""
             severity="ALL"
             state="ALL"
@@ -1978,7 +1787,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
               gutterSize="s"
               style={
                 Object {
-                  "padding": "0px 5px",
+                  "padding": "0px 0px 16px",
                 }
               }
             >
@@ -1986,7 +1795,7 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                 className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
                 style={
                   Object {
-                    "padding": "0px 5px",
+                    "padding": "0px 0px 16px",
                   }
                 }
               >
@@ -2412,216 +2221,9 @@ exports[`Dashboard renders with alert by triggers view 1`] = `
                     </EuiCompressedSelect>
                   </div>
                 </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                  style={
-                    Object {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                    style={
-                      Object {
-                        "justifyContent": "center",
-                      }
-                    }
-                  >
-                    <EuiPagination
-                      activePage={0}
-                      onPageClick={[Function]}
-                      pageCount={1}
-                    >
-                      <nav
-                        className="euiPagination"
-                      >
-                        <EuiI18n
-                          default="Previous page, {page}"
-                          token="euiPagination.previousPage"
-                          values={
-                            Object {
-                              "page": 0,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Previous page"
-                            token="euiPagination.disabledPreviousPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Previous page"
-                              color="text"
-                              data-test-subj="pagination-button-previous"
-                              disabled={true}
-                              iconType="arrowLeft"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Previous page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-previous"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowLeft"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                        <ul
-                          className="euiPagination__list"
-                        >
-                          <PaginationButton
-                            key="0"
-                            pageIndex={0}
-                          >
-                            <li
-                              className="euiPagination__item"
-                            >
-                              <EuiPaginationButton
-                                hideOnMobile={true}
-                                isActive={true}
-                                onClick={[Function]}
-                                pageIndex={0}
-                                totalPages={1}
-                              >
-                                <EuiI18n
-                                  default="Page {page} of {totalPages}"
-                                  token="euiPaginationButton.longPageString"
-                                  values={
-                                    Object {
-                                      "page": 1,
-                                      "totalPages": 1,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Page {page}"
-                                    token="euiPaginationButton.shortPageString"
-                                    values={
-                                      Object {
-                                        "page": 1,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-current={true}
-                                      aria-label="Page 1 of 1"
-                                      className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                      color="text"
-                                      data-test-subj="pagination-button-0"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      size="s"
-                                    >
-                                      <button
-                                        aria-current={true}
-                                        aria-label="Page 1 of 1"
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                        data-test-subj="pagination-button-0"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconGap="m"
-                                          iconSide="left"
-                                          iconSize="m"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonEmpty__content"
-                                          >
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              1
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </EuiI18n>
-                                </EuiI18n>
-                              </EuiPaginationButton>
-                            </li>
-                          </PaginationButton>
-                        </ul>
-                        <EuiI18n
-                          default="Next page, {page}"
-                          token="euiPagination.nextPage"
-                          values={
-                            Object {
-                              "page": 2,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Next page"
-                            token="euiPagination.disabledNextPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Next page"
-                              color="text"
-                              data-test-subj="pagination-button-next"
-                              disabled={true}
-                              iconType="arrowRight"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Next page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-next"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowRight"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                      </nav>
-                    </EuiPagination>
-                  </div>
-                </EuiFlexItem>
               </div>
             </EuiFlexGroup>
           </DashboardControls>
-          <EuiHorizontalRule
-            margin="xs"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-            />
-          </EuiHorizontalRule>
           <EuiBasicTable
             columns={
               Array [
@@ -3777,14 +3379,18 @@ exports[`Dashboard renders with per alert view 1`] = `
         "hideTitleBorder": false,
       }
     }
+    panelStyles={
+      Object {
+        "padding": "16px",
+      }
+    }
     title="Alerts"
     titleSize="s"
   >
     <EuiPanel
       style={
         Object {
-          "paddingLeft": "0px",
-          "paddingRight": "0px",
+          "padding": "16px",
         }
       }
     >
@@ -3792,8 +3398,7 @@ exports[`Dashboard renders with per alert view 1`] = `
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         style={
           Object {
-            "paddingLeft": "0px",
-            "paddingRight": "0px",
+            "padding": "16px",
           }
         }
       >
@@ -3965,6 +3570,11 @@ exports[`Dashboard renders with per alert view 1`] = `
             onSeverityChange={[Function]}
             onStateChange={[Function]}
             pageCount={1}
+            panelStyles={
+              Object {
+                "padding": "8px 0px 16px",
+              }
+            }
             search=""
             severity="ALL"
             state="ALL"
@@ -3973,7 +3583,7 @@ exports[`Dashboard renders with per alert view 1`] = `
               gutterSize="s"
               style={
                 Object {
-                  "padding": "0px 5px",
+                  "padding": "8px 0px 16px",
                 }
               }
             >
@@ -3981,7 +3591,7 @@ exports[`Dashboard renders with per alert view 1`] = `
                 className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
                 style={
                   Object {
-                    "padding": "0px 5px",
+                    "padding": "8px 0px 16px",
                   }
                 }
               >
@@ -4407,216 +4017,9 @@ exports[`Dashboard renders with per alert view 1`] = `
                     </EuiCompressedSelect>
                   </div>
                 </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                  style={
-                    Object {
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                    style={
-                      Object {
-                        "justifyContent": "center",
-                      }
-                    }
-                  >
-                    <EuiPagination
-                      activePage={0}
-                      onPageClick={[Function]}
-                      pageCount={1}
-                    >
-                      <nav
-                        className="euiPagination"
-                      >
-                        <EuiI18n
-                          default="Previous page, {page}"
-                          token="euiPagination.previousPage"
-                          values={
-                            Object {
-                              "page": 0,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Previous page"
-                            token="euiPagination.disabledPreviousPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Previous page"
-                              color="text"
-                              data-test-subj="pagination-button-previous"
-                              disabled={true}
-                              iconType="arrowLeft"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Previous page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-previous"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowLeft"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                        <ul
-                          className="euiPagination__list"
-                        >
-                          <PaginationButton
-                            key="0"
-                            pageIndex={0}
-                          >
-                            <li
-                              className="euiPagination__item"
-                            >
-                              <EuiPaginationButton
-                                hideOnMobile={true}
-                                isActive={true}
-                                onClick={[Function]}
-                                pageIndex={0}
-                                totalPages={1}
-                              >
-                                <EuiI18n
-                                  default="Page {page} of {totalPages}"
-                                  token="euiPaginationButton.longPageString"
-                                  values={
-                                    Object {
-                                      "page": 1,
-                                      "totalPages": 1,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Page {page}"
-                                    token="euiPaginationButton.shortPageString"
-                                    values={
-                                      Object {
-                                        "page": 1,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-current={true}
-                                      aria-label="Page 1 of 1"
-                                      className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                      color="text"
-                                      data-test-subj="pagination-button-0"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      size="s"
-                                    >
-                                      <button
-                                        aria-current={true}
-                                        aria-label="Page 1 of 1"
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                        data-test-subj="pagination-button-0"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconGap="m"
-                                          iconSide="left"
-                                          iconSize="m"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonEmpty__content"
-                                          >
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              1
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </EuiI18n>
-                                </EuiI18n>
-                              </EuiPaginationButton>
-                            </li>
-                          </PaginationButton>
-                        </ul>
-                        <EuiI18n
-                          default="Next page, {page}"
-                          token="euiPagination.nextPage"
-                          values={
-                            Object {
-                              "page": 2,
-                            }
-                          }
-                        >
-                          <EuiI18n
-                            default="Next page"
-                            token="euiPagination.disabledNextPage"
-                          >
-                            <EuiButtonIcon
-                              aria-label="Next page"
-                              color="text"
-                              data-test-subj="pagination-button-next"
-                              disabled={true}
-                              iconType="arrowRight"
-                              onClick={[Function]}
-                            >
-                              <button
-                                aria-label="Next page"
-                                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                data-test-subj="pagination-button-next"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiButtonIcon__icon"
-                                  color="inherit"
-                                  size="m"
-                                  type="arrowRight"
-                                >
-                                  <div>
-                                    EuiIconMock
-                                  </div>
-                                </EuiIcon>
-                              </button>
-                            </EuiButtonIcon>
-                          </EuiI18n>
-                        </EuiI18n>
-                      </nav>
-                    </EuiPagination>
-                  </div>
-                </EuiFlexItem>
               </div>
             </EuiFlexGroup>
           </DashboardControls>
-          <EuiHorizontalRule
-            margin="xs"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"
-            />
-          </EuiHorizontalRule>
           <EuiBasicTable
             columns={
               Array [

--- a/public/pages/Home/Home.js
+++ b/public/pages/Home/Home.js
@@ -86,7 +86,7 @@ export default class Home extends Component {
             {this.tabs.map(this.renderTab)}
           </EuiTabs>
         )}
-        <div style={{ padding: '25px 25px' }}>
+        <div style={{ padding: '16px' }}>
           <Switch>
             <Route
               exact

--- a/public/pages/Home/Home.js
+++ b/public/pages/Home/Home.js
@@ -82,7 +82,7 @@ export default class Home extends Component {
     return (
       <div>
         {!defaultRoute && (
-          <EuiTabs size="s">
+          <EuiTabs size="s" style={{ padding: '16px 16px 0px' }}>
             {this.tabs.map(this.renderTab)}
           </EuiTabs>
         )}

--- a/public/pages/Home/__snapshots__/Home.test.js.snap
+++ b/public/pages/Home/__snapshots__/Home.test.js.snap
@@ -5,6 +5,7 @@ exports[`Home renders 1`] = `
   <div
     class="euiTabs euiTabs--small"
     role="tablist"
+    style="padding:16px 16px 0px"
   >
     <button
       aria-selected="true"
@@ -44,7 +45,7 @@ exports[`Home renders 1`] = `
     </button>
   </div>
   <div
-    style="padding:25px 25px"
+    style="padding:16px"
   />
 </div>
 `;

--- a/public/pages/Main/Main.js
+++ b/public/pages/Main/Main.js
@@ -146,7 +146,7 @@ class Main extends Component {
                   <MultiDataSourceContext.Provider
                     value={{ dataSourceId: this.state.selectedDataSourceId }}
                   >
-                    <div style={{ padding: '15px 0px' }}>
+                    <div>
                       <Flyout
                         flyout={flyout}
                         onClose={() => {

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -3,7 +3,7 @@
 exports[`MonitorOverview renders 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-  style="padding-left:0px;padding-right:0px"
+  style="padding:16px"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -521,7 +521,7 @@ export default class MonitorDetails extends Component {
     }
 
     return (
-      <div style={{ padding: '25px 50px' }}>
+      <div style={{ padding: '16px' }}>
         {this.renderNoTriggersCallOut()}
         <PageHeader
           appBadgeControls={[{ renderComponent: badgeControl }]}
@@ -545,7 +545,6 @@ export default class MonitorDetails extends Component {
             ))}
           </EuiFlexGroup>
         </PageHeader>
-        <EuiSpacer />
         <MonitorOverview
           monitor={monitor}
           monitorId={monitorId}

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -545,6 +545,7 @@ export default class MonitorDetails extends Component {
             ))}
           </EuiFlexGroup>
         </PageHeader>
+        {!useUpdatedUx && <EuiSpacer />}
         <MonitorOverview
           monitor={monitor}
           monitorId={monitorId}

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -76,7 +76,7 @@ export default class MonitorDetails extends Component {
         const monitorType = this.state.monitor.monitor_type;
         this.props.history.push({
           ...this.props.location,
-          search: `?action=${MONITOR_ACTIONS.UPDATE_MONITOR}&monitorType=${monitorType}${
+          search: `?action=${MONITOR_ACTIONS.EDIT_MONITOR}&monitorType=${monitorType}${
             dataSourceId !== undefined ? `&dataSourceId=${dataSourceId}` : ''
           }`,
         });
@@ -444,7 +444,7 @@ export default class MonitorDetails extends Component {
       setFlyout,
     } = this.props;
     const { action } = queryString.parse(location.search);
-    const updatingMonitor = action === MONITOR_ACTIONS.UPDATE_MONITOR;
+    const updatingMonitor = action === MONITOR_ACTIONS.EDIT_MONITOR;
     const detectorId = _.get(monitor, MONITOR_INPUT_DETECTOR_ID, undefined);
 
     if (loading) {

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -26,9 +26,9 @@ import {
   EuiTab,
   EuiTabs,
   EuiText,
-  EuiButtonIcon,
-  EuiButton, EuiToolTip, EuiIcon
-} from "@elastic/eui";
+  EuiToolTip,
+  EuiIcon,
+} from '@elastic/eui';
 import CreateMonitor from '../../CreateMonitor';
 import MonitorOverview from '../components/MonitorOverview';
 import MonitorHistory from './MonitorHistory';

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -27,7 +27,7 @@ import {
   EuiTabs,
   EuiText,
   EuiButtonIcon,
-  EuiButton, EuiToolTip
+  EuiButton, EuiToolTip, EuiIcon
 } from "@elastic/eui";
 import CreateMonitor from '../../CreateMonitor';
 import MonitorOverview from '../components/MonitorOverview';
@@ -494,11 +494,12 @@ export default class MonitorDetails extends Component {
       monitorActions.unshift(
         <EuiToolTip content="Delete">
           <EuiSmallButton
-            iconType={'trash'}
             onClick={this.onDeleteClick}
             color="danger"
             aria-label="Delete"
-          ></EuiSmallButton>
+          >
+            <EuiIcon type="trash" />
+          </EuiSmallButton>
         </EuiToolTip>
       );
       monitorActions.push(

--- a/public/pages/MonitorDetails/containers/MonitorDetails.js
+++ b/public/pages/MonitorDetails/containers/MonitorDetails.js
@@ -27,8 +27,8 @@ import {
   EuiTabs,
   EuiText,
   EuiButtonIcon,
-  EuiButton,
-} from '@elastic/eui';
+  EuiButton, EuiToolTip
+} from "@elastic/eui";
 import CreateMonitor from '../../CreateMonitor';
 import MonitorOverview from '../components/MonitorOverview';
 import MonitorHistory from './MonitorHistory';
@@ -492,12 +492,14 @@ export default class MonitorDetails extends Component {
 
     if (useUpdatedUx) {
       monitorActions.unshift(
-        <EuiSmallButton
-          iconType={'trash'}
-          onClick={this.onDeleteClick}
-          color="danger"
-          aria-label="Delete"
-        ></EuiSmallButton>
+        <EuiToolTip content="Delete">
+          <EuiSmallButton
+            iconType={'trash'}
+            onClick={this.onDeleteClick}
+            color="danger"
+            aria-label="Delete"
+          ></EuiSmallButton>
+        </EuiToolTip>
       );
       monitorActions.push(
         <EuiSmallButton onClick={editMonitor} fill>

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.js
@@ -37,6 +37,17 @@ export default class MonitorActions extends Component {
         Acknowledge
       </EuiContextMenuItem>,
       <EuiContextMenuItem
+        key="edit"
+        data-test-subj="editItem"
+        onClick={() => {
+          this.onCloseActions();
+          this.props.onClickEdit();
+        }}
+        disabled={isEditDisabled}
+      >
+        Edit
+      </EuiContextMenuItem>,
+      <EuiContextMenuItem
         key="enable"
         data-test-subj="enableItem"
         onClick={() => {
@@ -117,15 +128,6 @@ export default class MonitorActions extends Component {
           >
             <EuiContextMenuPanel items={this.getActions()} size="s" />
           </EuiPopover>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiSmallButton
-            disabled={isEditDisabled}
-            onClick={onClickEdit}
-            data-test-subj="editButton"
-          >
-            Edit
-          </EuiSmallButton>
         </EuiFlexItem>
         <PageHeader
           appRightControls={[

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.js
@@ -10,8 +10,8 @@ import {
   EuiContextMenuPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPopover, EuiButton
-} from "@elastic/eui";
+  EuiPopover,
+} from '@elastic/eui';
 
 import { APP_PATH } from '../../../../utils/constants';
 import { PageHeader } from '../../../../components/PageHeader/PageHeader';

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.js
@@ -10,8 +10,8 @@ import {
   EuiContextMenuPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiPopover,
-} from '@elastic/eui';
+  EuiPopover, EuiButton
+} from "@elastic/eui";
 
 import { APP_PATH } from '../../../../utils/constants';
 import { PageHeader } from '../../../../components/PageHeader/PageHeader';
@@ -84,7 +84,13 @@ export default class MonitorActions extends Component {
     const { isActionsOpen } = this.state;
     const { isEditDisabled, onClickEdit } = this.props;
     const createMonitorControl = (
-      <EuiSmallButton fill href={`#${APP_PATH.CREATE_MONITOR}`} data-test-subj="createButton">
+      <EuiSmallButton
+        fill href={`#${APP_PATH.CREATE_MONITOR}`}
+        data-test-subj="createButton"
+        iconType="plus"
+        iconSide="left"
+        iconGap="s"
+      >
         Create monitor
       </EuiSmallButton>
     );

--- a/public/pages/Monitors/components/MonitorActions/MonitorActions.test.js
+++ b/public/pages/Monitors/components/MonitorActions/MonitorActions.test.js
@@ -107,14 +107,16 @@ describe('MonitorActions', () => {
   });
 
   test('does not call onClickEdit when Edit is clicked and edit is disabled', () => {
-    wrapper.find('[data-test-subj="editButton"]').hostNodes().simulate('click');
+    wrapper.find('[data-test-subj="actionsButton"]').hostNodes().simulate('click');
+    wrapper.find('[data-test-subj="editItem"]').hostNodes().simulate('click');
     expect(props.onClickEdit).toHaveBeenCalledTimes(0);
   });
 
   test('calls onClickEdit when Edit is clicked and isEditDisabled=false', () => {
     const props = getProps();
     wrapper.setProps({ ...props, isEditDisabled: false });
-    wrapper.find('[data-test-subj="editButton"]').hostNodes().simulate('click');
+    wrapper.find('[data-test-subj="actionsButton"]').hostNodes().simulate('click');
+    wrapper.find('[data-test-subj="editItem"]').hostNodes().simulate('click');
     expect(props.onClickEdit).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
+++ b/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
@@ -38,26 +38,6 @@ exports[`MonitorActions renders 1`] = `
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
-    <button
-      class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
-      data-test-subj="editButton"
-      disabled=""
-      type="button"
-    >
-      <span
-        class="euiButtonContent euiButton__content"
-      >
-        <span
-          class="euiButton__text"
-        >
-          Edit
-        </span>
-      </span>
-    </button>
-  </div>
-  <div
-    class="euiFlexItem euiFlexItem--flexGrowZero"
-  >
     <a
       class="euiButton euiButton--primary euiButton--small euiButton--fill"
       data-test-subj="createButton"
@@ -65,8 +45,11 @@ exports[`MonitorActions renders 1`] = `
       rel="noreferrer"
     >
       <span
-        class="euiButtonContent euiButton__content"
+        class="euiButtonContent euiButtonContent--smallIconGap euiButton__content"
       >
+        <div>
+          EuiIconMock
+        </div>
         <span
           class="euiButton__text"
         >

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -34,7 +34,7 @@ const MonitorControls = ({
   onPageClick,
   monitorActions = null,
 }) => (
-  <EuiFlexGroup style={{ padding: '0px 16px 16px' }}>
+  <EuiFlexGroup style={{ padding: '0px 16px 16px' }} gutterSize="s">
     <EuiFlexItem>
       <EuiCompressedFieldSearch
         fullWidth={true}

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -34,7 +34,7 @@ const MonitorControls = ({
   onPageClick,
   monitorActions = null,
 }) => (
-  <EuiFlexGroup style={{ padding: '0px 5px' }} gutterSize="s">
+  <EuiFlexGroup style={{ padding: '0px 16px 16px' }}>
     <EuiFlexItem>
       <EuiCompressedFieldSearch
         fullWidth={true}

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -47,9 +47,6 @@ const MonitorControls = ({
       <EuiCompressedSelect options={states} value={state} onChange={onStateChange} />
     </EuiFlexItem>
     {monitorActions && <EuiFlexItem grow={false}>{monitorActions}</EuiFlexItem>}
-    <EuiFlexItem grow={false} style={{ justifyContent: 'center' }}>
-      <EuiPagination pageCount={pageCount} activePage={activePage} onPageClick={onPageClick} />
-    </EuiFlexItem>
   </EuiFlexGroup>
 );
 

--- a/public/pages/Monitors/components/MonitorControls/MonitorControls.js
+++ b/public/pages/Monitors/components/MonitorControls/MonitorControls.js
@@ -34,7 +34,7 @@ const MonitorControls = ({
   onPageClick,
   monitorActions = null,
 }) => (
-  <EuiFlexGroup style={{ padding: '0px 16px 16px' }} gutterSize="s">
+  <EuiFlexGroup style={{ padding: '0px 0px 16px' }} gutterSize="s">
     <EuiFlexItem>
       <EuiCompressedFieldSearch
         fullWidth={true}

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -285,7 +285,7 @@ export default class Monitors extends Component {
     const {
       selectedItems: [{ id }],
     } = this.state;
-    if (id) this.props.history.push(`/monitors/${id}?action=${MONITOR_ACTIONS.UPDATE_MONITOR}`);
+    if (id) this.props.history.push(`/monitors/${id}?action=${MONITOR_ACTIONS.EDIT_MONITOR}`);
   }
 
   onClickEnable(item) {

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -479,8 +479,6 @@ export default class Monitors extends Component {
             monitorActions={useUpdatedUx ? monitorActions : null}
           />
 
-          <EuiHorizontalRule margin="xs" />
-
           {showAcknowledgeModal && (
             <AcknowledgeModal
               alerts={alerts}

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import _ from 'lodash';
 import queryString from 'query-string';
-import { EuiBasicTable, EuiHorizontalRule } from '@elastic/eui';
+import { EuiBasicTable } from '@elastic/eui';
 import AcknowledgeModal from '../../components/AcknowledgeModal';
 import ContentPanel from '../../../../components/ContentPanel';
 import MonitorActions from '../../components/MonitorActions';
@@ -512,7 +512,7 @@ export default class Monitors extends Component {
             pagination={pagination}
             selection={selection}
             sorting={sorting}
-            style={{ padding: '0px 16px 0px' }}
+            style={{ padding: useUpdatedUx ? '0px 16px' : '0px' }}
           />
         </ContentPanel>
         {monitorItemsToDelete && (

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -512,7 +512,6 @@ export default class Monitors extends Component {
             pagination={pagination}
             selection={selection}
             sorting={sorting}
-            style={{ padding: '0px 16px'}}
           />
         </ContentPanel>
         {monitorItemsToDelete && (

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -512,6 +512,7 @@ export default class Monitors extends Component {
             pagination={pagination}
             selection={selection}
             sorting={sorting}
+            style={{ padding: '0px 16px 0px' }}
           />
         </ContentPanel>
         {monitorItemsToDelete && (

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -467,6 +467,7 @@ export default class Monitors extends Component {
           bodyStyles={{ padding: 'initial' }}
           title={useUpdatedUx ? undefined : 'Monitors'}
           panelOptions={{ hideTitleBorder: useUpdatedUx }}
+          panelStyles={{ padding: useUpdatedUx && totalMonitors < 1 ? '16px 16px 0px' : '16px' }}
         >
           <MonitorControls
             activePage={page}

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -512,7 +512,7 @@ export default class Monitors extends Component {
             pagination={pagination}
             selection={selection}
             sorting={sorting}
-            style={{ padding: useUpdatedUx ? '0px 16px' : '0px' }}
+            style={{ padding: '0px 16px'}}
           />
         </ContentPanel>
         {monitorItemsToDelete && (

--- a/public/pages/Monitors/containers/Monitors/Monitors.test.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.test.js
@@ -218,7 +218,7 @@ describe('Monitors', () => {
 
     expect(onClickEdit).toHaveBeenCalled();
     expect(historyMock.push).toHaveBeenCalled();
-    expect(historyMock.push).toHaveBeenCalledWith(`/monitors/random_id?action=update-monitor`);
+    expect(historyMock.push).toHaveBeenCalledWith(`/monitors/random_id?action=edit-monitor`);
   });
 
   test('onClickEnable calls updateMonitors with monitor and enable:true update', () => {

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -24,6 +24,11 @@ exports[`Monitors renders 1`] = `
         "hideTitleBorder": undefined,
       }
     }
+    panelStyles={
+      Object {
+        "padding": "16px",
+      }
+    }
     title="Monitors"
   >
     <MonitorControls
@@ -35,9 +40,6 @@ exports[`Monitors renders 1`] = `
       pageCount={1}
       search=""
       state="all"
-    />
-    <EuiHorizontalRule
-      margin="xs"
     />
     <EuiBasicTable
       columns={

--- a/public/utils/constants.js
+++ b/public/utils/constants.js
@@ -40,7 +40,7 @@ export const DESTINATION_ACTIONS = {
 };
 
 export const MONITOR_ACTIONS = {
-  UPDATE_MONITOR: 'update-monitor',
+  EDIT_MONITOR: 'edit-monitor',
 };
 
 export const TRIGGER_ACTIONS = {

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -160,7 +160,9 @@ export function initManageChannelsUrl(httpClient) {
     const relativePath = `/app/${
       getUseUpdatedUx() ? 'channels' : 'notifications-dashboards'
     }#/channels`;
-    MANAGE_CHANNELS_URL = httpClient.basePath.prepend(relativePath);
+    MANAGE_CHANNELS_URL = httpClient.basePath.prepend(relativePath, {
+      withoutClientBasePath: true,
+    });
   }
 }
 


### PR DESCRIPTION
### Description
Addresses the fit and finish UX changes. Changes in this PR include:
- Fixes the redirect from Notifications button so that breadcrumbs reflects the correct path
- Adds tooltip to delete icon button
- Moves the `edit` action under `actions` dropdown in the monitors page
- Changes so that view alerts in the datasource alerts card opens in the same tab
- makes the spacing between the header and panel consistent (16px) across all pages
- makes the spacing around the content consistent (16px) across all pages
- Moves pagination to the bottom of the table
- Changes `Updated monitor` to `Edit monitor` in the title
- Changes `Update monitor` to `Save`
- Removes the bottom border in the empty state for the alerts and monitors pages
- Adds a plus icon to the create monitor button

Alerts Page
![Screenshot 2024-09-16 at 12 00 16 PM](https://github.com/user-attachments/assets/505075ce-a43a-489e-aba3-005c8c11c309)

Monitors Page
![Screenshot 2024-09-16 at 12 01 03 PM](https://github.com/user-attachments/assets/2309ca21-70bc-4024-8f4d-3b813d17a69e)

Empty Monitors Page
![Screenshot 2024-09-16 at 12 03 49 PM](https://github.com/user-attachments/assets/72534b5a-2eaf-446d-835c-d742d2581a69)

View Monitor Page
![Screenshot 2024-09-16 at 12 01 27 PM](https://github.com/user-attachments/assets/0014faa7-f49b-44cc-b4aa-d98e2bc4b57c)

Edit Monitor Page
![Screenshot 2024-09-16 at 12 01 41 PM](https://github.com/user-attachments/assets/97d33f72-a536-460a-b9d5-d3f94945f68e)

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
