### PR TITLE
fix alert acknowledge not refreshing page

### DIFF
--- a/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
+++ b/public/components/Flyout/flyouts/components/AlertsDashboardFlyoutComponent.js
@@ -239,7 +239,8 @@ export default class AlertsDashboardFlyoutComponent extends Component {
     if (!selectedItems.length) return;
 
     const { httpClient, notifications } = this.props;
-    acknowledgeAlerts(httpClient, notifications, selectedItems);
+    // Wait for acknowledgment to complete before refetching alerts
+    await acknowledgeAlerts(httpClient, notifications, selectedItems);
 
     const { page, size, search, sortField, sortDirection, severityLevel, alertState, monitorIds } =
       this.state;

--- a/public/pages/Dashboard/containers/Dashboard.js
+++ b/public/pages/Dashboard/containers/Dashboard.js
@@ -45,7 +45,7 @@ import {
   getDataSourceId,
   appendCommentsAction,
   getIsCommentsEnabled,
-  getIsAgentConfigured
+  getIsAgentConfigured,
 } from '../../utils/helpers';
 import { getUseUpdatedUx } from '../../../services';
 
@@ -226,7 +226,7 @@ export default class Dashboard extends Component {
 
   acknowledgeAlerts = async (alerts) => {
     const { httpClient, notifications } = this.props;
-    await Promise.all(acknowledgeAlerts(httpClient, notifications, alerts));
+    await acknowledgeAlerts(httpClient, notifications, alerts);
   };
 
   // TODO: exists in both Dashboard and Monitors, should be moved to redux when implemented

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -135,7 +135,7 @@ export async function acknowledgeAlerts(httpClient, notifications, alerts) {
         .catch((error) => error)
   );
 
-  return acknowledgePromises;
+  return Promise.all(acknowledgePromises);
 }
 
 export const titleTemplate = (title, subTitle) => (


### PR DESCRIPTION
### Description
After acknowledging an alert in the flyout, it doesn't update status of that alert as acknowledged unless you renter flyout or reload the page. We updated helpers.js so function returns a single awaitable promise. We then updated the alerts dashboard to wait for acknowledgeAlerts() to complete before getting alerts. This essentially fixed the problem, but there is now aredundant Promise.all() wrapper that we remove from Dashboard.js since our helpers.js change does that.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
