### PR TITLE
don't support datasources with no version in featureAnywhere

### DIFF
--- a/public/actions/alerting_dashboard_action.tsx
+++ b/public/actions/alerting_dashboard_action.tsx
@@ -58,7 +58,7 @@ export const createAlertingAction = ({
         embeddable.getInput()?.viewMode === 'view' &&
         isDashboard(embeddable.parent) &&
         embeddable.vis &&
-        isEligibleForVisLayers(embeddable.vis, getUISettings())
+        await isEligibleForVisLayers(embeddable.vis, getUISettings())
       );
     },
     execute: async (context: ActionContext) => {


### PR DESCRIPTION
### Description
* Changes to not to support dataSource with no Version in FeatureAnywhere-Alertin
* Corresponding OSD change https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8915/files
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
