### PR TITLE
add react-monaco-editor to jest transformIgnorePatterns

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: [
     '<rootDir>/test/setup.jest.js',
-    '<rootDir>../../src/dev/jest/setup/monaco_mock.js'
+    '<rootDir>../../src/dev/jest/setup/monaco_mock.js',
   ],
   modulePaths: ['node_modules', `../../node_modules`],
   coverageDirectory: './coverage',
@@ -54,6 +54,6 @@ module.exports = {
   transformIgnorePatterns: [
     // ignore all node_modules except d3-color which requires babel transforms to handle export statement
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios))[/\\\\].+\\.js$',
   ],
 };


### PR DESCRIPTION
### Description
- add `react-monaco-editor` to transform ignore pattern in jest config. This is needed due to OSD's version bump of monaco editor: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9618
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
