### PR TITLE
[BugFix] Pass isVisualEditorMonitor flag to downstream for verification

### DIFF
--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -283,6 +283,7 @@ export const alertColumns = (
             dsl: dsl,
             index: index,
             topNLogPatternData: topNLogPatternData,
+            isVisualEditorMonitor: isVisualEditorMonitor,
           },
           dataSourceId: dataSourceQuery?.query?.dataSourceId,
         };


### PR DESCRIPTION
### Description
Pass isVisualEditorMonitor flag to downstream for verification. Downstream context consumer like assistant plugin needs to identify whether the monitor is created via visual editor and parse related dsl.
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
