### PR TITLE
allow keyword filter to be attached to bucket level monitor trigger

### DIFF
--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/utils/whereHelpers.js
@@ -5,7 +5,10 @@
 
 import _ from 'lodash';
 import { OPERATORS_MAP, Expressions } from './constants';
-import { TRIGGER_COMPARISON_OPERATORS } from '../../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
+import {
+  TRIGGER_COMPARISON_OPERATORS,
+  TRIGGER_OPERATORS_MAP,
+} from '../../../../../CreateTrigger/containers/DefineBucketLevelTrigger/DefineBucketLevelTrigger';
 import { DATA_TYPES } from '../../../../../../utils/constants';
 import { FORMIK_INITIAL_WHERE_EXPRESSION_VALUES } from '../../../../containers/CreateMonitor/utils/constants';
 
@@ -97,6 +100,10 @@ export const validateWhereFilter = (filter = FORMIK_INITIAL_WHERE_EXPRESSION_VAL
     case OPERATORS_MAP.IS_NOT_NULL.value:
       // These operators don't store a query value in the FORMIK_INITIAL_WHERE_EXPRESSION_VALUES.
       // No further validation needed.
+      break;
+    case TRIGGER_OPERATORS_MAP.INCLUDE:
+    case TRIGGER_OPERATORS_MAP.EXCLUDE:
+      filterIsValid = filterIsValid && !_.isEmpty(filter.fieldValue?.toString());
       break;
     default:
       console.log('Unknown query operator detected:', fieldOperator);


### PR DESCRIPTION
### Description
Keyword filter was not getting attached in bucket level monitor trigger because it stores the query in TRIGGER_OPERATORS_MAP.INCLUDE and TRIGGER_OPERATORS_MAP.EXCLUDE. However, these cases were not included and validateFormField returned false as it assumed the field value was empty. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
