### PR TITLE
Fix ui_metadata is not fetched when MDS client is used

### DIFF
--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { INDEX } from '../../utils/constants';
 import { isIndexNotFoundError } from './utils/helpers';
 import { MDSEnabledClientService } from './MDSEnabledClientService';
+import { DEFAULT_HEADERS } from "./utils/constants";
 
 export default class MonitorService extends MDSEnabledClientService {
   createMonitor = async (context, req, res) => {
@@ -103,7 +104,7 @@ export default class MonitorService extends MDSEnabledClientService {
   getMonitor = async (context, req, res) => {
     try {
       const { id } = req.params;
-      const params = { monitorId: id };
+      const params = { monitorId: id, headers: DEFAULT_HEADERS };
       const client = this.getClientBasedOnDataSource(context, req);
       const getResponse = await client('alerting.getMonitor', params);
       let monitor = _.get(getResponse, 'monitor', null);


### PR DESCRIPTION
### Description
Fix ui_metadata is not fetched when MDS client is used
 
### Issues Resolved
[#1123 ]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
