### PR TITLE
fix: data source picker is remounted multiple times in alerts card

### DIFF
--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -3,7 +3,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { EuiBadge, EuiDescriptionList, EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiLink, EuiLoadingContent, EuiPanel, EuiText, EuiTitle } from "@elastic/eui";
 import { DataSourceManagementPluginSetup, DataSourceOption } from "../../../../../src/plugins/data_source_management/public";
 import { getApplication, getClient, getNotifications, getSavedObjectsClient } from "../../services";
@@ -18,7 +18,13 @@ export interface DataSourceAlertsCardProps {
 }
 
 export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ getDataSourceMenu }) => {
-  const DataSourceSelector = getDataSourceMenu?.();
+  const DataSourceSelector = useMemo(() => {
+    if (getDataSourceMenu) {
+      return getDataSourceMenu();
+    }
+
+    return null;
+  }, [getDataSourceMenu]);
   const [loading, setLoading] = useState(false);
   const [dataSource, setDataSource] = useState<DataSourceOption>({
     label: 'Local cluster',


### PR DESCRIPTION
### Description
[Describe what this change achieves]
The DataSourceSelector is generated in every render and React recognizes the component as a new component thus unmount the old element and mount an new element with the new `DataSourceSelector`.

This PR is to fix this behavior by adding a useMemo to ensure only single instance of DataSourceSelector will be generated.

![image](https://github.com/user-attachments/assets/8dcef418-dfd7-45ba-b68d-ce7d1eb30728)

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
