### PR TITLE
fix: error toast message while configuring trigger while creating a monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.22.9",
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
-    "cypress": "9.5.4",
+    "cypress": "12.17.4",
     "husky": "^8.0.0",
     "lint-staged": "^10.2.0",
     "@types/react": "^16.14.23"
@@ -67,5 +67,6 @@
   },
   "engines": {
     "yarn": "^1.21.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -175,9 +175,13 @@ export default class DestinationsService extends MDSEnabledClientService {
         },
       });
     } catch (err) {
+      // Indices will be created when the monitor is created.
       if (isIndexNotFoundError(err)) {
         return res.ok({
-          body: { ok: false, resp: {} },
+          body: { 
+            ok: true, 
+            resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]" 
+          },
         });
       }
       return res.ok({

--- a/server/services/DestinationsService.test.js
+++ b/server/services/DestinationsService.test.js
@@ -1,0 +1,186 @@
+import DestinationsService from "./DestinationsService";
+
+describe("Test DestinationsService -- getDestinations", () => {
+  let destinationsService;
+  let mockContext;
+  let mockReq;
+  let mockRes;
+  let mockClient;
+
+  beforeEach(() => {
+    mockClient = jest.fn();
+    
+    mockContext = {};
+    
+    mockRes = {
+      ok: jest.fn().mockReturnValue({ body: {} }),
+    };
+
+    destinationsService = new DestinationsService();
+    destinationsService.getClientBasedOnDataSource = jest.fn().mockReturnValue(mockClient);
+  
+  });
+
+  describe("Test getDestinations", () => {
+  
+    test("should successfully get destinations list -- name as sort string", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+
+      const mockResponse = {
+        destinations: [{
+          id: "1",
+          name: "Sample Destination",
+          schema_version: 1,
+          seq_no: 1,
+          primary_term: 1,
+        }],
+        totalDestinations: 1,
+      };
+      mockClient.mockResolvedValueOnce(mockResponse);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockClient).toHaveBeenCalledWith("alerting.searchDestinations", {
+        sortString: "destination.name.keyword",
+        sortOrder: "desc",
+        startIndex: 0,
+        size: 20,
+        searchString: "",
+        destinationType: "ALL",
+      });
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          destinations: [{
+            id: "1",
+            name: "Sample Destination",
+            schema_version: 1,
+            seq_no: 1,
+            primary_term: 1,
+            version: 1,
+            ifSeqNo: 1,
+            ifPrimaryTerm: 1,
+          }],
+          totalDestinations: 1,
+        },
+      });
+    });
+
+    test("should successfully get destinations list -- type as sort string", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "type",
+          type: "ALL",
+        },
+      };
+
+      const mockResponse = {
+        destinations: [{
+          id: "1",
+          name: "Sample Destination",
+          schema_version: 1,
+          seq_no: 1,
+          primary_term: 1,
+        }],
+        totalDestinations: 1,
+      };
+      mockClient.mockResolvedValueOnce(mockResponse);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockClient).toHaveBeenCalledWith("alerting.searchDestinations", {
+        sortString: "destination.type",
+        sortOrder: "desc",
+        startIndex: 0,
+        size: 20,
+        searchString: "",
+        destinationType: "ALL",
+      });
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          destinations: [{
+            id: "1",
+            name: "Sample Destination",
+            schema_version: 1,
+            seq_no: 1,
+            primary_term: 1,
+            version: 1,
+            ifSeqNo: 1,
+            ifPrimaryTerm: 1,
+          }],
+          totalDestinations: 1,
+        },
+      });
+    });
+
+    test("should handle index not found error", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+      const error = new Error();
+      error.statusCode = 404;
+      error.body = { 
+        error: { 
+          reason: 'Configured indices are not found: [.opendistro-alerting-config]'
+        } 
+      };
+      mockClient.mockRejectedValueOnce(error);
+    
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+    
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]"
+        },
+      });
+    });
+    
+    test("should handle other errors", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+
+      const error = new Error("Some error");
+      mockClient.mockRejectedValueOnce(error);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: false,
+          err: "Some error"
+        },
+      });
+    });
+    
+  });
+});


### PR DESCRIPTION
### Description
This PR fixes the issue of an unnecessary error popup appearing while creation of a monitor. The error popup is raised because the config index is not been before a monitor is created, but is created automatically when the monitor is created. So, the error popup is redundant when creating a monitor.

![Error Popup](https://github.com/user-attachments/assets/191cdad3-6f77-48bb-9197-c3aefb0465fc)
 
### Check List
- [x] Bug fix tested locally.
- [x] Added new unit test cases.
- [x] All tests passed.
- [x] Commits are signed per the DCO using --signoff


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
