### PR TITLE
Fix alerting CI failures

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,7 +8,7 @@ on:
       - "**"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-beta1-SNAPSHOT'
+  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
   ALERTING_PLUGIN_BRANCH: 'main'
 jobs:
   tests:

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "alertingDashboards",
-  "version": "3.0.0.0-beta1",
+  "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["opensearch_alerting"],
   "optionalPlugins": ["dataSource", "dataSourceManagement", "assistantDashboards"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-alerting-dashboards",
-  "version": "3.0.0.0-beta1",
+  "version": "3.0.0.0",
   "description": "OpenSearch Dashboards Alerting Plugin",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/release-notes/opensearch-alerting-dashboards-plugin.release-notes-3.0.0.0.md
+++ b/release-notes/opensearch-alerting-dashboards-plugin.release-notes-3.0.0.0.md
@@ -1,0 +1,11 @@
+## Version 3.0.0.0 2025-05-01
+Compatible with OpenSearch Dashboards 3.0.0
+
+### Maintenance
+* Increment version to 3.0.0.0. ([#1246](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1246))
+
+### Bug fixes
+* Alerting Dashboard doesn't find sub-fields when building the list of fields by type. ([1234](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1234))
+
+### Documentation
+* Added 3.0.0 release notes. ([#1246](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1246))


### PR DESCRIPTION
### Description
This PR fixes CI failures in alerting main branch.
 
### Issues Resolved
CI failures in alerting
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
