### PR TITLE
fix: error toast message while configuring trigger while creating a monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.22.9",
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
-    "cypress": "12.17.4",
+    "cypress": "9.5.4",
     "husky": "^8.0.0",
     "lint-staged": "^10.2.0",
     "@types/react": "^16.14.23"
@@ -67,6 +67,5 @@
   },
   "engines": {
     "yarn": "^1.21.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.22.9",
     "@elastic/elastic-eslint-config-kibana": "link:../../packages/opensearch-eslint-config-opensearch-dashboards",
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
-    "cypress": "9.5.4",
+    "cypress": "12.17.4",
     "husky": "^8.0.0",
     "lint-staged": "^10.2.0",
     "@types/react": "^16.14.23"
@@ -67,5 +67,6 @@
   },
   "engines": {
     "yarn": "^1.21.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -183,7 +183,10 @@ class ConfigureActions extends React.Component {
             description: '',
           }));
       } else {
-        backendErrorNotification(notifications, 'load', 'destinations', response.err);
+        // If the config index is not created, don't show the notification
+        if (response.totalMonitors !== 0) {
+          backendErrorNotification(notifications, 'load', 'destinations', response.err);
+        }
       }
 
       let channels = await this.getChannels();

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActions.js
@@ -182,11 +182,9 @@ class ConfigureActions extends React.Component {
             type: toChannelType(destination.type),
             description: '',
           }));
-      } else {
-        // If the config index is not created, don't show the notification
-        if (response.totalMonitors !== 0) {
+      } else if (response.totalMonitors !== 0) {
+          // If the config index is not created, don't show the notification
           backendErrorNotification(notifications, 'load', 'destinations', response.err);
-        }
       }
 
       let channels = await this.getChannels();

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -175,9 +175,13 @@ export default class DestinationsService extends MDSEnabledClientService {
         },
       });
     } catch (err) {
+      // Indices will be created when the monitor is created.
       if (isIndexNotFoundError(err)) {
         return res.ok({
-          body: { ok: false, resp: {} },
+          body: { 
+            ok: true, 
+            resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]" 
+          },
         });
       }
       return res.ok({

--- a/server/services/DestinationsService.js
+++ b/server/services/DestinationsService.js
@@ -178,18 +178,21 @@ export default class DestinationsService extends MDSEnabledClientService {
       // Indices will be created when the monitor is created.
       if (isIndexNotFoundError(err)) {
         return res.ok({
-          body: { 
-            ok: true, 
-            resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]" 
+          body: {
+            ok: false,
+            totalMonitors: 0, 
+            monitors: [],
+            message: "Config index will be created automatically when the monitor is created"
+          },
+        });
+      } else {
+        return res.ok({
+          body: {
+            ok: false,
+            err: err.message,
           },
         });
       }
-      return res.ok({
-        body: {
-          ok: false,
-          err: err.message,
-        },
-      });
     }
   };
 

--- a/server/services/DestinationsService.test.js
+++ b/server/services/DestinationsService.test.js
@@ -1,0 +1,186 @@
+import DestinationsService from "./DestinationsService";
+
+describe("Test DestinationsService -- getDestinations", () => {
+  let destinationsService;
+  let mockContext;
+  let mockReq;
+  let mockRes;
+  let mockClient;
+
+  beforeEach(() => {
+    mockClient = jest.fn();
+    
+    mockContext = {};
+    
+    mockRes = {
+      ok: jest.fn().mockReturnValue({ body: {} }),
+    };
+
+    destinationsService = new DestinationsService();
+    destinationsService.getClientBasedOnDataSource = jest.fn().mockReturnValue(mockClient);
+  
+  });
+
+  describe("Test getDestinations", () => {
+  
+    test("should successfully get destinations list -- name as sort string", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+
+      const mockResponse = {
+        destinations: [{
+          id: "1",
+          name: "Sample Destination",
+          schema_version: 1,
+          seq_no: 1,
+          primary_term: 1,
+        }],
+        totalDestinations: 1,
+      };
+      mockClient.mockResolvedValueOnce(mockResponse);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockClient).toHaveBeenCalledWith("alerting.searchDestinations", {
+        sortString: "destination.name.keyword",
+        sortOrder: "desc",
+        startIndex: 0,
+        size: 20,
+        searchString: "",
+        destinationType: "ALL",
+      });
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          destinations: [{
+            id: "1",
+            name: "Sample Destination",
+            schema_version: 1,
+            seq_no: 1,
+            primary_term: 1,
+            version: 1,
+            ifSeqNo: 1,
+            ifPrimaryTerm: 1,
+          }],
+          totalDestinations: 1,
+        },
+      });
+    });
+
+    test("should successfully get destinations list -- type as sort string", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "type",
+          type: "ALL",
+        },
+      };
+
+      const mockResponse = {
+        destinations: [{
+          id: "1",
+          name: "Sample Destination",
+          schema_version: 1,
+          seq_no: 1,
+          primary_term: 1,
+        }],
+        totalDestinations: 1,
+      };
+      mockClient.mockResolvedValueOnce(mockResponse);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockClient).toHaveBeenCalledWith("alerting.searchDestinations", {
+        sortString: "destination.type",
+        sortOrder: "desc",
+        startIndex: 0,
+        size: 20,
+        searchString: "",
+        destinationType: "ALL",
+      });
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          destinations: [{
+            id: "1",
+            name: "Sample Destination",
+            schema_version: 1,
+            seq_no: 1,
+            primary_term: 1,
+            version: 1,
+            ifSeqNo: 1,
+            ifPrimaryTerm: 1,
+          }],
+          totalDestinations: 1,
+        },
+      });
+    });
+
+    test("should handle index not found error", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+      const error = new Error();
+      error.statusCode = 404;
+      error.body = { 
+        error: { 
+          reason: 'Configured indices are not found: [.opendistro-alerting-config]'
+        } 
+      };
+      mockClient.mockRejectedValueOnce(error);
+    
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+    
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: true,
+          resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]"
+        },
+      });
+    });
+    
+    test("should handle other errors", async () => {
+      const mockReq = {
+        query: {
+          from: 0,
+          size: 20,
+          search: "",
+          sortDirection: "desc",
+          sortField: "name",
+          type: "ALL",
+        },
+      };
+
+      const error = new Error("Some error");
+      mockClient.mockRejectedValueOnce(error);
+
+      await destinationsService.getDestinations(mockContext, mockReq, mockRes);
+
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: {
+          ok: false,
+          err: "Some error"
+        },
+      });
+    });
+    
+  });
+});

