### PR TITLE
BugFix: [Alert Summary]change the format configuration correspondingly

### DIFF
--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -188,8 +188,8 @@ export const alertColumns = (
             query = query.replaceAll('{{period_end}}', alert.start_time);
             const alertStartTime = moment.utc(alert.start_time).format('YYYY-MM-DDTHH:mm:ss');
             dsl = dsl.replaceAll('{{period_end}}', alertStartTime);
-            // as we changed the format, remove it
-            dsl = dsl.replaceAll('"format":"epoch_millis",', '');
+            // as we changed the format of time value, need to change the format configuration as well.
+            dsl = dsl.replaceAll('"format":"epoch_millis",', '"format":"strict_date_optional_time",');
             monitorDefinitionStr = monitorDefinitionStr.replaceAll(
               '{{period_end}}',
               alertStartTime


### PR DESCRIPTION
### Description
The current implementation removes the format configuration directly in the DSL query, it will cause query execution error in the corner cases that the timestamp field in index doesn't support the format of `strict_date_optional_time`. It can be fixed with specifying the format to be `strict_date_optional_time` in DSL.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
