### PR TITLE
2.15.1 version bump.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -76,13 +76,13 @@ jobs:
           command: yarn run cypress run
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  ALERTING_PLUGIN_BRANCH: '2.x'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.15'
+  ALERTING_PLUGIN_BRANCH: '2.15'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -66,7 +66,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
+          yarn start --no-base-path --no-watch --server.host="0.0.0.0" --opensearch.ignoreVersionMismatch=true &
           sleep 300
         # timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5601/api/status)" != "200" ]]; do sleep 5; done'
       - name: Run Cypress tests

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "**"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.13.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.15.0'
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "alertingDashboards",
-  "version": "2.15.0.0",
-  "opensearchDashboardsVersion": "2.15.0",
+  "version": "2.15.1.0",
+  "opensearchDashboardsVersion": "2.15.1",
   "configPath": [
     "opensearch_alerting"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "2.15.0.0",
+  "version": "2.15.1.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Description
1. 2.15.1 version bump.
2. Adjusted the cypress workflow to use the `--opensearch.ignoreVersionMismatch=true` as the alerting backend has been bumped to 2.15.1, but OSD is still on 2.15.0. Checked with dashboards team offline to clarify that they don't plan to increment their branch at this time as a 2.15.1 patch release hasn't been announced (https://github.com/opensearch-project/OpenSearch-Dashboards/releases). 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
