### PR TITLE
[BugFix] AlertSummary still displays when agents required are not configured

### DIFF
--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -45,6 +45,7 @@ import {
   getDataSourceId,
   appendCommentsAction,
   getIsCommentsEnabled,
+  getIsAgentConfigured
 } from '../../utils/helpers';
 import { getUseUpdatedUx } from '../../../services';
 
@@ -78,6 +79,7 @@ export default class Dashboard extends Component {
       totalTriggers: 0,
       chainedAlert: undefined,
       commentsEnabled: false,
+      isAgentConfigured: false,
     };
   }
 
@@ -102,17 +104,34 @@ export default class Dashboard extends Component {
     getIsCommentsEnabled(this.props.httpClient).then((commentsEnabled) => {
       this.setState({ commentsEnabled });
     });
+    this.getUpdatedAgentConfig();
   }
 
   componentDidUpdate(prevProps, prevState) {
     const prevQuery = getQueryObjectFromState(prevState);
     const currQuery = getQueryObjectFromState(this.state);
     if (!_.isEqual(prevQuery, currQuery)) {
+      this.getUpdatedAgentConfig();
       this.getUpdatedAlerts();
     }
     if (isDataSourceChanged(prevProps, this.props)) {
       this.dataSourceQuery = getDataSourceQueryObj();
+      this.getUpdatedAgentConfig();
       this.getUpdatedAlerts();
+    }
+  }
+
+  getUpdatedAgentConfig() {
+    const dataSourceId = getDataSourceId();
+    console.log("ds", dataSourceId);
+    if (dataSourceId){
+      getIsAgentConfigured(dataSourceId).then((isAgentConfigured) => {
+        this.setState({ isAgentConfigured });
+        console.log("UpAC", this.state.isAgentConfigured);
+      });
+    }
+    else{
+      this.setState({ isAgentConfigured: false });
     }
   }
 
