### PR TITLE
Ensure that .keyword subfields are selectable in the group by dropdown in bucket monitor

### DIFF
--- a/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/utils/mappings.js
@@ -36,6 +36,11 @@ export function getTypeFromMappings(mappings, dataTypes, path = '') {
 
   if (dataTypes[type]) dataTypes[type].add(path);
   else dataTypes[type] = new Set([path]);
+
+  if (mappings.fields && mappings.fields.keyword) {
+    if (dataTypes["keyword"]) dataTypes["keyword"].add(`${path}.keyword`);
+    else dataTypes["keyword"] = new Set([`${path}.keyword`]);
+  }
   return dataTypes;
 }
 


### PR DESCRIPTION
### Description

When opensearch auto creates mappings for indices, it will assume that any field containing a string will be of type `text`, but it will also create a `.keyword` subfield up to 256 chars that is a keyword field\

Example:

```
"audit_category": {
  "type": "text",
  "fields": {
    "keyword": {
      "type": "keyword",
      "ignore_above": 256
    }
  }
}
```

When creating a bucket monitor, I noticed that these subfields were not selectable in the groupBy dropdown. After applying these changes the subfield is selectable and the monitor works as expected. 
 
### Issues Resolved

Resolves https://github.com/opensearch-project/alerting-dashboards-plugin/issues/517
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
