### PR TITLE
Make data source default cluster for alerts card

### DIFF
--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -26,10 +26,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
     return null;
   }, [getDataSourceMenu]);
   const [loading, setLoading] = useState(false);
-  const [dataSource, setDataSource] = useState<DataSourceOption>({
-    label: 'Local cluster',
-    id: '',
-  });
+  const [dataSource, setDataSource] = useState<DataSourceOption>();
   const [alerts, setAlerts] = useState<any[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
### Description
- Make data source default cluster for alerts card
![Screenshot 2024-10-28 at 10 44 57 AM](https://github.com/user-attachments/assets/60b4d455-c6d4-416e-8f18-42da0612fc0b)

https://github.com/user-attachments/assets/107be16d-c751-4e74-9b3d-c0ad0b4aeb51

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
