### PR TITLE
Fixed monitor schedule edit workflow when there is no ui_metadata for the monitor.

### DIFF
--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          # TODO: Parse this from alerting plugin
+          distribution: 'temurin'
           java-version: 21
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: alerting
           repository: opensearch-project/alerting
@@ -50,13 +50,13 @@ jobs:
           ./gradlew :alerting:run &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Checkout Alerting OpenSearch Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
       - name: Setup Node

--- a/.github/workflows/cypress-workflow.yml
+++ b/.github/workflows/cypress-workflow.yml
@@ -34,12 +34,12 @@ jobs:
       TERM: xterm
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v1
         with:
-          distribution: 'temurin'
+          # TODO: Parse this from alerting plugin
           java-version: 21
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           path: alerting
           repository: opensearch-project/alerting
@@ -50,13 +50,13 @@ jobs:
           ./gradlew :alerting:run &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Checkout Alerting OpenSearch Dashboards plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           path: OpenSearch-Dashboards/plugins/alerting-dashboards-plugin
       - name: Setup Node

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -30,15 +30,14 @@ export default function monitorToFormik(monitor) {
     monitorOptions = [],
   } = monitor;
 
-  // When ui_metadata.schedule is absent, derive schedule fields from monitor.schedule
-  if (!monitor.ui_metadata?.schedule) {
-    if (schedulePeriod) {
-      schedule.frequency = 'interval';
-      schedule.period = { interval: schedulePeriod.interval, unit: schedulePeriod.unit };
-    } else if (monitor.schedule?.cron) {
-      schedule.frequency = 'cronExpression';
-    }
+  // Derive schedule fields from monitor.schedule (source of truth)
+  if (schedulePeriod) {
+    schedule.frequency = 'interval';
+    schedule.period = { interval: schedulePeriod.interval, unit: schedulePeriod.unit };
+  } else if (monitor.schedule?.cron) {
+    schedule.frequency = 'cronExpression';
   }
+
   // Default searchType to query, because if there is no ui_metadata or search then it was created through API or overwritten by API
   // In that case we don't want to guess on the UI what selections a user made, so we will default to just showing the extraction query
   const { searchType = 'query', fieldName } = search;

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.js
@@ -21,11 +21,24 @@ export default function monitorToFormik(monitor) {
     name,
     monitor_type,
     enabled,
-    schedule: { cron: { expression: cronExpression = formikValues.cronExpression, timezone } = {} },
+    schedule: {
+      cron: { expression: cronExpression = formikValues.cronExpression, timezone } = {},
+      period: schedulePeriod,
+    },
     inputs,
     ui_metadata: { schedule = {}, search = {} } = {},
     monitorOptions = [],
   } = monitor;
+
+  // When ui_metadata.schedule is absent, derive schedule fields from monitor.schedule
+  if (!monitor.ui_metadata?.schedule) {
+    if (schedulePeriod) {
+      schedule.frequency = 'interval';
+      schedule.period = { interval: schedulePeriod.interval, unit: schedulePeriod.unit };
+    } else if (monitor.schedule?.cron) {
+      schedule.frequency = 'cronExpression';
+    }
+  }
   // Default searchType to query, because if there is no ui_metadata or search then it was created through API or overwritten by API
   // In that case we don't want to guess on the UI what selections a user made, so we will default to just showing the extraction query
   const { searchType = 'query', fieldName } = search;

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
@@ -188,7 +188,7 @@ describe('monitorToFormik', () => {
   });
 });
 
