### PR TITLE
Add missing import in TriggerNotifications.js

### DIFF
--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotifications.js
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/TriggerNotifications.js
@@ -13,6 +13,7 @@ import {
   EuiButtonIcon,
   EuiToolTip,
 } from '@elastic/eui';
+import _ from 'lodash';
 import TriggerNotificationsContent from './TriggerNotificationsContent';
 import { MAX_CHANNELS_RESULT_SIZE, OS_NOTIFICATION_PLUGIN } from '../../../../utils/constants';
 import { titleTemplate } from '../../../../utils/helpers';


### PR DESCRIPTION
### Description
Add a missing import in `TriggerNotifications.js` which was causing add trigger functionality to fail for composite monitors.
 
### Issues Resolved
Fixes failing add trigger functionality in composite monitors (No GitHub issue recorded).
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
