### PR TITLE
Resolved CVE-2026-27903, CVE-2026-27904, CVE-2026-33671, CVE-2026-33750, and CVE-2026-33532.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,12 @@
     "json-schema": "^0.4.0",
     "minimist": "^1.2.6",
     "moment": "^2.29.4",
-    "terser": "^4.8.1"
+    "terser": "^4.8.1",
+    "minimatch": "^3.1.4",
+    "picomatch": "^2.3.2",
+    "brace-expansion": "^5.0.5",
+    "yaml": "^1.10.3",
+    "qs": "^6.14.2"
   },
   "engines": {
     "yarn": "^1.21.1"


### PR DESCRIPTION
## Summary
Resolves the following CVEs by adding yarn resolutions:
- **CVE-2026-27903** / **CVE-2026-27904** (minimatch) — bumped to `^3.1.4`
- **CVE-2026-33671** (picomatch ReDoS) — added `^2.3.2`
- **CVE-2026-33750** (brace-expansion) — added `^5.0.5`
- **CVE-2026-33532** (yaml stack overflow) — added `^1.10.3`

## Testing
- `yarn build` passes