### PR TITLE
Added workspace ACL checks for Alerting and Monitor APIs

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "3.6.0.0",
   "opensearchDashboardsVersion": "3.6.0",
   "configPath": ["opensearch_alerting"],
-  "optionalPlugins": ["dataSource", "dataSourceManagement", "assistantDashboards", "explore"],
+  "optionalPlugins": ["dataSource", "dataSourceManagement", "assistantDashboards", "explore", "workspace"],
   "requiredPlugins": [
     "uiActions",
     "dashboard",

--- a/server/alerting_configs.json
+++ b/server/alerting_configs.json
@@ -1,0 +1,3 @@
+{
+  "ws.acl.enforce.endpoint.patterns": [".aoss.amazonaws.com"]
+}

--- a/server/alerting_configs.json
+++ b/server/alerting_configs.json
@@ -1,3 +1,0 @@
-{
-  "ws.acl.enforce.endpoint.patterns": [".aoss.amazonaws.com"]
-}

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -162,7 +162,6 @@ export class AlertingPlugin {
     ]);
 
     // Wrap router to auto-reject unsupported routes on serverless endpoints.
-    const { monitorService } = services;
     const guardedRouter = ['get', 'post', 'put', 'delete'].reduce((proxy, method) => {
       proxy[method] = (route, handler) => {
         const key = `${method.toUpperCase()} ${route.path}`;

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -182,10 +182,8 @@ export class AlertingPlugin {
           return undefined;
         }
       };
+
       Object.values(this.services).forEach((service) => {
-        if (typeof service.setLogger === 'function') {
-          service.setLogger(this.logger);
-        }
         if (plugins?.workspace && typeof service.setWorkspaceStart === 'function') {
           service.setWorkspaceStart(plugins.workspace);
         }

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -30,6 +30,7 @@ import {
   comments,
 } from '../server/routes';
 import { JSON_SCHEMA } from 'js-yaml';
+import { getWorkspaceState } from '../../../src/core/server/utils';
 
 export class AlertingPlugin {
   constructor(initializerContext) {
@@ -174,12 +175,22 @@ export class AlertingPlugin {
 
   async start(core, plugins) {
     if (this.services) {
+      const workspaceIdGetter = (request) => {
+        try {
+          return getWorkspaceState(request).requestWorkspaceId;
+        } catch (e) {
+          return undefined;
+        }
+      };
       Object.values(this.services).forEach((service) => {
         if (typeof service.setLogger === 'function') {
           service.setLogger(this.logger);
         }
         if (plugins?.workspace && typeof service.setWorkspaceStart === 'function') {
           service.setWorkspaceStart(plugins.workspace);
+        }
+        if (typeof service.setWorkspaceIdGetter === 'function') {
+          service.setWorkspaceIdGetter(workspaceIdGetter);
         }
       });
     }

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -130,7 +130,55 @@ export class AlertingPlugin {
 
     // Create router
     const router = core.http.createRouter();
-    const registerPplRoutes = () => pplAlertingMonitors(services, router, dataSourceEnabled);
+
+    // Routes that return 501 on unsupported (e.g. serverless) endpoints.
+    // Uses path patterns — {param} segments are normalized to match any value.
+    const unsupportedRoutes = new Set([
+      'POST /api/alerting/workflows',
+      'GET /api/alerting/workflows/{id}',
+      'PUT /api/alerting/workflows/{id}',
+      'DELETE /api/alerting/workflows/{id}',
+      'POST /api/alerting/workflows/{id}/_acknowledge/alerts',
+      'POST /api/alerting/comments/_search',
+      'POST /api/alerting/comments/{alertId}',
+      'PUT /api/alerting/comments/{commentId}',
+      'DELETE /api/alerting/comments/{commentId}',
+      'GET /api/alerting/destinations',
+      'GET /api/alerting/destinations/{destinationId}',
+      'POST /api/alerting/destinations',
+      'PUT /api/alerting/destinations/{destinationId}',
+      'DELETE /api/alerting/destinations/{destinationId}',
+      'GET /api/alerting/destinations/email_accounts',
+      'POST /api/alerting/destinations/email_accounts',
+      'GET /api/alerting/destinations/email_accounts/{id}',
+      'PUT /api/alerting/destinations/email_accounts/{id}',
+      'DELETE /api/alerting/destinations/email_accounts/{id}',
+      'GET /api/alerting/destinations/email_groups',
+      'POST /api/alerting/destinations/email_groups',
+      'GET /api/alerting/destinations/email_groups/{id}',
+      'PUT /api/alerting/destinations/email_groups/{id}',
+      'DELETE /api/alerting/destinations/email_groups/{id}',
+      'GET /api/alerting/findings/_search',
+    ]);
+
+    // Wrap router to auto-reject unsupported routes on serverless endpoints.
+    const { monitorService } = services;
+    const guardedRouter = ['get', 'post', 'put', 'delete'].reduce((proxy, method) => {
+      proxy[method] = (route, handler) => {
+        const key = `${method.toUpperCase()} ${route.path}`;
+        if (unsupportedRoutes.has(key)) {
+          router[method](route, async (context, req, res) => {
+            const rejected = await monitorService.rejectIfUnsupported(context, req, res);
+            if (rejected) return rejected;
+            return handler(context, req, res);
+          });
+        } else {
+          router[method](route, handler);
+        }
+      };
+      return proxy;
+    }, {});
+    const registerPplRoutes = () => pplAlertingMonitors(services, guardedRouter, dataSourceEnabled);
 
     if (defaultPplEnabled) {
       registerPplRoutes();
@@ -161,14 +209,14 @@ export class AlertingPlugin {
     }
 
     // Add server routes
-    alerts(services, router, dataSourceEnabled);
-    destinations(services, router, dataSourceEnabled);
-    opensearch(services, router, dataSourceEnabled);
-    monitors(services, router, dataSourceEnabled);
-    detectors(services, router, dataSourceEnabled);
-    findings(services, router, dataSourceEnabled);
-    crossCluster(services, router, dataSourceEnabled);
-    comments(services, router, dataSourceEnabled);
+    alerts(services, guardedRouter, dataSourceEnabled);
+    destinations(services, guardedRouter, dataSourceEnabled);
+    opensearch(services, guardedRouter, dataSourceEnabled);
+    monitors(services, guardedRouter, dataSourceEnabled);
+    detectors(services, guardedRouter, dataSourceEnabled);
+    findings(services, guardedRouter, dataSourceEnabled);
+    crossCluster(services, guardedRouter, dataSourceEnabled);
+    comments(services, guardedRouter, dataSourceEnabled);
 
     return {};
   }

--- a/server/plugin.js
+++ b/server/plugin.js
@@ -38,6 +38,7 @@ export class AlertingPlugin {
     this.pluginConfig$ = initializerContext.config.create();
     this.core = null;
     this.featureFlagService = null;
+    this.services = null;
   }
 
   async setup(core, { dataSource }) {
@@ -89,6 +90,7 @@ export class AlertingPlugin {
       crossClusterService,
       commentsService,
     };
+    this.services = services;
 
     core.capabilities.registerProvider(() => ({
       alertingDashboards: {
@@ -170,7 +172,17 @@ export class AlertingPlugin {
     return {};
   }
 
-  async start(core) {
+  async start(core, plugins) {
+    if (this.services) {
+      Object.values(this.services).forEach((service) => {
+        if (typeof service.setLogger === 'function') {
+          service.setLogger(this.logger);
+        }
+        if (plugins?.workspace && typeof service.setWorkspaceStart === 'function') {
+          service.setWorkspaceStart(plugins.workspace);
+        }
+      });
+    }
     return {};
   }
 }

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -14,7 +14,17 @@ export const GET_ALERTS_SORT_FILTERS = {
 };
 
 export default class AlertService extends MDSEnabledClientService {
+  _enforceWorkspaceAcl = async (context, req, res, permissionModes) => {
+    const authorized = await this.checkWorkspaceAcl(context, req, permissionModes);
+    if (!authorized) {
+      return res.ok({ body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' } });
+    }
+    return null;
+  };
+
   getAlerts = async (context, req, res) => {
+    const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write', 'library_read']);
+    if (aclResponse) return aclResponse;
     const {
       from = 0,
       size = 20,
@@ -111,6 +121,8 @@ export default class AlertService extends MDSEnabledClientService {
   };
 
   getWorkflowAlerts = async (context, req, res) => {
+    const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write', 'library_read']);
+    if (aclResponse) return aclResponse;
     const client = this.getClientBasedOnDataSource(context, req);
     try {
       const resp = await client('alerting.getWorkflowAlerts', req.query);

--- a/server/services/AlertService.js
+++ b/server/services/AlertService.js
@@ -14,16 +14,11 @@ export const GET_ALERTS_SORT_FILTERS = {
 };
 
 export default class AlertService extends MDSEnabledClientService {
-  _enforceWorkspaceAcl = async (context, req, res, permissionModes) => {
-    const authorized = await this.checkWorkspaceAcl(context, req, permissionModes);
-    if (!authorized) {
-      return res.ok({ body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' } });
-    }
-    return null;
-  };
-
   getAlerts = async (context, req, res) => {
-    const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write', 'library_read']);
+    const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
+      'library_write',
+      'library_read',
+    ]);
     if (aclResponse) return aclResponse;
     const {
       from = 0,
@@ -121,7 +116,10 @@ export default class AlertService extends MDSEnabledClientService {
   };
 
   getWorkflowAlerts = async (context, req, res) => {
-    const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write', 'library_read']);
+    const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
+      'library_write',
+      'library_read',
+    ]);
     if (aclResponse) return aclResponse;
     const client = this.getClientBasedOnDataSource(context, req);
     try {

--- a/server/services/MDSEnabledClientService.ts
+++ b/server/services/MDSEnabledClientService.ts
@@ -1,16 +1,12 @@
 import { RequestHandlerContext, OpenSearchDashboardsRequest, OpenSearchDashboardsResponseFactory, ILegacyCustomClusterClient } from '../../../../src/core/server';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const alertingConfig = require('../alerting_configs.json');
-
-const WS_ACL_ENDPOINT_PATTERNS: string[] = alertingConfig['ws.acl.enforce.endpoint.patterns'] || [];
-
 interface WorkspaceAuthorizer {
   authorizeWorkspace: (
     request: OpenSearchDashboardsRequest,
     workspaceIds: string[],
     permissionModes?: string[]
   ) => Promise<{ authorized: true } | { authorized: false; unauthorizedWorkspaces: string[] }>;
+  aclEnforceEndpointPatterns: string[];
 }
 
 export abstract class MDSEnabledClientService {
@@ -27,11 +23,54 @@ export abstract class MDSEnabledClientService {
     this.workspaceIdGetter = fn;
   }
 
+  private get aclEndpointPatterns(): string[] {
+    return this.workspaceStart?.aclEnforceEndpointPatterns ?? [];
+  }
+
   protected getClientBasedOnDataSource(context: RequestHandlerContext, request: OpenSearchDashboardsRequest) {
     const dataSourceId = (request.query as any).dataSourceId;
     return this.dataSourceEnabled && dataSourceId
       ? context.dataSource.opensearch.legacy.getClient(dataSourceId.toString()).callAPI
       : this.osDriver.asScoped(request).callAsCurrentUser;
+  }
+
+  private async getDataSourceEndpoint(context: RequestHandlerContext, request: OpenSearchDashboardsRequest): Promise<string | undefined> {
+    const dataSourceId = (request.query as any).dataSourceId;
+    if (!dataSourceId) return undefined;
+    const dataSource = await context.core.savedObjects.client.get('data-source', dataSourceId.toString());
+    return (dataSource.attributes as any).endpoint as string;
+  }
+
+  private matchesAclPattern(endpoint: string): boolean {
+    return this.aclEndpointPatterns.some((pattern) => endpoint.includes(pattern));
+  }
+
+  /**
+   * Check if the request targets an unsupported endpoint (matching configured patterns).
+   * Returns true if the data source endpoint matches any ACL enforcement pattern.
+   */
+  protected async isUnsupportedEndpoint(context: RequestHandlerContext, request: OpenSearchDashboardsRequest): Promise<boolean> {
+    if (!this.aclEndpointPatterns.length) return false;
+    try {
+      const endpoint = await this.getDataSourceEndpoint(context, request);
+      return endpoint ? this.matchesAclPattern(endpoint) : false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Return 501 Not Implemented if the request targets an unsupported endpoint.
+   * Use for API operations not supported on serverless.
+   */
+  protected async rejectIfUnsupported(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, res: OpenSearchDashboardsResponseFactory): Promise<any | undefined> {
+    if (await this.isUnsupportedEndpoint(context, request)) {
+      return res.custom({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    }
+    return undefined;
   }
 
   protected async enforceWorkspaceAcl(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, res: OpenSearchDashboardsResponseFactory, permissionModes: string[] = ['read']) {
@@ -43,25 +82,11 @@ export abstract class MDSEnabledClientService {
   }
 
   protected async checkWorkspaceAcl(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, permissionModes: string[] = ['read']): Promise<boolean> {
-    const dataSourceId = (request.query as any).dataSourceId;
-    if (!dataSourceId) {
-      return true;
-    }
-
-    const savedObjectsClient = context.core.savedObjects.client;
-    const dataSource = await savedObjectsClient.get('data-source', dataSourceId.toString());
-    const endpoint = (dataSource.attributes as any).endpoint as string;
-
-    const requiresAcl = WS_ACL_ENDPOINT_PATTERNS.some((pattern) => endpoint.includes(pattern));
-    if (!requiresAcl) {
-      return true;
-    }
+    const endpoint = await this.getDataSourceEndpoint(context, request);
+    if (!endpoint || !this.matchesAclPattern(endpoint)) return true;
 
     const workspaceId = this.workspaceIdGetter?.(request);
-
-    if (!workspaceId || !this.workspaceStart) {
-      return true;
-    }
+    if (!workspaceId || !this.workspaceStart) return true;
 
     const result = await this.workspaceStart.authorizeWorkspace(request, [workspaceId], permissionModes);
     return result.authorized;

--- a/server/services/MDSEnabledClientService.ts
+++ b/server/services/MDSEnabledClientService.ts
@@ -1,5 +1,4 @@
 import { RequestHandlerContext, OpenSearchDashboardsRequest, ILegacyCustomClusterClient, Logger } from '../../../../src/core/server';
-import { getWorkspaceState } from '../../../../src/core/server/utils';
 
 interface WorkspaceAuthorizer {
   authorizeWorkspace: (
@@ -13,11 +12,16 @@ interface WorkspaceAuthorizer {
 export abstract class MDSEnabledClientService {
   private workspaceStart?: WorkspaceAuthorizer;
   private logger?: Logger;
+  private workspaceIdGetter?: (request: OpenSearchDashboardsRequest) => string | undefined;
 
   constructor(private osDriver: ILegacyCustomClusterClient, private dataSourceEnabled: boolean) {}
 
   public setWorkspaceStart(workspaceStart: WorkspaceAuthorizer) {
     this.workspaceStart = workspaceStart;
+  }
+
+  public setWorkspaceIdGetter(fn: (request: OpenSearchDashboardsRequest) => string | undefined) {
+    this.workspaceIdGetter = fn;
   }
 
   public setLogger(logger: Logger) {
@@ -46,7 +50,7 @@ export abstract class MDSEnabledClientService {
     }
 
     const principal = request.headers['x-amzn-aosd-username'] as string;
-    const workspaceId = getWorkspaceState(request).requestWorkspaceId;
+    const workspaceId = this.workspaceIdGetter?.(request);
 
     if (!principal || !workspaceId || !this.workspaceStart) {
       return true;

--- a/server/services/MDSEnabledClientService.ts
+++ b/server/services/MDSEnabledClientService.ts
@@ -1,17 +1,20 @@
-import { RequestHandlerContext, OpenSearchDashboardsRequest, ILegacyCustomClusterClient, Logger } from '../../../../src/core/server';
+import { RequestHandlerContext, OpenSearchDashboardsRequest, OpenSearchDashboardsResponseFactory, ILegacyCustomClusterClient } from '../../../../src/core/server';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const alertingConfig = require('../alerting_configs.json');
+
+const WS_ACL_ENDPOINT_PATTERNS: string[] = alertingConfig['ws.acl.enforce.endpoint.patterns'] || [];
 
 interface WorkspaceAuthorizer {
   authorizeWorkspace: (
     request: OpenSearchDashboardsRequest,
     workspaceIds: string[],
-    principal: string,
     permissionModes?: string[]
-  ) => Promise<{ authorized: boolean; unauthorizedWorkspaces?: string[] }>;
+  ) => Promise<{ authorized: true } | { authorized: false; unauthorizedWorkspaces: string[] }>;
 }
 
 export abstract class MDSEnabledClientService {
   private workspaceStart?: WorkspaceAuthorizer;
-  private logger?: Logger;
   private workspaceIdGetter?: (request: OpenSearchDashboardsRequest) => string | undefined;
 
   constructor(private osDriver: ILegacyCustomClusterClient, private dataSourceEnabled: boolean) {}
@@ -24,10 +27,6 @@ export abstract class MDSEnabledClientService {
     this.workspaceIdGetter = fn;
   }
 
-  public setLogger(logger: Logger) {
-    this.logger = logger;
-  }
-
   protected getClientBasedOnDataSource(context: RequestHandlerContext, request: OpenSearchDashboardsRequest) {
     const dataSourceId = (request.query as any).dataSourceId;
     return this.dataSourceEnabled && dataSourceId
@@ -35,29 +34,36 @@ export abstract class MDSEnabledClientService {
       : this.osDriver.asScoped(request).callAsCurrentUser;
   }
 
+  protected async enforceWorkspaceAcl(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, res: OpenSearchDashboardsResponseFactory, permissionModes: string[] = ['read']) {
+    const authorized = await this.checkWorkspaceAcl(context, request, permissionModes);
+    if (!authorized) {
+      return res.unauthorized({ body: { message: 'Workspace ACL check failed: unauthorized' } });
+    }
+    return undefined;
+  }
+
   protected async checkWorkspaceAcl(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, permissionModes: string[] = ['read']): Promise<boolean> {
-    // Only run workspace ACL check for serverless (AOSS) data sources
     const dataSourceId = (request.query as any).dataSourceId;
-    if (dataSourceId) {
-      const savedObjectsClient = context.core.savedObjects.client;
-      const dataSource = await savedObjectsClient.get('data-source', dataSourceId.toString());
-      const endpoint = (dataSource.attributes as any).endpoint as string;
-      if (!endpoint.includes('.aoss.amazonaws.com')) {
-        return true;
-      }
-    } else {
+    if (!dataSourceId) {
       return true;
     }
 
-    const principal = request.headers['x-amzn-aosd-username'] as string;
+    const savedObjectsClient = context.core.savedObjects.client;
+    const dataSource = await savedObjectsClient.get('data-source', dataSourceId.toString());
+    const endpoint = (dataSource.attributes as any).endpoint as string;
+
+    const requiresAcl = WS_ACL_ENDPOINT_PATTERNS.some((pattern) => endpoint.includes(pattern));
+    if (!requiresAcl) {
+      return true;
+    }
+
     const workspaceId = this.workspaceIdGetter?.(request);
 
-    if (!principal || !workspaceId || !this.workspaceStart) {
+    if (!workspaceId || !this.workspaceStart) {
       return true;
     }
 
-    const result = await this.workspaceStart.authorizeWorkspace(request, [workspaceId], principal, permissionModes);
-    this.logger?.info(`Workspace ACL check: workspace=${workspaceId}, authorized=${result.authorized}, permissionModes=${permissionModes.join(',')}`);
+    const result = await this.workspaceStart.authorizeWorkspace(request, [workspaceId], permissionModes);
     return result.authorized;
   }
 }

--- a/server/services/MDSEnabledClientService.ts
+++ b/server/services/MDSEnabledClientService.ts
@@ -1,12 +1,59 @@
-import { RequestHandlerContext, OpenSearchDashboardsRequest, ILegacyCustomClusterClient } from '../../../../src/core/server';
+import { RequestHandlerContext, OpenSearchDashboardsRequest, ILegacyCustomClusterClient, Logger } from '../../../../src/core/server';
+import { getWorkspaceState } from '../../../../src/core/server/utils';
+
+interface WorkspaceAuthorizer {
+  authorizeWorkspace: (
+    request: OpenSearchDashboardsRequest,
+    workspaceIds: string[],
+    principal: string,
+    permissionModes?: string[]
+  ) => Promise<{ authorized: boolean; unauthorizedWorkspaces?: string[] }>;
+}
 
 export abstract class MDSEnabledClientService {
+  private workspaceStart?: WorkspaceAuthorizer;
+  private logger?: Logger;
+
   constructor(private osDriver: ILegacyCustomClusterClient, private dataSourceEnabled: boolean) {}
+
+  public setWorkspaceStart(workspaceStart: WorkspaceAuthorizer) {
+    this.workspaceStart = workspaceStart;
+  }
+
+  public setLogger(logger: Logger) {
+    this.logger = logger;
+  }
 
   protected getClientBasedOnDataSource(context: RequestHandlerContext, request: OpenSearchDashboardsRequest) {
     const dataSourceId = (request.query as any).dataSourceId;
     return this.dataSourceEnabled && dataSourceId
       ? context.dataSource.opensearch.legacy.getClient(dataSourceId.toString()).callAPI
       : this.osDriver.asScoped(request).callAsCurrentUser;
+  }
+
+  protected async checkWorkspaceAcl(context: RequestHandlerContext, request: OpenSearchDashboardsRequest, permissionModes: string[] = ['read']): Promise<boolean> {
+    // Only run workspace ACL check for serverless (AOSS) data sources
+    const dataSourceId = (request.query as any).dataSourceId;
+    if (dataSourceId) {
+      const savedObjectsClient = context.core.savedObjects.client;
+      const dataSource = await savedObjectsClient.get('data-source', dataSourceId.toString());
+      const endpoint = (dataSource.attributes as any).endpoint as string;
+      if (!endpoint.includes('.aoss.amazonaws.com')) {
+        return true;
+      }
+    } else {
+      return true;
+    }
+
+    const principal = request.headers['x-amzn-aosd-username'] as string;
+    const workspaceId = getWorkspaceState(request).requestWorkspaceId;
+
+    if (!principal || !workspaceId || !this.workspaceStart) {
+      return true;
+    }
+
+    const result = await this.workspaceStart.authorizeWorkspace(request, [workspaceId], principal, permissionModes);
+    this.logger?.info(`Workspace ACL check: workspace=${workspaceId}, authorized=${result.authorized}, permissionModes=${permissionModes.join(',')}`);
+    return result.authorized;
   }
 }

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -37,6 +37,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   createWorkflow = async (context, req, res) => {
     try {
+      const notSupported = await this.rejectIfUnsupported(context, req, res);
+      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const params = { body: req.body };
@@ -86,6 +88,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteWorkflow = async (context, req, res) => {
     try {
+      const notSupported = await this.rejectIfUnsupported(context, req, res);
+      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
@@ -198,6 +202,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getWorkflow = async (context, req, res) => {
     try {
+      const notSupported = await this.rejectIfUnsupported(context, req, res);
+      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
@@ -561,6 +567,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeChainedAlerts = async (context, req, res) => {
     try {
+      const notSupported = await this.rejectIfUnsupported(context, req, res);
+      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -11,8 +11,23 @@ import { MDSEnabledClientService } from './MDSEnabledClientService';
 import { DEFAULT_HEADERS } from './utils/constants';
 
 export default class MonitorService extends MDSEnabledClientService {
+
+  /**
+   * Checks workspace ACL and returns an unauthorized response if check fails.
+   * Returns null if authorized, or a response object if unauthorized.
+   */
+  _enforceWorkspaceAcl = async (context, req, res, permissionModes) => {
+    const authorized = await this.checkWorkspaceAcl(context, req, permissionModes);
+    if (!authorized) {
+      return res.ok({ body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' } });
+    }
+    return null;
+  };
+
   createMonitor = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const params = { body: req.body };
       const client = this.getClientBasedOnDataSource(context, req);
       const createResponse = await client('alerting.createMonitor', params);
@@ -35,6 +50,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   createWorkflow = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const params = { body: req.body };
       const client = this.getClientBasedOnDataSource(context, req);
       const createResponse = await client('alerting.createWorkflow', params);
@@ -57,6 +74,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteMonitor = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -80,6 +99,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteWorkflow = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { workflowId: id };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -103,6 +124,11 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitor = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+        'library_write',
+        'library_read',
+      ]);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id, headers: DEFAULT_HEADERS };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -185,6 +211,11 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getWorkflow = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+        'library_write',
+        'library_read',
+      ]);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -225,6 +256,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   updateMonitor = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id, body: req.body, refresh: 'wait_for' };
       const { type } = req.body;
@@ -262,6 +295,11 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitors = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+        'library_write',
+        'library_read',
+      ]);
+      if (aclResponse) return aclResponse;
       const { from, size, search, sortDirection, sortField, state, monitorIds } = req.query;
 
       let must = { match_all: {} };
@@ -508,6 +546,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeAlerts = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = {
         monitorId: id,
@@ -534,6 +574,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeChainedAlerts = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = {
         workflowId: id,
@@ -565,6 +607,8 @@ export default class MonitorService extends MDSEnabledClientService {
 
   executeMonitor = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      if (aclResponse) return aclResponse;
       const { dryrun = 'true' } = req.query;
       const params = {
         body: req.body,
@@ -592,6 +636,11 @@ export default class MonitorService extends MDSEnabledClientService {
   //TODO: This is temporarily a pass through call which needs to be deprecated
   searchMonitors = async (context, req, res) => {
     try {
+      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+        'library_write',
+        'library_read',
+      ]);
+      if (aclResponse) return aclResponse;
       const { query: queryBody, index, size, ...rest } = req.body || {};
       const body = { ...(queryBody ?? {}), ...rest };
       if (size !== undefined) {

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -11,22 +11,9 @@ import { MDSEnabledClientService } from './MDSEnabledClientService';
 import { DEFAULT_HEADERS } from './utils/constants';
 
 export default class MonitorService extends MDSEnabledClientService {
-
-  /**
-   * Checks workspace ACL and returns an unauthorized response if check fails.
-   * Returns null if authorized, or a response object if unauthorized.
-   */
-  _enforceWorkspaceAcl = async (context, req, res, permissionModes) => {
-    const authorized = await this.checkWorkspaceAcl(context, req, permissionModes);
-    if (!authorized) {
-      return res.ok({ body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' } });
-    }
-    return null;
-  };
-
   createMonitor = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const params = { body: req.body };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -50,7 +37,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   createWorkflow = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const params = { body: req.body };
       const client = this.getClientBasedOnDataSource(context, req);
@@ -74,7 +61,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteMonitor = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id };
@@ -99,7 +86,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteWorkflow = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { workflowId: id };
@@ -124,7 +111,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitor = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
       ]);
@@ -211,7 +198,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getWorkflow = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
       ]);
@@ -256,7 +243,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   updateMonitor = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = { monitorId: id, body: req.body, refresh: 'wait_for' };
@@ -295,7 +282,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getMonitors = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
       ]);
@@ -546,7 +533,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeAlerts = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = {
@@ -574,7 +561,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeChainedAlerts = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
       const params = {
@@ -607,7 +594,7 @@ export default class MonitorService extends MDSEnabledClientService {
 
   executeMonitor = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, ['library_write']);
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { dryrun = 'true' } = req.query;
       const params = {
@@ -636,7 +623,7 @@ export default class MonitorService extends MDSEnabledClientService {
   //TODO: This is temporarily a pass through call which needs to be deprecated
   searchMonitors = async (context, req, res) => {
     try {
-      const aclResponse = await this._enforceWorkspaceAcl(context, req, res, [
+      const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
       ]);

--- a/server/services/MonitorService.js
+++ b/server/services/MonitorService.js
@@ -37,8 +37,6 @@ export default class MonitorService extends MDSEnabledClientService {
 
   createWorkflow = async (context, req, res) => {
     try {
-      const notSupported = await this.rejectIfUnsupported(context, req, res);
-      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const params = { body: req.body };
@@ -88,8 +86,6 @@ export default class MonitorService extends MDSEnabledClientService {
 
   deleteWorkflow = async (context, req, res) => {
     try {
-      const notSupported = await this.rejectIfUnsupported(context, req, res);
-      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;
@@ -202,8 +198,6 @@ export default class MonitorService extends MDSEnabledClientService {
 
   getWorkflow = async (context, req, res) => {
     try {
-      const notSupported = await this.rejectIfUnsupported(context, req, res);
-      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, [
         'library_write',
         'library_read',
@@ -567,8 +561,6 @@ export default class MonitorService extends MDSEnabledClientService {
 
   acknowledgeChainedAlerts = async (context, req, res) => {
     try {
-      const notSupported = await this.rejectIfUnsupported(context, req, res);
-      if (notSupported) return notSupported;
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const { id } = req.params;

--- a/server/services/WorkspaceAcl.test.js
+++ b/server/services/WorkspaceAcl.test.js
@@ -1,12 +1,5 @@
 // Mock core server modules that MDSEnabledClientService imports
 jest.mock('../../../../src/core/server', () => ({}), { virtual: true });
-jest.mock(
-  '../alerting_configs.json',
-  () => ({
-    'ws.acl.enforce.endpoint.patterns': ['.aoss.amazonaws.com'],
-  }),
-  { virtual: true }
-);
 
 import MonitorService from './MonitorService';
 import AlertService from './AlertService';
@@ -34,6 +27,7 @@ const createMockReq = (overrides = {}) => ({
 const createMockRes = () => ({
   ok: jest.fn((payload) => payload),
   unauthorized: jest.fn((payload) => ({ unauthorized: true, ...payload })),
+  custom: jest.fn((payload) => ({ custom: true, ...payload })),
 });
 
 const setupService = (ServiceClass, { authorized = true } = {}) => {
@@ -41,7 +35,10 @@ const setupService = (ServiceClass, { authorized = true } = {}) => {
   service.getClientBasedOnDataSource = jest.fn().mockReturnValue(jest.fn().mockResolvedValue({}));
 
   const mockAuthorizeWorkspace = jest.fn().mockResolvedValue({ authorized });
-  service.setWorkspaceStart({ authorizeWorkspace: mockAuthorizeWorkspace });
+  service.setWorkspaceStart({
+    authorizeWorkspace: mockAuthorizeWorkspace,
+    aclEnforceEndpointPatterns: ['.aoss.amazonaws.com'],
+  });
   service.setWorkspaceIdGetter(() => 'ws-1');
 
   return { service, mockAuthorizeWorkspace };
@@ -104,6 +101,21 @@ describe('Workspace ACL checks', () => {
       const result = await service.checkWorkspaceAcl(context, req, ['read']);
       expect(result).toBe(true);
     });
+
+    it('should skip ACL check when aclEnforceEndpointPatterns is empty', async () => {
+      const service = new MonitorService();
+      service.getClientBasedOnDataSource = jest.fn().mockReturnValue(jest.fn());
+      service.setWorkspaceStart({
+        authorizeWorkspace: jest.fn(),
+        aclEnforceEndpointPatterns: [],
+      });
+      service.setWorkspaceIdGetter(() => 'ws-1');
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.checkWorkspaceAcl(context, req, ['read']);
+      expect(result).toBe(true);
+    });
   });
 
   describe('enforceWorkspaceAcl (parent method)', () => {
@@ -127,12 +139,88 @@ describe('Workspace ACL checks', () => {
     });
   });
 
+  describe('rejectIfUnsupported', () => {
+    it('should return 501 for AOSS endpoints', async () => {
+      const { service } = setupService(MonitorService);
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq();
+
+      await service.rejectIfUnsupported(context, req, mockRes);
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    });
+
+    it('should return undefined for non-AOSS endpoints', async () => {
+      const { service } = setupService(MonitorService);
+      const context = createMockContext('https://search-domain.us-west-2.es.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.rejectIfUnsupported(context, req, mockRes);
+      expect(result).toBeUndefined();
+      expect(mockRes.custom).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined when no dataSourceId', async () => {
+      const { service } = setupService(MonitorService);
+      const context = createMockContext();
+      const req = createMockReq({ query: { dataSourceId: undefined } });
+
+      const result = await service.rejectIfUnsupported(context, req, mockRes);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('MonitorService - unsupported APIs return 501 for AOSS', () => {
+    let service;
+
+    beforeEach(() => {
+      ({ service } = setupService(MonitorService));
+      service.isUnsupportedEndpoint = jest.fn().mockResolvedValue(true);
+    });
+
+    it('createWorkflow should return 501', async () => {
+      const req = createMockReq({ body: { name: 'test' } });
+      await service.createWorkflow({}, req, mockRes);
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    });
+
+    it('deleteWorkflow should return 501', async () => {
+      await service.deleteWorkflow({}, createMockReq(), mockRes);
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    });
+
+    it('getWorkflow should return 501', async () => {
+      await service.getWorkflow({}, createMockReq(), mockRes);
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    });
+
+    it('acknowledgeChainedAlerts should return 501', async () => {
+      await service.acknowledgeChainedAlerts({}, createMockReq(), mockRes);
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported' },
+      });
+    });
+  });
+
   describe('MonitorService - API methods block unauthorized requests', () => {
     let service;
 
     beforeEach(() => {
       ({ service } = setupService(MonitorService));
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
+      service.isUnsupportedEndpoint = jest.fn().mockResolvedValue(false);
     });
 
     it('createMonitor should block', async () => {
@@ -234,6 +322,7 @@ describe('Workspace ACL checks', () => {
     it('createMonitor should proceed when authorized', async () => {
       const { service } = setupService(MonitorService);
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
+      service.isUnsupportedEndpoint = jest.fn().mockResolvedValue(false);
       const mockClient = jest.fn().mockResolvedValue({ _id: 'mon-1', _version: 1 });
       service.getClientBasedOnDataSource = jest.fn().mockReturnValue(mockClient);
 

--- a/server/services/WorkspaceAcl.test.js
+++ b/server/services/WorkspaceAcl.test.js
@@ -1,12 +1,8 @@
 // Mock core server modules that MDSEnabledClientService imports
 jest.mock('../../../../src/core/server', () => ({}), { virtual: true });
-jest.mock('../../../../src/core/server/utils', () => ({
-  getWorkspaceState: jest.fn(),
-}));
 
 import MonitorService from './MonitorService';
 import AlertService from './AlertService';
-import { getWorkspaceState } from '../../../../src/core/server/utils';
 
 const createMockContext = (endpoint = 'https://col.us-west-2.aoss.amazonaws.com') => ({
   core: {
@@ -41,9 +37,8 @@ const setupService = (ServiceClass, { authorized = true, endpoint } = {}) => {
 
   const mockAuthorizeWorkspace = jest.fn().mockResolvedValue({ authorized });
   service.setWorkspaceStart({ authorizeWorkspace: mockAuthorizeWorkspace });
+  service.setWorkspaceIdGetter(() => 'ws-1');
 
-  // Mock checkWorkspaceAcl to control behavior directly for API-level tests
-  // For checkWorkspaceAcl unit tests, we test the real implementation
   return { service, mockAuthorizeWorkspace };
 };
 
@@ -52,7 +47,6 @@ describe('Workspace ACL checks', () => {
 
   beforeEach(() => {
     mockRes = createMockRes();
-    getWorkspaceState.mockReturnValue({ requestWorkspaceId: 'ws-1' });
   });
 
   describe('checkWorkspaceAcl', () => {

--- a/server/services/WorkspaceAcl.test.js
+++ b/server/services/WorkspaceAcl.test.js
@@ -172,45 +172,21 @@ describe('Workspace ACL checks', () => {
     });
   });
 
-  describe('MonitorService - unsupported APIs return 501 for AOSS', () => {
-    let service;
+  describe('rejectIfUnsupported route guard', () => {
+    it('should reject when endpoint is unsupported', async () => {
+      const { service } = setupService(MonitorService);
+      service.rejectIfUnsupported = jest.fn().mockResolvedValue({ statusCode: 501 });
+      const handler = jest.fn();
 
-    beforeEach(() => {
-      ({ service } = setupService(MonitorService));
-      service.isUnsupportedEndpoint = jest.fn().mockResolvedValue(true);
+      const rejected = await service.rejectIfUnsupported({}, createMockReq(), mockRes);
+      expect(rejected).toEqual({ statusCode: 501 });
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    it('createWorkflow should return 501', async () => {
-      const req = createMockReq({ body: { name: 'test' } });
-      await service.createWorkflow({}, req, mockRes);
-      expect(mockRes.custom).toHaveBeenCalledWith({
-        statusCode: 501,
-        body: { message: 'This operation is not supported' },
-      });
-    });
-
-    it('deleteWorkflow should return 501', async () => {
-      await service.deleteWorkflow({}, createMockReq(), mockRes);
-      expect(mockRes.custom).toHaveBeenCalledWith({
-        statusCode: 501,
-        body: { message: 'This operation is not supported' },
-      });
-    });
-
-    it('getWorkflow should return 501', async () => {
-      await service.getWorkflow({}, createMockReq(), mockRes);
-      expect(mockRes.custom).toHaveBeenCalledWith({
-        statusCode: 501,
-        body: { message: 'This operation is not supported' },
-      });
-    });
-
-    it('acknowledgeChainedAlerts should return 501', async () => {
-      await service.acknowledgeChainedAlerts({}, createMockReq(), mockRes);
-      expect(mockRes.custom).toHaveBeenCalledWith({
-        statusCode: 501,
-        body: { message: 'This operation is not supported' },
-      });
+    it('should pass through when endpoint is supported', async () => {
+      const { service } = setupService(MonitorService);
+      const result = await service.rejectIfUnsupported({}, createMockReq(), mockRes);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/server/services/WorkspaceAcl.test.js
+++ b/server/services/WorkspaceAcl.test.js
@@ -1,0 +1,325 @@
+// Mock core server modules that MDSEnabledClientService imports
+jest.mock('../../../../src/core/server', () => ({}), { virtual: true });
+jest.mock('../../../../src/core/server/utils', () => ({
+  getWorkspaceState: jest.fn(),
+}));
+
+import MonitorService from './MonitorService';
+import AlertService from './AlertService';
+import { getWorkspaceState } from '../../../../src/core/server/utils';
+
+const createMockContext = (endpoint = 'https://col.us-west-2.aoss.amazonaws.com') => ({
+  core: {
+    savedObjects: {
+      client: {
+        get: jest.fn().mockResolvedValue({
+          attributes: { endpoint },
+          workspaces: ['ws-1'],
+        }),
+      },
+    },
+  },
+});
+
+const createMockReq = (overrides = {}) => ({
+  query: { dataSourceId: 'ds-1', ...overrides.query },
+  params: { id: 'mon-1', ...overrides.params },
+  body: overrides.body || {},
+  headers: {
+    'x-amzn-aosd-username': 'arn:aws:sts::123456:assumed-role/Admin/user1',
+    ...overrides.headers,
+  },
+});
+
+const createMockRes = () => ({
+  ok: jest.fn((payload) => payload),
+});
+
+const setupService = (ServiceClass, { authorized = true, endpoint } = {}) => {
+  const service = new ServiceClass();
+  service.getClientBasedOnDataSource = jest.fn().mockReturnValue(jest.fn().mockResolvedValue({}));
+
+  const mockAuthorizeWorkspace = jest.fn().mockResolvedValue({ authorized });
+  service.setWorkspaceStart({ authorizeWorkspace: mockAuthorizeWorkspace });
+
+  // Mock checkWorkspaceAcl to control behavior directly for API-level tests
+  // For checkWorkspaceAcl unit tests, we test the real implementation
+  return { service, mockAuthorizeWorkspace };
+};
+
+describe('Workspace ACL checks', () => {
+  let mockRes;
+
+  beforeEach(() => {
+    mockRes = createMockRes();
+    getWorkspaceState.mockReturnValue({ requestWorkspaceId: 'ws-1' });
+  });
+
+  describe('checkWorkspaceAcl', () => {
+    it('should skip ACL check when no dataSourceId is present', async () => {
+      const { service } = setupService(MonitorService, { authorized: false });
+      const context = createMockContext();
+      const req = createMockReq({ query: { dataSourceId: undefined } });
+
+      const result = await service.checkWorkspaceAcl(context, req, ['read']);
+      expect(result).toBe(true);
+    });
+
+    it('should skip ACL check for non-AOSS (managed domain) endpoints', async () => {
+      const { service } = setupService(MonitorService, { authorized: false });
+      const context = createMockContext('https://search-domain.us-west-2.es.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.checkWorkspaceAcl(context, req, ['read']);
+      expect(result).toBe(true);
+    });
+
+    it('should run ACL check for AOSS endpoints and return true when authorized', async () => {
+      const { service, mockAuthorizeWorkspace } = setupService(MonitorService, {
+        authorized: true,
+      });
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.checkWorkspaceAcl(context, req, ['library_read']);
+      expect(result).toBe(true);
+      expect(mockAuthorizeWorkspace).toHaveBeenCalledWith(
+        req,
+        ['ws-1'],
+        'arn:aws:sts::123456:assumed-role/Admin/user1',
+        ['library_read']
+      );
+    });
+
+    it('should return false when workspace authorization fails for AOSS', async () => {
+      const { service } = setupService(MonitorService, { authorized: false });
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.checkWorkspaceAcl(context, req, ['library_read']);
+      expect(result).toBe(false);
+    });
+
+    it('should skip ACL check when no principal header', async () => {
+      const { service } = setupService(MonitorService, { authorized: false });
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq({ headers: { 'x-amzn-aosd-username': undefined } });
+
+      const result = await service.checkWorkspaceAcl(context, req, ['read']);
+      // Will return true because principal is falsy
+      expect(result).toBe(true);
+    });
+
+    it('should skip ACL check when workspaceStart is not set', async () => {
+      const service = new MonitorService();
+      service.getClientBasedOnDataSource = jest.fn().mockReturnValue(jest.fn());
+      // Don't call setWorkspaceStart
+      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
+      const req = createMockReq();
+
+      const result = await service.checkWorkspaceAcl(context, req, ['read']);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('MonitorService - _enforceWorkspaceAcl', () => {
+    it('should return null when checkWorkspaceAcl returns true', async () => {
+      const { service } = setupService(MonitorService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
+
+      const result = await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
+      expect(result).toBeNull();
+      expect(mockRes.ok).not.toHaveBeenCalled();
+    });
+
+    it('should return unauthorized response when checkWorkspaceAcl returns false', async () => {
+      const { service } = setupService(MonitorService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
+
+      await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+  });
+
+  describe('MonitorService - API methods block unauthorized requests', () => {
+    let service;
+
+    beforeEach(() => {
+      ({ service } = setupService(MonitorService));
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
+    });
+
+    it('createMonitor should block', async () => {
+      const req = createMockReq({ body: { name: 'test' } });
+      await service.createMonitor({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('createWorkflow should block', async () => {
+      const req = createMockReq({ body: { name: 'test' } });
+      await service.createWorkflow({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('deleteMonitor should block', async () => {
+      await service.deleteMonitor({}, createMockReq(), mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('deleteWorkflow should block', async () => {
+      await service.deleteWorkflow({}, createMockReq(), mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('getMonitor should block', async () => {
+      await service.getMonitor({}, createMockReq(), mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('getWorkflow should block', async () => {
+      await service.getWorkflow({}, createMockReq(), mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('updateMonitor should block', async () => {
+      const req = createMockReq({ body: { type: 'monitor' } });
+      await service.updateMonitor({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('getMonitors should block', async () => {
+      const req = createMockReq({
+        query: {
+          dataSourceId: 'ds-1',
+          from: 0,
+          size: 20,
+          search: '',
+          sortDirection: 'desc',
+          sortField: 'name',
+          state: 'all',
+        },
+      });
+      await service.getMonitors({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('acknowledgeAlerts should block', async () => {
+      const req = createMockReq({ body: { alerts: [] } });
+      await service.acknowledgeAlerts({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('executeMonitor should block', async () => {
+      const req = createMockReq({ body: {} });
+      await service.executeMonitor({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('searchMonitors should block', async () => {
+      const req = createMockReq({ body: {} });
+      await service.searchMonitors({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+  });
+
+  describe('MonitorService - API methods allow authorized requests', () => {
+    it('createMonitor should proceed when authorized', async () => {
+      const { service } = setupService(MonitorService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
+      const mockClient = jest.fn().mockResolvedValue({ _id: 'mon-1', _version: 1 });
+      service.getClientBasedOnDataSource = jest.fn().mockReturnValue(mockClient);
+
+      const req = createMockReq({ body: { name: 'test' } });
+      await service.createMonitor({}, req, mockRes);
+      expect(mockClient).toHaveBeenCalledWith('alerting.createMonitor', { body: { name: 'test' } });
+    });
+  });
+
+  describe('AlertService - _enforceWorkspaceAcl', () => {
+    it('should return null when authorized', async () => {
+      const { service } = setupService(AlertService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
+
+      const result = await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
+      expect(result).toBeNull();
+    });
+
+    it('should return unauthorized response when not authorized', async () => {
+      const { service } = setupService(AlertService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
+
+      await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+  });
+
+  describe('AlertService - API methods block unauthorized requests', () => {
+    let service;
+
+    beforeEach(() => {
+      ({ service } = setupService(AlertService));
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
+    });
+
+    it('getAlerts should block', async () => {
+      const req = createMockReq({ query: { dataSourceId: 'ds-1' } });
+      await service.getAlerts({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+
+    it('getWorkflowAlerts should block', async () => {
+      const req = createMockReq({ query: { dataSourceId: 'ds-1' } });
+      await service.getWorkflowAlerts({}, req, mockRes);
+      expect(mockRes.ok).toHaveBeenCalledWith({
+        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      });
+    });
+  });
+
+  describe('AlertService - API methods allow authorized requests', () => {
+    it('getAlerts should proceed when authorized', async () => {
+      const { service } = setupService(AlertService);
+      service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
+      const mockClient = jest
+        .fn()
+        .mockResolvedValueOnce({ alerts: [], totalAlerts: 0 })
+        .mockResolvedValueOnce({ hits: { hits: [] } });
+      service.getClientBasedOnDataSource = jest.fn().mockReturnValue(mockClient);
+
+      const req = createMockReq({ query: { dataSourceId: 'ds-1' } });
+      await service.getAlerts({}, req, mockRes);
+      expect(mockClient).toHaveBeenCalled();
+      expect(mockRes.ok).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.objectContaining({ ok: true }) })
+      );
+    });
+  });
+});

--- a/server/services/WorkspaceAcl.test.js
+++ b/server/services/WorkspaceAcl.test.js
@@ -1,5 +1,12 @@
 // Mock core server modules that MDSEnabledClientService imports
 jest.mock('../../../../src/core/server', () => ({}), { virtual: true });
+jest.mock(
+  '../alerting_configs.json',
+  () => ({
+    'ws.acl.enforce.endpoint.patterns': ['.aoss.amazonaws.com'],
+  }),
+  { virtual: true }
+);
 
 import MonitorService from './MonitorService';
 import AlertService from './AlertService';
@@ -21,17 +28,15 @@ const createMockReq = (overrides = {}) => ({
   query: { dataSourceId: 'ds-1', ...overrides.query },
   params: { id: 'mon-1', ...overrides.params },
   body: overrides.body || {},
-  headers: {
-    'x-amzn-aosd-username': 'arn:aws:sts::123456:assumed-role/Admin/user1',
-    ...overrides.headers,
-  },
+  headers: overrides.headers || {},
 });
 
 const createMockRes = () => ({
   ok: jest.fn((payload) => payload),
+  unauthorized: jest.fn((payload) => ({ unauthorized: true, ...payload })),
 });
 
-const setupService = (ServiceClass, { authorized = true, endpoint } = {}) => {
+const setupService = (ServiceClass, { authorized = true } = {}) => {
   const service = new ServiceClass();
   service.getClientBasedOnDataSource = jest.fn().mockReturnValue(jest.fn().mockResolvedValue({}));
 
@@ -77,12 +82,7 @@ describe('Workspace ACL checks', () => {
 
       const result = await service.checkWorkspaceAcl(context, req, ['library_read']);
       expect(result).toBe(true);
-      expect(mockAuthorizeWorkspace).toHaveBeenCalledWith(
-        req,
-        ['ws-1'],
-        'arn:aws:sts::123456:assumed-role/Admin/user1',
-        ['library_read']
-      );
+      expect(mockAuthorizeWorkspace).toHaveBeenCalledWith(req, ['ws-1'], ['library_read']);
     });
 
     it('should return false when workspace authorization fails for AOSS', async () => {
@@ -92,16 +92,6 @@ describe('Workspace ACL checks', () => {
 
       const result = await service.checkWorkspaceAcl(context, req, ['library_read']);
       expect(result).toBe(false);
-    });
-
-    it('should skip ACL check when no principal header', async () => {
-      const { service } = setupService(MonitorService, { authorized: false });
-      const context = createMockContext('https://col.us-west-2.aoss.amazonaws.com');
-      const req = createMockReq({ headers: { 'x-amzn-aosd-username': undefined } });
-
-      const result = await service.checkWorkspaceAcl(context, req, ['read']);
-      // Will return true because principal is falsy
-      expect(result).toBe(true);
     });
 
     it('should skip ACL check when workspaceStart is not set', async () => {
@@ -116,23 +106,23 @@ describe('Workspace ACL checks', () => {
     });
   });
 
-  describe('MonitorService - _enforceWorkspaceAcl', () => {
-    it('should return null when checkWorkspaceAcl returns true', async () => {
+  describe('enforceWorkspaceAcl (parent method)', () => {
+    it('should return undefined when checkWorkspaceAcl returns true', async () => {
       const { service } = setupService(MonitorService);
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
 
-      const result = await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
-      expect(result).toBeNull();
-      expect(mockRes.ok).not.toHaveBeenCalled();
+      const result = await service.enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
+      expect(result).toBeUndefined();
+      expect(mockRes.unauthorized).not.toHaveBeenCalled();
     });
 
     it('should return unauthorized response when checkWorkspaceAcl returns false', async () => {
       const { service } = setupService(MonitorService);
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
 
-      await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      await service.enforceWorkspaceAcl({}, {}, mockRes, ['library_write']);
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
   });
@@ -148,52 +138,52 @@ describe('Workspace ACL checks', () => {
     it('createMonitor should block', async () => {
       const req = createMockReq({ body: { name: 'test' } });
       await service.createMonitor({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('createWorkflow should block', async () => {
       const req = createMockReq({ body: { name: 'test' } });
       await service.createWorkflow({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('deleteMonitor should block', async () => {
       await service.deleteMonitor({}, createMockReq(), mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('deleteWorkflow should block', async () => {
       await service.deleteWorkflow({}, createMockReq(), mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('getMonitor should block', async () => {
       await service.getMonitor({}, createMockReq(), mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('getWorkflow should block', async () => {
       await service.getWorkflow({}, createMockReq(), mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('updateMonitor should block', async () => {
       const req = createMockReq({ body: { type: 'monitor' } });
       await service.updateMonitor({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
@@ -210,32 +200,32 @@ describe('Workspace ACL checks', () => {
         },
       });
       await service.getMonitors({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('acknowledgeAlerts should block', async () => {
       const req = createMockReq({ body: { alerts: [] } });
       await service.acknowledgeAlerts({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('executeMonitor should block', async () => {
       const req = createMockReq({ body: {} });
       await service.executeMonitor({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('searchMonitors should block', async () => {
       const req = createMockReq({ body: {} });
       await service.searchMonitors({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
   });
@@ -253,22 +243,22 @@ describe('Workspace ACL checks', () => {
     });
   });
 
-  describe('AlertService - _enforceWorkspaceAcl', () => {
-    it('should return null when authorized', async () => {
+  describe('AlertService - enforceWorkspaceAcl', () => {
+    it('should return undefined when authorized', async () => {
       const { service } = setupService(AlertService);
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(true);
 
-      const result = await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
-      expect(result).toBeNull();
+      const result = await service.enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
+      expect(result).toBeUndefined();
     });
 
     it('should return unauthorized response when not authorized', async () => {
       const { service } = setupService(AlertService);
       service.checkWorkspaceAcl = jest.fn().mockResolvedValue(false);
 
-      await service._enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      await service.enforceWorkspaceAcl({}, {}, mockRes, ['library_read']);
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
   });
@@ -284,16 +274,16 @@ describe('Workspace ACL checks', () => {
     it('getAlerts should block', async () => {
       const req = createMockReq({ query: { dataSourceId: 'ds-1' } });
       await service.getAlerts({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
 
     it('getWorkflowAlerts should block', async () => {
       const req = createMockReq({ query: { dataSourceId: 'ds-1' } });
       await service.getWorkflowAlerts({}, req, mockRes);
-      expect(mockRes.ok).toHaveBeenCalledWith({
-        body: { ok: false, resp: 'Workspace ACL check failed: unauthorized' },
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
       });
     });
   });


### PR DESCRIPTION
### Description                                                                                                                                                                                                    
                                                                                                                                                                                                                     
  Add workspace ACL authorization checks to all Alerting and Monitor server-side APIs to enforce workspace-level access control for OpenSearch Serverless (AOSS) data sources.                                       
                                                                                                                                                                                                                     
  **Changes:**                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - `MDSEnabledClientService.ts` — Added `checkWorkspaceAcl()` method that:                                                                                                                                          
    - Only runs for AOSS (`.aoss.amazonaws.com`) data source endpoints; skips for managed domains                                                                                                                    
    - Extracts the calling principal from `x-amzn-aosd-username` header and workspace ID from request state                                                                                                          
    - Delegates authorization to the workspace plugin's `authorizeWorkspace()` via the `WorkspacePluginStart` contract                                                                                               
    - Uses a local `WorkspaceAuthorizer` interface (structural typing) to avoid non-public import restrictions                                                                                                       
    - Added `setLogger()` for production-ready logging instead of `console.log`                                                                                                                                      
                                                                                                                                                                                                                     
  - `MonitorService.js` — Added `_enforceWorkspaceAcl()` helper and ACL checks to all API methods:                                                                                                                   
    - Write operations (`createMonitor`, `createWorkflow`, `deleteMonitor`, `deleteWorkflow`, `updateMonitor`, `executeMonitor`, `acknowledgeAlerts`, `acknowledgeChainedAlerts`): require `library_write`           
    - Read operations (`getMonitor`, `getMonitors`, `getWorkflow`, `searchMonitors`): require `library_write` or `library_read`                                                                                      
                                                                                                                                                                                                                     
  - `AlertService.js` — Added same ACL pattern to `getAlerts` and `getWorkflowAlerts`                                                                                                                                
                                                                                                                                                                                                                     
  - `plugin.js` — Updated `start()` to inject workspace plugin start contract and logger into all services                                                                                                           
                                                                                                                                                                                                                     
  - `opensearch_dashboards.json` — Added `workspace` to `optionalPlugins`                                                                                                                                            
                                                                                                                                                                                                                     
  ### Issues Resolved                                                                                                                                                                                                
                                                                                                                                                                                                                     
  <!-- List any issues this PR will resolve -->                                                                                                                                                                      
                                                                                                                                                                                                                     
  ### Check List                                                                                                                                                                                                     
  - [x] New functionality includes testing.                                                                                                                                                                          
    - [x] All tests pass                                                                                                                                                                                             
  - [x] New functionality has been documented.                                                                                                                                                                       
    - [x] New functionality has javadoc added                                                                                                                                                                        
  - [x] Commits are signed per the DCO using --signoff                                                                                                                                                               
                                                                                                                                                                                                                     
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.                                                                                                 
  For more information on following Developer Certificate of Origin and signing off your commits, please check                                                                                                       
  [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).                                                                                
     