### PR TITLE
[Navigation] Add icon side nav support for alerting plugin

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -119,17 +119,15 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     });
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
-      const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
-
-      // register applications with category and use case information
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-        {
-          id: PLUGIN_NAME,
-          category: enableIconSideNav ? undefined : DEFAULT_APP_CATEGORIES.detect,
-          showInAllNavGroup: false,
-          ...(enableIconSideNav ? { order: 200, title: 'Alerts', euiIconType: 'navAlerting' } : {}),
-        }
-      ])
+      if (!core.chrome.getIsIconSideNavEnabled()) {
+        core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+          {
+            id: PLUGIN_NAME,
+            category: DEFAULT_APP_CATEGORIES.detect,
+            showInAllNavGroup: false
+          }
+        ]);
+      }
 
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS['security-analytics'], [
         {
@@ -202,10 +200,22 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
         },
       ];
 
-      core.chrome.navGroup.addNavLinksToGroup(
-        DEFAULT_NAV_GROUPS.observability,
-        navLinks
-      );
+      if (core.chrome.getIsIconSideNavEnabled()) {
+        core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+          {
+            id: PLUGIN_NAME,
+            category: DEFAULT_APP_CATEGORIES.observabilityTools,
+            order: 8000,
+            euiIconType: 'bell',
+          },
+          ...navLinks,
+        ]);
+      } else {
+        core.chrome.navGroup.addNavLinksToGroup(
+          DEFAULT_NAV_GROUPS.observability,
+          navLinks
+        );
+      }
 
       core.chrome.navGroup.addNavLinksToGroup(
         DEFAULT_NAV_GROUPS['security-analytics'],

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -119,12 +119,15 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
     });
 
     if (core.chrome.navGroup.getNavGroupEnabled()) {
+      const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
+
       // register applications with category and use case information
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
         {
           id: PLUGIN_NAME,
-          category: DEFAULT_APP_CATEGORIES.detect,
-          showInAllNavGroup: false
+          category: enableIconSideNav ? undefined : DEFAULT_APP_CATEGORIES.detect,
+          showInAllNavGroup: false,
+          ...(enableIconSideNav ? { order: 200, title: 'Alerts', euiIconType: 'navAlerting' } : {}),
         }
       ])
 

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -4,8 +4,20 @@
  */
 
 import { coreMock } from '../../../src/core/public/mocks';
-import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/utils';
 import { AlertingPlugin } from './plugin';
+
+jest.mock('@osd/monaco', () => ({
+  monaco: {
+    languages: {
+      CompletionItemKind: { Function: 1, Field: 4, Module: 6, Operator: 12, Keyword: 14 },
+      CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+      registerCompletionItemProvider: jest.fn(),
+    },
+    editor: { create: jest.fn(), defineTheme: jest.fn() },
+    Range: jest.fn(),
+  },
+}));
 
 // Mock dynamic imports used in mount functions
 jest.mock('./app', () => ({

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../src/core/public/mocks';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { AlertingPlugin } from './plugin';
+
+// Mock dynamic imports used in mount functions
+jest.mock('./app', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+
+describe('AlertingPlugin nav registration', () => {
+  let coreSetup: ReturnType<typeof coreMock.createSetup>;
+  let plugin: AlertingPlugin;
+
+  const mockSetupDeps = {
+    expressions: { registerFunction: jest.fn() },
+    uiActions: {
+      addTriggerAction: jest.fn(),
+      registerTrigger: jest.fn(),
+    },
+    dataSourceManagement: {},
+    dataSource: {},
+  } as any;
+
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup();
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    plugin = new AlertingPlugin();
+  });
+
+  it('should not register alerting in observability detect category when icon side nav ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    plugin.setup(coreSetup, mockSetupDeps);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // With icon side nav ON, alerting should NOT be added to observability with detect category
+    const observabilityDetectCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.observability &&
+        call[1].some(
+          (link: any) =>
+            link.id === 'alerting' && link.category === DEFAULT_APP_CATEGORIES.detect
+        )
+    );
+    expect(observabilityDetectCall).toBeUndefined();
+
+    // Instead, it should be registered with observabilityTools category and bell icon
+    const observabilityToolsCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.observability &&
+        call[1].some(
+          (link: any) =>
+            link.id === 'alerting' &&
+            link.category === DEFAULT_APP_CATEGORIES.observabilityTools &&
+            link.euiIconType === 'bell'
+        )
+    );
+    expect(observabilityToolsCall).toBeDefined();
+  });
+
+  it('should register alerting in observability detect category when icon side nav OFF', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    plugin.setup(coreSetup, mockSetupDeps);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // With icon side nav OFF, alerting SHOULD be added to observability with detect category
+    const observabilityDetectCall = calls.find(
+      (call: any) =>
+        call[0] === DEFAULT_NAV_GROUPS.observability &&
+        call[1].some(
+          (link: any) =>
+            link.id === 'alerting' && link.category === DEFAULT_APP_CATEGORIES.detect
+        )
+    );
+    expect(observabilityDetectCall).toBeDefined();
+  });
+});

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -41,6 +41,9 @@ describe('AlertingPlugin nav registration', () => {
   beforeEach(() => {
     coreSetup = coreMock.createSetup();
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+      coreSetup.chrome.getIsIconSideNavEnabled = jest.fn();
+    }
     plugin = new AlertingPlugin();
   });
 


### PR DESCRIPTION
## Summary

Adds support for the new icon-based sidebar navigation in the Observability workspace, part of the OSD modern side nav initiative.

**Changes:**
- Use `core.chrome.getIsIconSideNavEnabled()` API instead of reading `home:enableIconSideNav` UI setting directly
- When icon side nav is **enabled**: register alerting under the `observabilityTools` category with a bell icon (`euiIconType: 'bell'`) and order 8000, placing it in the collapsible "Tools" section
- When icon side nav is **disabled**: register alerting under the `detect` category (existing behavior)
- Add unit tests for both icon side nav enabled and disabled paths

**Files changed:**
- `public/plugin.tsx` — branching nav registration based on `getIsIconSideNavEnabled()`
- `public/plugin_nav.test.ts` — new test file with coverage for both nav modes

## Related Issue

opensearch-project/OpenSearch-Dashboards#11545

## Test plan
- [ ] Verify alerting appears under "Tools" section in icon side nav (Observability workspace)
- [ ] Verify alerting appears under "Detect" category in default nav
- [ ] Run unit tests: `yarn test --testPathPattern=plugin_nav`