### PR TITLE
Fix monitor deep-link datasource menu initialization

### DIFF
--- a/public/pages/Main/Main.js
+++ b/public/pages/Main/Main.js
@@ -112,9 +112,10 @@ class Main extends Component {
     const { setActionMenu } = this.props;
     const componentConfig = {
       fullWidth: false,
-      activeOption: this.state.dataSourceLoading
-        ? undefined
-        : [{ id: this.state.selectedDataSourceId }],
+      activeOption:
+        this.state.selectedDataSourceId !== undefined
+          ? [{ id: this.state.selectedDataSourceId }]
+          : [],
       savedObjects: getSavedObjectsClient(),
       notifications: getNotifications(),
       dataSourceFilter: dataSourceFilterFn,


### PR DESCRIPTION
## Summary

This PR fixes Alerting monitor deep-link initialization in datasource-enabled environments.

### Related Issue
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11439

## What changed

- Updated `Main.js` to always pass `activeOption` as an array to the datasource menu
- Uses:
  - `[]` while datasource state is still loading
  - `[{ id }]` when a datasource is selected

## Why

The monitor details deep link from Metrics can enter Alerting before datasource state is fully resolved. In that case, `activeOption` could be `undefined`, which is not the shape expected by the datasource menu and could break page initialization.

This keeps the Alerting-side fix minimal and localized to the deep-link boot path.

## Testing

- Verified `View monitor` link opens correctly from Metrics
- Verified datasource-enabled monitor details page no longer boots into a blank state
