### PR TITLE
fix: add field validation for anomaly detector results (#1126)

### DIFF
--- a/server/routes/anomalyDetector.js
+++ b/server/routes/anomalyDetector.js
@@ -37,7 +37,11 @@ export default function (services, router, dataSourceEnabled) {
         params: schema.object({
           detectorId: schema.string(),
         }),
-        query: createValidateQuerySchema(dataSourceEnabled),
+        query: createValidateQuerySchema(dataSourceEnabled, {
+          startTime: schema.maybe(schema.number()),
+          endTime: schema.maybe(schema.number()),
+          preview: schema.maybe(schema.boolean()),
+        }),
       },
     },
     anomalyDetectorService.getDetectorResults


### PR DESCRIPTION
### Description
adds the correct field validation for detector results. Right now its not possible to create monitors for anomaly detectors since features are not correctly fetched due to missing field validations of the query.
 
### Issues Resolved
#1126 
 
### Check List
- [ x] New functionality includes testing.
  - [x ] All tests pass
- [ x] New functionality has been documented.
  - [ x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