-describe('schedule derivation without ui_metadata', () => {
+describe('schedule derivation prioritizes monitor.schedule', () => {
   test('derives interval schedule from monitor.schedule.period when ui_metadata is absent', () => {
     const monitor = {
       name: 'No UI Metadata Monitor',
@@ -215,10 +215,13 @@ describe('schedule derivation without ui_metadata', () => {
     expect(formikValues.cronExpression).toBe('0 0 * * *');
   });
 
-  test('uses ui_metadata.schedule when present (does not override)', () => {
-    const formikValues = monitorToFormik(exampleMonitor);
-    expect(formikValues.frequency).toBe('cronExpression');
-    expect(formikValues.cronExpression).toBe('0 0 0/2 * * ?');
+  test('monitor.schedule.period overrides ui_metadata.schedule when both present', () => {
+    const monitor = _.cloneDeep(exampleMonitor);
+    // ui_metadata says cronExpression with interval 1 MINUTES, but actual schedule is 10 HOURS
+    monitor.schedule = { period: { interval: 10, unit: 'HOURS' } };
+    const formikValues = monitorToFormik(monitor);
+    expect(formikValues.frequency).toBe('interval');
+    expect(formikValues.period).toEqual({ interval: 10, unit: 'HOURS' });
   });
 
   test('preserves default schedule when ui_metadata is absent and no period/cron', () => {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/monitorToFormik.test.js
@@ -187,3 +187,50 @@ describe('monitorToFormik', () => {
     });
   });
 });
+
+describe('schedule derivation without ui_metadata', () => {
+  test('derives interval schedule from monitor.schedule.period when ui_metadata is absent', () => {
+    const monitor = {
+      name: 'No UI Metadata Monitor',
+      enabled: true,
+      schedule: { period: { interval: 5, unit: 'DAYS' } },
+      inputs: [{ search: { indices: ['test-index'], query: JSON.parse(MATCH_ALL_QUERY) } }],
+      triggers: [],
+    };
+    const formikValues = monitorToFormik(monitor);
+    expect(formikValues.frequency).toBe('interval');
+    expect(formikValues.period).toEqual({ interval: 5, unit: 'DAYS' });
+  });
+
+  test('derives cron schedule when ui_metadata is absent and monitor uses cron', () => {
+    const monitor = {
+      name: 'Cron No UI Metadata',
+      enabled: true,
+      schedule: { cron: { expression: '0 0 * * *', timezone: 'US/Pacific' } },
+      inputs: [{ search: { indices: ['test-index'], query: JSON.parse(MATCH_ALL_QUERY) } }],
+      triggers: [],
+    };
+    const formikValues = monitorToFormik(monitor);
+    expect(formikValues.frequency).toBe('cronExpression');
+    expect(formikValues.cronExpression).toBe('0 0 * * *');
+  });
+
+  test('uses ui_metadata.schedule when present (does not override)', () => {
+    const formikValues = monitorToFormik(exampleMonitor);
+    expect(formikValues.frequency).toBe('cronExpression');
+    expect(formikValues.cronExpression).toBe('0 0 0/2 * * ?');
+  });
+
+  test('preserves default schedule when ui_metadata is absent and no period/cron', () => {
+    const monitor = {
+      name: 'Empty Schedule Monitor',
+      enabled: true,
+      schedule: {},
+      inputs: [{ search: { indices: ['test-index'], query: JSON.parse(MATCH_ALL_QUERY) } }],
+      triggers: [],
+    };
+    const formikValues = monitorToFormik(monitor);
+    expect(formikValues.frequency).toBe(FORMIK_INITIAL_VALUES.frequency);
+    expect(formikValues.period).toEqual(FORMIK_INITIAL_VALUES.period);
+  });
+});


### PR DESCRIPTION
### Description
The `ui_metadata` attribute of a monitor is generated and used by the alerting dashboard plugin to enhance the experience of creating and editing a monitor. It is not a required attribute, and is not generated when a monitor is created via API directly (e.g., via devtools).

There was a bug in the UI when editing a monitor that did not have `ui_metadata`. The schedule configuration panel displayed the default values of 1 minute instead of the monitor's actual schedule.

The `monitorToFormik` function relied on `ui_metadata.schedule` to populate the formik frequency and period fields — when absent, these remained at their initial values.

This PR adds a fallback that derives schedule fields directly from `monitor.schedule.period` (or `monitor.schedule.cron`) when `ui_metadata.schedule` is not available. 
### Backports
1. Backporting fix to v2.19 as that's the last released 2.x version.
2. Targeting 3.x release in v3.7.
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
