### PR TITLE
[Fit & Finish] Add width for recent alerts card

### DIFF
--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -206,6 +206,7 @@ export function registerAlertsCard() {
       id: 'analytics_all_recent_alerts_card',
       kind: 'custom',
       order: 10,
+      width: 16,
       render: () => (
         <DataSourceAlertsCard
           getDataSourceMenu={getDataSourceManagementPlugin()?.ui.getDataSourceMenu}


### PR DESCRIPTION
### Description
Add width for recent alerts card, the default value is 12 which is 1/4 of whole row.

After remove what's new there only have 3 cards left, so the width comes to 16

![image](https://github.com/user-attachments/assets/0b1992df-43c4-4329-ba60-90a055804b44)

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
