### PR TITLE
Fix data source picker for alerts card

### DIFF
--- a/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
+++ b/public/components/DataSourceAlertsCard/DataSourceAlertsCard.tsx
@@ -49,7 +49,7 @@ export const DataSourceAlertsCard: React.FC<DataSourceAlertsCardProps> =  ({ get
   }, [dataSource]);
 
   const onDataSourceSelected = useCallback((options: any[]) => {
-    if (dataSource?.id !== undefined && dataSource?.id !== options[0]?.id) {
+    if (dataSource?.id === undefined || dataSource?.id !== options[0]?.id) {
       setDataSource(options[0]);
     }
   }, [dataSource]);


### PR DESCRIPTION
### Description
- Fixes the data source picker for the alerts card so it loads alerts from different selected clusters
- Loads the default cluster by default
 
https://github.com/user-attachments/assets/ef0bab87-77b3-4a55-8547-e9fafa1ed288

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
