### PR TITLE
fix: support {{period_start}} placeholder in Alert Insight

### DIFF
--- a/public/pages/Dashboard/utils/constants.js
+++ b/public/pages/Dashboard/utils/constants.js
@@ -40,6 +40,7 @@ export const DEFAULT_LOG_PATTERN_SAMPLE_SIZE = 20;
 export const DEFAULT_ACTIVE_ALERTS_AI_TOP_N = 1;
 export const DEFAULT_DSL_QUERY_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 export const DEFAULT_PPL_QUERY_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+export const PERIOD_START_PLACEHOLDER = '{{period_start}}';
 export const PERIOD_END_PLACEHOLDER = '{{period_end}}';
 export const BUCKET_UNIT_PPL_UNIT_MAP = {
   'd': 'DAY',


### PR DESCRIPTION
### Description

Fixed an issue where Alert Insight failed to parse queries containing `{{period_start}}`.

The code has been updated to correctly calculate the start time (based on the notification time) and replace the `{{period_start}}` placeholder with the actual timestamp before executing the search.
This resolves the `failed to parse date field` exception when using time ranges in extraction queries.
 
### Issues Resolved

Fixes #1340 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