--- a/server/services/DestinationsService.test.js
+++ b/server/services/DestinationsService.test.js
@@ -151,8 +151,10 @@ describe("Test DestinationsService -- getDestinations", () => {
     
       expect(mockRes.ok).toHaveBeenCalledWith({
         body: {
-          ok: true,
-          resp: "Indices will be configured when the monitor is created: [.opendistro-alerting-config]"
+          ok: false,
+            totalMonitors: 0, 
+            monitors: [],
+            message: "Config index will be created automatically when the monitor is created"
         },
       });
     });

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -481,18 +481,28 @@ export default class MonitorService extends MDSEnabledClientService {
         },
       });
     } catch (err) {
-      console.error('Alerting - MonitorService - getMonitors', err);
       if (isIndexNotFoundError(err)) {
+        // Config index is not created unitl a monitor is created.
         return res.ok({
-          body: { ok: false, resp: { totalMonitors: 0, monitors: [] } },
+          body: { 
+            ok: false, 
+            resp: { 
+              totalMonitors: 0, 
+              monitors: [],
+              message: "No monitors created"
+            } 
+          },
+        });
+      } else {
+        // If the index is created, some error in retrieving the monitors.
+        console.error('Alerting - MonitorService - getMonitors', err);
+        return res.ok({
+          body: {
+            ok: false,
+            resp: err.message,
+          },
         });
       }
-      return res.ok({
-        body: {
-          ok: false,
-          resp: err.message,
-        },
-      });
     }
   };
 
@@ -594,13 +604,28 @@ export default class MonitorService extends MDSEnabledClientService {
         },
       });
     } catch (err) {
-      console.error('Alerting - MonitorService - searchMonitor:', err);
-      return res.ok({
-        body: {
-          ok: false,
-          resp: err.message,
-        },
-      });
+      if (isIndexNotFoundError(err)) {
+        // Config index is not created unitl a monitor is created.
+        return res.ok({
+          body: { 
+            ok: false, 
+            resp: { 
+              totalMonitors: 0, 
+              monitors: [],
+              message: "No monitors created"
+            } 
+          },
+        });
+      } else {
+        // If the index is created, some error in retrieving the monitors.
+        console.error('Alerting - MonitorService - searchMonitor:', err);
+        return res.ok({
+          body: {
+            ok: false,
+            resp: err.message,
+          },
+        });
+      } 
     }
   };
 }


### PR DESCRIPTION
### Description
This PR fixes the issue of an unnecessary error popup appearing while creation of a monitor. The error popup is raised because the config index is not been before a monitor is created, but is created automatically when the monitor is created. So, the error popup is redundant when creating a monitor.

![image](https://github.com/user-attachments/assets/5258a053-7f46-431e-bf33-2dd0ee1be0ed)
  
### Check List
- [x] Bug fix tested locally.
- [x] Added new unit test cases.
- [x] All tests passed.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
