### PR TITLE
Read max triggers limit from backend setting

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -8,6 +8,7 @@ on:
       - "**"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
   ALERTING_PLUGIN_BRANCH: 'main'
 jobs:
   tests:
@@ -47,7 +48,7 @@ jobs:
       - name: Run Opensearch with plugin
         run: |
           cd alerting
-          ./gradlew :alerting:run &
+          ./gradlew :alerting:run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggers.js
@@ -20,10 +20,11 @@ import TriggerEmptyPrompt from '../../components/TriggerEmptyPrompt';
 import { MAX_TRIGGERS } from '../../../MonitorDetails/containers/Triggers/Triggers';
 import DefineTrigger from '../DefineTrigger';
 import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../utils/constants';
+import { MAX_TRIGGERS_SETTING } from '../../../utils/constants';
 import { getPathsPerDataType } from '../../../CreateMonitor/containers/DefineMonitor/utils/mappings';
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
 import { buildRequest } from '../../../CreateMonitor/containers/DefineMonitor/utils/searchRequests';
-import { backendErrorNotification, inputLimitText } from '../../../../utils/helpers';
+import { backendErrorNotification, inputLimitText, getClusterSetting } from '../../../../utils/helpers';
 import DefineDocumentLevelTrigger from '../DefineDocumentLevelTrigger/DefineDocumentLevelTrigger';
 import {
   buildClusterMetricsRequest,
@@ -51,6 +52,7 @@ class ConfigureTriggers extends React.Component {
       triggerEmptyPrompt: this.prepareTriggerEmptyPrompt(),
       currentSubmitCount: 0,
       accordionsOpen,
+      maxTriggers: MAX_TRIGGERS,
       TriggerContainer: props.flyoutMode
         ? (props) => <EnhancedAccordion {...props} />
         : ({ children }) => <>{children}</>,
@@ -65,6 +67,13 @@ class ConfigureTriggers extends React.Component {
 
   componentDidMount() {
     this.monitorSetupByType();
+    this.fetchMaxTriggers();
+  }
+
+  async fetchMaxTriggers() {
+    const { httpClient } = this.props;
+    const maxTriggers = await getClusterSetting(httpClient, MAX_TRIGGERS_SETTING, MAX_TRIGGERS);
+    this.setState({ maxTriggers: parseInt(maxTriggers, 10) });
   }
 
   componentDidUpdate(prevProps) {
@@ -132,7 +141,7 @@ class ConfigureTriggers extends React.Component {
   prepareAddTriggerButton = () => {
     const { monitorValues, triggerArrayHelpers, triggerValues } = this.props;
     const disableAddTriggerButton =
-      _.get(triggerValues, 'triggerDefinitions', []).length >= MAX_TRIGGERS;
+      _.get(triggerValues, 'triggerDefinitions', []).length >= this.state.maxTriggers;
     return (
       <AddTriggerButton
         arrayHelpers={triggerArrayHelpers}
@@ -440,7 +449,7 @@ class ConfigureTriggers extends React.Component {
     const { ContentPanelStructure } = this.state;
     const numOfTriggers = _.get(triggerValues, 'triggerDefinitions', []).length;
     const displayAddTriggerButton = numOfTriggers > 0;
-    const disableAddTriggerButton = numOfTriggers >= MAX_TRIGGERS;
+    const disableAddTriggerButton = numOfTriggers >= this.state.maxTriggers;
     const monitorType = monitorValues.monitor_type;
     const isComposite = monitorType === MONITOR_TYPE.COMPOSITE_LEVEL;
 
@@ -477,7 +486,7 @@ class ConfigureTriggers extends React.Component {
               monitorType={monitorType}
             />
             <EuiSpacer size={'s'} />
-            {inputLimitText(numOfTriggers, MAX_TRIGGERS, 'trigger', 'triggers')}
+            {inputLimitText(numOfTriggers, this.state.maxTriggers, 'trigger', 'triggers')}
           </div>
         ) : null}
       </ContentPanelStructure>

--- a/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggersPpl.js
+++ b/public/pages/CreateTrigger/containers/ConfigureTriggers/ConfigureTriggersPpl.js
@@ -11,9 +11,10 @@ import AddTriggerButtonPpl from '../../components/AddTriggerButton/AddTriggerBut
 import TriggerEmptyPrompt from '../../components/TriggerEmptyPrompt';
 import { MAX_TRIGGERS } from '../../../MonitorDetails/containers/Triggers/Triggers';
 import monitorToFormik from '../../../CreateMonitor/containers/CreateMonitor/utils/monitorToFormik';
-import { backendErrorNotification, inputLimitText } from '../../../../utils/helpers';
+import { backendErrorNotification, inputLimitText, getClusterSetting } from '../../../../utils/helpers';
 import EnhancedAccordion from '../../../../components/FeatureAnywhereContextMenu/EnhancedAccordion';
 import { getDataSourceQueryObj } from '../../../../../public/pages/utils/helpers';
+import { MAX_TRIGGERS_SETTING } from '../../../utils/constants';
 import DefineTriggerPpl from '../DefineTrigger/DefineTriggerPpl';
 import {
   addTimeFilterToQuery,
@@ -133,6 +134,7 @@ class ConfigureTriggersPpl extends React.Component {
       executeResponse: null,
       previewError: null,
       accordionsOpen,
+      maxTriggers: MAX_TRIGGERS,
       TriggerContainer: props.flyoutMode
         ? (p) => <EnhancedAccordion {...p} />
         : ({ children }) => <>{children}</>,
@@ -142,12 +144,19 @@ class ConfigureTriggersPpl extends React.Component {
 
   componentDidMount() {
     this.onRunExecute(this.props.monitorValues);
+    this.fetchMaxTriggers();
+  }
+
+  async fetchMaxTriggers() {
+    const { httpClient } = this.props;
+    const maxTriggers = await getClusterSetting(httpClient, MAX_TRIGGERS_SETTING, MAX_TRIGGERS);
+    this.setState({ maxTriggers: parseInt(maxTriggers, 10) });
   }
 
   prepareAddTriggerButton = () => {
     const { monitorValues, triggerArrayHelpers, triggerValues } = this.props;
     const disableAddTriggerButton =
-      _.get(triggerValues, 'triggerDefinitions', []).length >= MAX_TRIGGERS;
+      _.get(triggerValues, 'triggerDefinitions', []).length >= this.state.maxTriggers;
     return (
       <AddTriggerButtonPpl arrayHelpers={triggerArrayHelpers} disabled={disableAddTriggerButton} />
     );
@@ -363,7 +372,7 @@ class ConfigureTriggersPpl extends React.Component {
         {!flyoutMode && hasTriggers && (
           <>
             <EuiSpacer size="m" />
-            {inputLimitText(numTriggers, MAX_TRIGGERS, 'trigger', 'triggers')}
+            {inputLimitText(numTriggers, this.state.maxTriggers, 'trigger', 'triggers')}
           </>
         )}
       </ContentPanelStructure>

--- a/public/pages/MonitorDetails/containers/Triggers/TriggersPpl.js
+++ b/public/pages/MonitorDetails/containers/Triggers/TriggersPpl.js
@@ -12,8 +12,6 @@ import ContentPanel from '../../../../components/ContentPanel';
 import { DEFAULT_EMPTY_DATA } from '../../../../utils/constants';
 import { formatDuration } from '../../../CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers';
 
-const MAX_TRIGGERS = 10;
-
 const formatTriggerMode = (mode) => {
   if (!mode) return DEFAULT_EMPTY_DATA;
   switch (mode) {

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -8,6 +8,7 @@ import { BehaviorSubject } from 'rxjs';
 import { DataSourceOption } from "../../../../../src/plugins/data_source_management/public";
 
 export const COMMENTS_ENABLED_SETTING = "plugins.alerting.comments_enabled";
+export const MAX_TRIGGERS_SETTING = "plugins.alerting.monitor.max_triggers";
 const LocalCluster: DataSourceOption = {
   label: i18n.translate("dataSource.localCluster", {
     defaultMessage: "Local cluster",


### PR DESCRIPTION
### Description

Fetch plugins.alerting.monitor.max_triggers cluster setting instead of using hardcoded MAX_TRIGGERS constant. Falls back to default of 10 if the setting cannot be retrieved.

Resolves opensearch-project/alerting#468

### Issues Resolved
https://github.com/opensearch-project/alerting/issues/1828
https://github.com/opensearch-project/alerting#468

Testing info here : https://github.com/opensearch-project/common-utils/pull/913#issue-4054949628
 
### Check List
- [X ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
