### PR TITLE
Onboarded opensearch apis to use MDS client when MDS is enabled

### DIFF
--- a/server/routes/opensearch.js
+++ b/server/routes/opensearch.js
@@ -62,7 +62,9 @@ export default function (services, router, dataSourceEnabled) {
   router.get(
     {
       path: '/api/alerting/_plugins',
-      validate: false,
+      validate: {
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
     },
     opensearchService.getPlugins
   );
@@ -70,7 +72,9 @@ export default function (services, router, dataSourceEnabled) {
   router.get(
     {
       path: '/api/alerting/_settings',
-      validate: false,
+      validate: {
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
     },
     opensearchService.getSettings
   );
@@ -78,7 +82,9 @@ export default function (services, router, dataSourceEnabled) {
   router.get(
     {
       path: '/api/alerting/_health',
-      validate: false,
+      validate: {
+        query: createValidateQuerySchema(dataSourceEnabled),
+      },
     },
     opensearchService.getClusterHealth
   );


### PR DESCRIPTION
### Description
Onboarded opensearch apis to use MDS client when MDS is enabled
 
### Issues Resolved
When calling apis for cluster plugins, settings, the alerting dashboards server is not getting the correct data sourceid and ends up using the wrong client. When multi data source is enabled the data source id passed to the api call from browser needs to be used for resolving the client. This PR fixes that issue
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
