### PR TITLE
Fit and Finish UX changes Pt 2

### DIFF
--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -88,8 +88,8 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
           <EuiFlexItem grow={false}>
             <EuiText size="s" color="subdued">Monitor:</EuiText>
           </EuiFlexItem>
-          <EuiFlexItem grow={false} >
-            <EuiText size="m">{monitorName}</EuiText>
+          <EuiFlexItem grow={false} style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            <EuiText size="m" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{monitorName}</EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiHorizontalRule margin="xs" />

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -10,7 +10,8 @@ import { getApplication, getClient, getNotifications, getSavedObjectsClient } fr
 import { dataSourceFilterFn, getSeverityColor, getSeverityBadgeText, getTruncatedText } from "../../utils/helpers";
 import { renderTime } from "../../pages/Dashboard/utils/tableUtils";
 import { ALERTS_NAV_ID, MONITORS_NAV_ID } from "../../../utils/constants";
-import { APP_PATH, DEFAULT_EMPTY_DATA, MONITOR_TYPE } from "../../utils/constants";
+import { APP_PATH, DEFAULT_EMPTY_DATA } from "../../utils/constants";
+import { dataSourceEnabled, getURL } from "../../pages/utils/helpers.js";
 
 export interface DataSourceAlertsCardProps {
   getDataSourceMenu?: DataSourceManagementPluginSetup['ui']['getDataSourceMenu'];
@@ -31,7 +32,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
       query: {
         size: 25,
         sortField: 'start_time',
-        ...(dataSource?.id && { dataSourceId: dataSource.id }),
+        ...(dataSourceEnabled() && { dataSourceId: dataSource?.id || ''}),
         sortDirection: 'desc'
       }
     }).then(res => {
@@ -55,7 +56,8 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
     const triggerName = alert.trigger_name ?? DEFAULT_EMPTY_DATA;
     const monitorUrl = `alerting#/monitors/${
       alert.alert_source === 'workflow' ? alert.workflow_id : alert.monitor_id
-    }?&type=${alert.alert_source}&dataSourceId=${dataSource?.id}`;
+    }?&type=${alert.alert_source}`;
+    const url = getURL(monitorUrl, dataSource?.id);
 
     return (
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
@@ -63,7 +65,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
           <div>
             <EuiBadge color={severityColor?.background} style={{ padding: '1px 4px', color: severityColor?.text }}>{getSeverityBadgeText(alert.severity)}</EuiBadge>
             &nbsp;&nbsp;
-            <EuiLink href={monitorUrl}>
+            <EuiLink href={url}>
               <span style={{ color: '#006BB4' }} className="eui-textTruncate">
                 {getTruncatedText(triggerName)}
               </span>

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -80,7 +80,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
             <EuiText size="s" color="subdued">Monitor:</EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false} >
-            <EuiText size="m">{getTruncatedText(monitorName)}</EuiText>
+            <EuiText size="m">{monitorName}</EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiHorizontalRule margin="xs" />

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -54,7 +54,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   const createAlertDetailsHeader = useCallback((alert) => {
     const severityColor = getSeverityColor(alert.severity);
     const triggerName = alert.trigger_name ?? DEFAULT_EMPTY_DATA;
-    const monitorUrl = `alerting#/monitors/${
+    const monitorUrl = `${MONITORS_NAV_ID}#/monitors/${
       alert.alert_source === 'workflow' ? alert.workflow_id : alert.monitor_id
     }?&type=${alert.alert_source}`;
     const url = getURL(monitorUrl, dataSource?.id);
@@ -105,7 +105,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   });
 
   return (
-    <EuiPanel hasBorder={false} hasShadow={false} grow={false} style={{ overflow: 'hidden' }}>
+    <EuiPanel hasBorder={false} hasShadow={false} style={{ overflow: 'hidden' }}>
       <EuiFlexGroup style={{ height: '100%' }} direction="column" justifyContent="spaceBetween" alignItems="flexStart" gutterSize="xs">
         <EuiFlexItem grow={false} style={{ width: '100%', height: '90%' }}>
           <EuiFlexGroup direction="column" style={{ height: '100%' }}>

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -10,7 +10,7 @@ import { getApplication, getClient, getNotifications, getSavedObjectsClient } fr
 import { dataSourceFilterFn, getSeverityColor, getSeverityBadgeText, getTruncatedText } from "../../utils/helpers";
 import { renderTime } from "../../pages/Dashboard/utils/tableUtils";
 import { ALERTS_NAV_ID, MONITORS_NAV_ID } from "../../../utils/constants";
-import { APP_PATH, DEFAULT_EMPTY_DATA } from "../../utils/constants";
+import { APP_PATH, DEFAULT_EMPTY_DATA, MONITOR_TYPE } from "../../utils/constants";
 
 export interface DataSourceAlertsCardProps {
   getDataSourceMenu?: DataSourceManagementPluginSetup['ui']['getDataSourceMenu'];
@@ -53,6 +53,9 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   const createAlertDetailsHeader = useCallback((alert) => {
     const severityColor = getSeverityColor(alert.severity);
     const triggerName = alert.trigger_name ?? DEFAULT_EMPTY_DATA;
+    const monitorUrl = `alerting#/monitors/${alert.monitor_id}${
+      alert.monitorType === MONITOR_TYPE.COMPOSITE_LEVEL ? '?type=workflow' : '?'
+    }&dataSourceId=${dataSource?.id}`;
 
     return (
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
@@ -60,7 +63,11 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
           <div>
             <EuiBadge color={severityColor?.background} style={{ padding: '1px 4px', color: severityColor?.text }}>{getSeverityBadgeText(alert.severity)}</EuiBadge>
             &nbsp;&nbsp;
-            <span style={{ color: "#006BB4" }} className="eui-textTruncate">{getTruncatedText(triggerName)}</span>
+            <EuiLink href={monitorUrl}>
+              <span style={{ color: '#006BB4' }} className="eui-textTruncate">
+                {getTruncatedText(triggerName)}
+              </span>
+            </EuiLink>
           </div>
         </EuiFlexItem>
         <EuiFlexItem grow={false} >

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -53,9 +53,9 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   const createAlertDetailsHeader = useCallback((alert) => {
     const severityColor = getSeverityColor(alert.severity);
     const triggerName = alert.trigger_name ?? DEFAULT_EMPTY_DATA;
-    const monitorUrl = `alerting#/monitors/${alert.monitor_id}${
-      alert.monitorType === MONITOR_TYPE.COMPOSITE_LEVEL ? '?type=workflow' : '?'
-    }&dataSourceId=${dataSource?.id}`;
+    const monitorUrl = `alerting#/monitors/${
+      alert.alert_source === 'workflow' ? alert.workflow_id : alert.monitor_id
+    }?&type=${alert.alert_source}&dataSourceId=${dataSource?.id}`;
 
     return (
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -105,7 +105,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   });
 
   return (
-    <EuiPanel hasBorder={false} hasShadow={false}>
+    <EuiPanel hasBorder={false} hasShadow={false} grow={false} style={{ overflow: 'hidden' }}>
       <EuiFlexGroup style={{ height: '100%' }} direction="column" justifyContent="spaceBetween" alignItems="flexStart" gutterSize="xs">
         <EuiFlexItem grow={false} style={{ width: '100%', height: '90%' }}>
           <EuiFlexGroup direction="column" style={{ height: '100%' }}>

--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -31,7 +31,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
       query: {
         size: 25,
         sortField: 'start_time',
-        dataSourceId: dataSource?.id || '',
+        ...(dataSource?.id && { dataSourceId: dataSource.id }),
         sortDirection: 'desc'
       }
     }).then(res => {


### PR DESCRIPTION
### Description
Second part of the fit and finish UX changes. This PR makes changes to the datasource alerts card which include:
- Removes truncating the monitor name
- Modifies the query that is used to grab alerts so that dataSourceId is only included as a field if data source is enabled. Without this change alerts were not fetched correctly when data source was disabled
- Alert links to the monitor page
 
Data source enabled
![Screenshot 2024-09-18 at 6 03 45 PM](https://github.com/user-attachments/assets/547e84c4-2e8b-47c6-93aa-316c73116865)

Data source disabled
![Screenshot 2024-09-18 at 6 03 01 PM](https://github.com/user-attachments/assets/d7b42da7-d466-4c24-b265-5fcff498e909)

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
