### PR TITLE
[Bug Fix] Fix assistant plugin override issue and return dataSourceId in context

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["opensearch_alerting"],
-  "optionalPlugins": ["dataSource", "dataSourceManagement"],
+  "optionalPlugins": ["dataSource", "dataSourceManagement", "assistantDashboards"],
   "requiredPlugins": [
     "uiActions",
     "dashboard",
@@ -17,7 +17,6 @@
     "opensearchDashboardsUtils",
     "contentManagement"
   ],
-  "optionalPlugins": ["assistantDashboards"],
   "server": true,
   "ui": true,
   "supportedOSDataSourceVersions": ">=2.13.0",

--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -235,6 +235,7 @@ export const alertColumns = (
             dsl: dsl,
             index: index,
           },
+          dataSourceId: dataSourceQuery?.query?.dataSourceId,
         };
       };
 


### PR DESCRIPTION
### Description
In previous context aware analysis PR, the optional assistantPlugin overrides optional dataSourceManagement PR, which caused the dataSource disabled. 
Also, there is possibly requirement to filter by dataSourceId. Hence, return additional dataSourceId in context.
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