@@ -361,6 +380,7 @@ export default class Dashboard extends Component {
       totalAlerts,
       totalTriggers,
       commentsEnabled,
+      isAgentConfigured,
     } = this.state;
     const {
       monitorIds,
@@ -444,6 +464,7 @@ export default class Dashboard extends Component {
         location,
         monitors,
         notifications,
+        isAgentConfigured,
         setFlyout,
         this.openFlyout,
         this.closeFlyout,

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -123,11 +123,9 @@ export default class Dashboard extends Component {
 
   getUpdatedAgentConfig() {
     const dataSourceId = getDataSourceId();
-    console.log("ds", dataSourceId);
     if (dataSourceId){
       getIsAgentConfigured(dataSourceId).then((isAgentConfigured) => {
         this.setState({ isAgentConfigured });
-        console.log("UpAC", this.state.isAgentConfigured);
       });
     }
     else{

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -123,14 +123,9 @@ export default class Dashboard extends Component {
 
   getUpdatedAgentConfig() {
     const dataSourceId = getDataSourceId();
-    if (dataSourceId){
-      getIsAgentConfigured(dataSourceId).then((isAgentConfigured) => {
-        this.setState({ isAgentConfigured });
-      });
-    }
-    else{
-      this.setState({ isAgentConfigured: false });
-    }
+    getIsAgentConfigured(dataSourceId).then((isAgentConfigured) => {
+      this.setState({ isAgentConfigured });
+    });
   }
 
   getUpdatedAlerts() {

--- a/public/pages/Dashboard/containers/Dashboard.test.js
+++ b/public/pages/Dashboard/containers/Dashboard.test.js
@@ -9,7 +9,7 @@ import { mount } from 'enzyme';
 import Dashboard from './Dashboard';
 import { historyMock, httpClientMock } from '../../../../test/mocks';
 import { setupCoreStart } from '../../../../test/utils/helpers';
-import { setAssistantDashboards } from '../../../services';
+import { setAssistantDashboards, setAssistantClient } from '../../../services';
 
 const location = {
   hash: '',
@@ -64,7 +64,7 @@ beforeAll(() => {
 
 describe('Dashboard', () => {
   setAssistantDashboards({ getFeatureStatus: () => ({ chat: false, alertInsight: false }) });
-
+  setAssistantClient({agentConfigExists: (agentConfigName, options) => {return Promise.resolve({ exists: false });}})
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/public/pages/Dashboard/utils/tableUtils.js
+++ b/public/pages/Dashboard/utils/tableUtils.js
@@ -136,6 +136,7 @@ export const alertColumns = (
   location,
   monitors,
   notifications,
+  isAgentConfigured,
   setFlyout,
   openFlyout,
   closeFlyout,
@@ -167,7 +168,7 @@ export const alertColumns = (
           }}
           data-test-subj={`euiLink_${alert.trigger_name}`}
         >
-          {`${total} alerts`}
+          {total > 1 ? `${total} alerts`:`${total} alert`}
         </EuiLink>
       );
       const contextProvider = async () => {
@@ -291,7 +292,7 @@ export const alertColumns = (
 
       const assistantEnabled = getApplication().capabilities?.assistant?.enabled === true;
       const assistantFeatureStatus = getAssistantDashboards().getFeatureStatus();
-      if (assistantFeatureStatus.alertInsight && assistantEnabled) {
+      if (assistantFeatureStatus.alertInsight && assistantEnabled && isAgentConfigured) {
         getAssistantDashboards().registerIncontextInsight([
           {
             key: alertId,

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -17,3 +17,5 @@ const LocalCluster: DataSourceOption = {
 
 // We should use empty object for default value as local cluster may be disabled
 export const dataSourceObservable = new BehaviorSubject<DataSourceOption>({});
+export const SUMMARY_AGENT_CONFIG_ID = 'os_summary';
+export const LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID = 'os_summary_with_log_pattern';

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -4,10 +4,15 @@
  */
 
 import React from 'react';
-import { getDataSourceEnabled, getDataSource } from '../../services/services';
+import { getDataSourceEnabled, getDataSource, getAssistantClient } from '../../services/services';
 import _ from 'lodash';
 import { ShowAlertComments } from '../../components/Comments/ShowAlertComments';
-import { COMMENTS_ENABLED_SETTING } from './constants';
+import { 
+  COMMENTS_ENABLED_SETTING,
+  SUMMARY_AGENT_CONFIG_ID,
+  LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID
+ } from './constants';
+import {} from '../../'
 
 export function dataSourceEnabled() {
   return getDataSourceEnabled()?.enabled;
@@ -67,6 +72,18 @@ export const appendCommentsAction = (columns, httpClient) => {
 
   return columns;
 };
+
+export async function getIsAgentConfigured(dataSourceId){
+  const assistantClient = getAssistantClient();
+  const res = await assistantClient.agentConfigExists(
+    [
+      SUMMARY_AGENT_CONFIG_ID,
+      LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID,
+    ],
+    { dataSourceId: dataSourceId }
+  );
+  return res.exists;
+}
 
 export async function getIsCommentsEnabled(httpClient) {
   let commentsEnabled = await getClusterSetting(httpClient, COMMENTS_ENABLED_SETTING, false);

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -73,8 +73,8 @@ export const appendCommentsAction = (columns, httpClient) => {
 };
 
 export async function getIsAgentConfigured(dataSourceId){
+  const assistantClient = getAssistantClient();
   try{
-    const assistantClient = getAssistantClient();
     const res = await assistantClient.agentConfigExists(
       [
         SUMMARY_AGENT_CONFIG_ID,

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -12,7 +12,6 @@ import {
   SUMMARY_AGENT_CONFIG_ID,
   LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID
  } from './constants';
-import {} from '../../'
 
 export function dataSourceEnabled() {
   return getDataSourceEnabled()?.enabled;

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -85,6 +85,7 @@ export async function getIsAgentConfigured(dataSourceId){
     return res.exists;
   }
   catch(e){
+    console.error('Error while checking if agent is configured:', e);
     return false;
   }
 }

--- a/public/pages/utils/helpers.js
+++ b/public/pages/utils/helpers.js
@@ -73,15 +73,20 @@ export const appendCommentsAction = (columns, httpClient) => {
 };
 
 export async function getIsAgentConfigured(dataSourceId){
-  const assistantClient = getAssistantClient();
-  const res = await assistantClient.agentConfigExists(
-    [
-      SUMMARY_AGENT_CONFIG_ID,
-      LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID,
-    ],
-    { dataSourceId: dataSourceId }
-  );
-  return res.exists;
+  try{
+    const assistantClient = getAssistantClient();
+    const res = await assistantClient.agentConfigExists(
+      [
+        SUMMARY_AGENT_CONFIG_ID,
+        LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID,
+      ],
+      { dataSourceId: dataSourceId }
+    );
+    return res.exists;
+  }
+  catch(e){
+    return false;
+  }
 }
 
 export async function getIsCommentsEnabled(httpClient) {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -241,8 +241,7 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     setApplication(core.application);
     setContentManagementStart(contentManagement);
     registerAlertsCard();
-    if (assistantDashboards)
-      setAssistantClient(assistantDashboards.assistantClient);
+    setAssistantClient(assistantDashboards?.assistantClient || {agentConfigExists: (agentConfigName: string | string[], options?: string) => {return Promise.resolve({ exists: false });}})
     return {};
   }
 }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -21,10 +21,10 @@ import { alertingTriggerAd } from './utils/contextMenu/triggers';
 import { ExpressionsSetup } from '../../../src/plugins/expressions/public';
 import { UiActionsSetup } from '../../../src/plugins/ui_actions/public';
 import { overlayAlertsFunction } from './expressions/overlay_alerts';
-import { setClient, setEmbeddable, setNotifications, setOverlays, setSavedAugmentVisLoader, setUISettings, setQueryService, setSavedObjectsClient, setDataSourceEnabled, setDataSourceManagementPlugin, setNavigationUI, setApplication, setContentManagementStart, setAssistantDashboards } from './services';
+import { setClient, setEmbeddable, setNotifications, setOverlays, setSavedAugmentVisLoader, setUISettings, setQueryService, setSavedObjectsClient, setDataSourceEnabled, setDataSourceManagementPlugin, setNavigationUI, setApplication, setContentManagementStart, setAssistantDashboards, setAssistantClient } from './services';
 import { VisAugmenterStart } from '../../../src/plugins/vis_augmenter/public';
 import { DataPublicPluginStart } from '../../../src/plugins/data/public';
-import { AssistantSetup } from './types';
+import { AssistantSetup, AssistantPublicPluginStart  } from './types';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { DataSourcePluginSetup } from '../../../src/plugins/data_source/public';
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
@@ -57,6 +57,7 @@ export interface AlertingStartDeps {
   data: DataPublicPluginStart;
   navigation: NavigationPublicPluginStart;
   contentManagement: ContentManagementPluginStart;
+  assistantDashboards: AssistantPublicPluginStart;
 }
 
 export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetupDeps, AlertingStartDeps> {
@@ -200,7 +201,6 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     }
 
     setAssistantDashboards(assistantDashboards || { getFeatureStatus: () => ({ chat: false, alertInsight: false }) });
-
     setUISettings(core.uiSettings);
 
     // Set the HTTP client so it can be pulled into expression fns to make
@@ -230,7 +230,7 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     uiActions.addTriggerAction(alertingTriggerAd.id, adAction);
   }
 
-  public start(core: CoreStart, { visAugmenter, embeddable, data, navigation, contentManagement }: AlertingStartDeps): AlertingStart {
+  public start(core: CoreStart, { visAugmenter, embeddable, data, navigation, contentManagement, assistantDashboards }: AlertingStartDeps): AlertingStart {
     setEmbeddable(embeddable);
     setOverlays(core.overlays);
     setQueryService(data.query);
@@ -241,6 +241,8 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     setApplication(core.application);
     setContentManagementStart(contentManagement);
     registerAlertsCard();
+    if (assistantDashboards)
+      setAssistantClient(assistantDashboards.assistantClient);
     return {};
   }
 }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -57,7 +57,7 @@ export interface AlertingStartDeps {
   data: DataPublicPluginStart;
   navigation: NavigationPublicPluginStart;
   contentManagement: ContentManagementPluginStart;
-  assistantDashboards: AssistantPublicPluginStart;
+  assistantDashboards?: AssistantPublicPluginStart;
 }
 
 export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetupDeps, AlertingStartDeps> {

--- a/public/services/services.ts
+++ b/public/services/services.ts
@@ -14,7 +14,7 @@ import { EmbeddableStart } from '../../../../src/plugins/embeddable/public';
 import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 import { ContentManagementPluginStart } from '../../../../src/plugins/content_management/public';
 import { createNullableGetterSetter } from './utils/helper';
-import { AssistantSetup } from '../types';
+import { AssistantSetup, AssistantPublicPluginStart } from '../types';
 
 const ServicesContext = createContext<BrowserServices | null>(null);
 
@@ -34,6 +34,9 @@ export const [getUISettings, setUISettings] = createGetterSetter<IUiSettingsClie
 export const [getAssistantDashboards, setAssistantDashboards] = createGetterSetter<
   AssistantSetup | {}
 >('assistantDashboards');
+
+export const [getAssistantClient, setAssistantClient] =
+  createGetterSetter<AssistantPublicPluginStart['assistantClient']>('AssistantClient');
 
 export const [getEmbeddable, setEmbeddable] = createGetterSetter<EmbeddableStart>('embeddable');
 

--- a/public/services/services.ts
+++ b/public/services/services.ts
@@ -36,7 +36,7 @@ export const [getAssistantDashboards, setAssistantDashboards] = createGetterSett
 >('assistantDashboards');
 
 export const [getAssistantClient, setAssistantClient] =
-  createGetterSetter<AssistantPublicPluginStart['assistantClient']>('AssistantClient');
+  createGetterSetter<AssistantPublicPluginStart['assistantClient'] | {}>('AssistantClient');
 
 export const [getEmbeddable, setEmbeddable] = createGetterSetter<EmbeddableStart>('embeddable');
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -10,3 +10,4 @@
  */
 // @ts-ignore
 export type { AssistantSetup } from '../../dashboards-assistant/public';
+export type { AssistantPublicPluginStart } from '../../dashboards-assistant/public/';


### PR DESCRIPTION
### Description
bug fix for alertSummary still displays when agents required are not configured in the selected datasource.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Screenshots
data source with required agents configured
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/77470327-4107-484c-9437-01c929d3f121">

data source without agents
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/64361427-4841-4d97-bd07-932b3bab2ed1">

