### PR TITLE
PPL Monitor Creation in Logs

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -8,6 +8,7 @@
     "dataSourceManagement",
     "assistantDashboards",
     "explore",
+    "observabilityDashboards",
     "workspace"
   ],
   "requiredPlugins": [

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -39,6 +39,10 @@ import type { ExplorePluginSetup, ExplorePluginStart } from '../../../src/plugin
 import { ResultStatus } from '../../../src/plugins/data/public';
 import { CreateMonitorFlyout } from './components/CreateMonitorFlyout';
 import { CoreContext } from './utils/CoreContext';
+import {
+  ObservabilityDashboardsSetupShape,
+  shouldRegisterAlertingExploreAction,
+} from './utils/should_register_alerting_explore_action';
 
 declare module '../../../src/plugins/ui_actions/public' {
   export interface ActionContextMapping {
@@ -51,17 +55,6 @@ let navigateToAppRef: CoreStart['application']['navigateToApp'] | null = null;
 export interface AlertingSetup { }
 
 export interface AlertingStart { }
-
-/**
- * Structural shape for the slice of `dashboards-observability`'s setup
- * contract we depend on. Inlined (rather than imported from the
- * observability package) to avoid a hard cross-plugin type dependency —
- * we only need to know whether observability has claimed ownership of
- * the Explore "Create monitor" entry.
- */
-interface ObservabilityDashboardsSetupShape {
-  ownsMonitorCreation: boolean;
-}
 
 export interface AlertingSetupDeps {
   expressions: ExpressionsSetup;
@@ -284,10 +277,8 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
      *    `ownsMonitorCreation` flag on its setup contract — registering
      *    ours alongside theirs would surface two duplicate menu entries.
      */
-    const isExploreEnabled = !!explore;
-    const obsOwnsMonitorCreation = !!observabilityDashboards?.ownsMonitorCreation;
-    if (isExploreEnabled && !obsOwnsMonitorCreation) {
-      explore.queryPanelActionsRegistry.register({
+    if (shouldRegisterAlertingExploreAction({ explore, observabilityDashboards })) {
+      explore!.queryPanelActionsRegistry.register({
         id: 'alerting-create-monitor-from-explore',
         order: 1,
         getIsEnabled: (deps) => {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -52,6 +52,17 @@ export interface AlertingSetup { }
 
 export interface AlertingStart { }
 
+/**
+ * Structural shape for the slice of `dashboards-observability`'s setup
+ * contract we depend on. Inlined (rather than imported from the
+ * observability package) to avoid a hard cross-plugin type dependency —
+ * we only need to know whether observability has claimed ownership of
+ * the Explore "Create monitor" entry.
+ */
+interface ObservabilityDashboardsSetupShape {
+  ownsMonitorCreation: boolean;
+}
+
 export interface AlertingSetupDeps {
   expressions: ExpressionsSetup;
   uiActions: UiActionsSetup;
@@ -59,6 +70,13 @@ export interface AlertingSetupDeps {
   dataSource: DataSourcePluginSetup;
   assistantDashboards?: AssistantSetup;
   explore?: ExplorePluginSetup;
+  /**
+   * Optional. Present when the observability plugin is loaded; carries an
+   * `ownsMonitorCreation` flag set to `true` when observability's alert
+   * manager is enabled. We skip our own Explore registration in that case
+   * so the user only sees one "Create monitor" entry.
+   */
+  observabilityDashboards?: ObservabilityDashboardsSetupShape;
 }
 
 export interface AlertingStartDeps {
@@ -92,7 +110,7 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
   private startServicesPromise!: ReturnType<CoreSetup['getStartServices']>;
 
 
-  public setup(core: CoreSetup<AlertingStartDeps, AlertingStart>, { expressions, uiActions, dataSourceManagement, dataSource, assistantDashboards, explore }: AlertingSetupDeps) {
+  public setup(core: CoreSetup<AlertingStartDeps, AlertingStart>, { expressions, uiActions, dataSourceManagement, dataSource, assistantDashboards, explore, observabilityDashboards }: AlertingSetupDeps) {
 
     this.startServicesPromise = core.getStartServices();
 
@@ -259,11 +277,16 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
 
     /**
      * Register a flyout action in Explore's Query Panel "Actions" menu
-     * that opens an inline monitor creation flyout with the PPL query pre-filled.
-     * Only register if the explore plugin is available.
+     * that opens an inline monitor creation flyout with the PPL query
+     * pre-filled. Skipped when:
+     *  - explore plugin isn't installed (nothing to register against), or
+     *  - observability has claimed ownership of "Create monitor" via the
+     *    `ownsMonitorCreation` flag on its setup contract — registering
+     *    ours alongside theirs would surface two duplicate menu entries.
      */
     const isExploreEnabled = !!explore;
-    if (isExploreEnabled) {
+    const obsOwnsMonitorCreation = !!observabilityDashboards?.ownsMonitorCreation;
+    if (isExploreEnabled && !obsOwnsMonitorCreation) {
       explore.queryPanelActionsRegistry.register({
         id: 'alerting-create-monitor-from-explore',
         order: 1,

--- a/public/utils/should_register_alerting_explore_action.test.ts
+++ b/public/utils/should_register_alerting_explore_action.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="jest" />
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shouldRegisterAlertingExploreAction } from './should_register_alerting_explore_action';
+
+describe('shouldRegisterAlertingExploreAction', () => {
+  // A truthy stand-in for Explore's setup contract. The predicate only
+  // checks for presence, so the value's shape doesn't matter.
+  const explore = { queryPanelActionsRegistry: {} };
+
+  it('does not register when Explore is absent', () => {
+    // Nothing to register against — the action lives on Explore's
+    // queryPanelActionsRegistry.
+    expect(shouldRegisterAlertingExploreAction({})).toBe(false);
+  });
+
+  it('does not register when Explore is absent even if observability is present', () => {
+    expect(
+      shouldRegisterAlertingExploreAction({
+        observabilityDashboards: { ownsMonitorCreation: false },
+      })
+    ).toBe(false);
+    expect(
+      shouldRegisterAlertingExploreAction({
+        observabilityDashboards: { ownsMonitorCreation: true },
+      })
+    ).toBe(false);
+  });
+
+  it('registers when Explore is present and observability is absent', () => {
+    // Status quo for clusters that don't run dashboards-observability.
+    expect(shouldRegisterAlertingExploreAction({ explore })).toBe(true);
+  });
+
+  it('registers when observability is loaded but did not claim monitor creation', () => {
+    // observability ships with `alertManager.enabled: false` — the plugin
+    // is loaded but its alert-manager surface is intentionally quiet, so
+    // alerting takes ownership of "Create monitor".
+    expect(
+      shouldRegisterAlertingExploreAction({
+        explore,
+        observabilityDashboards: { ownsMonitorCreation: false },
+      })
+    ).toBe(true);
+  });
+
+  it('defers when observability has claimed monitor creation', () => {
+    // Both plugins loaded, observability has `alertManager.enabled: true`
+    // and reports `ownsMonitorCreation: true`. Alerting must NOT register
+    // its action — otherwise the user sees two duplicate "Create monitor"
+    // entries on the Logs page Actions menu.
+    expect(
+      shouldRegisterAlertingExploreAction({
+        explore,
+        observabilityDashboards: { ownsMonitorCreation: true },
+      })
+    ).toBe(false);
+  });
+
+  it('treats a missing ownsMonitorCreation field as "not claimed"', () => {
+    // Defensive: an older observability build that predates the contract
+    // exposes its setup object without the field. `?.` coalesces to
+    // undefined, `!!` coerces to false, and alerting registers as before.
+    // This is the backwards-compatibility case called out in the PR
+    // description.
+    expect(
+      shouldRegisterAlertingExploreAction({
+        explore,
+        observabilityDashboards: ({} as unknown) as { ownsMonitorCreation: boolean },
+      })
+    ).toBe(true);
+  });
+});

--- a/public/utils/should_register_alerting_explore_action.ts
+++ b/public/utils/should_register_alerting_explore_action.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Predicate for the alerting plugin's "Create monitor" entry on Explore's
+ * Query Panel "Actions" menu.
+ *
+ * Pulled out of `plugin.tsx` so the gate's behavior can be unit-tested
+ * without dragging in the rest of the plugin's setup-time imports
+ * (React, EUI, embeddable, core, etc.). The runtime call site in
+ * `plugin.tsx::setup()` reads exactly two pieces of `setupDeps`:
+ *
+ *   const isExploreEnabled = !!explore;
+ *   const obsOwnsMonitorCreation = !!observabilityDashboards?.ownsMonitorCreation;
+ *   if (isExploreEnabled && !obsOwnsMonitorCreation) { register(); }
+ *
+ * Behavior matrix:
+ *
+ * | explore | observability | ownsMonitorCreation | register? |
+ * | ------- | ------------- | ------------------- | --------- |
+ * | absent  | n/a           | n/a                 | no        |
+ * | present | absent        | n/a                 | yes       |
+ * | present | present       | false (or missing)  | yes       |
+ * | present | present       | true                | no        |
+ *
+ * The "missing field" case lets older observability builds (predating the
+ * `ownsMonitorCreation` contract from dashboards-observability #2712)
+ * coexist — alerting registers as before since the flag is absent.
+ */
+
+/**
+ * Structural shape of the slice of `dashboards-observability`'s setup
+ * contract this plugin depends on. Inlined here (rather than imported
+ * from the observability package) so this plugin builds cleanly when
+ * observability isn't in the workspace.
+ */
+export interface ObservabilityDashboardsSetupShape {
+  ownsMonitorCreation: boolean;
+}
+
+export interface AlertingExploreActionGateDeps {
+  /** Truthy when Explore's setup contract is available. */
+  explore?: unknown;
+  /** Optional — present only when dashboards-observability is loaded. */
+  observabilityDashboards?: ObservabilityDashboardsSetupShape;
+}
+
+export function shouldRegisterAlertingExploreAction(
+  deps: AlertingExploreActionGateDeps
+): boolean {
+  const isExploreEnabled = !!deps.explore;
+  const obsOwnsMonitorCreation = !!deps.observabilityDashboards?.ownsMonitorCreation;
+  return isExploreEnabled && !obsOwnsMonitorCreation;
+}


### PR DESCRIPTION
# Defer "Create monitor" Explore action when observability owns it

## Description

Lets the alerting plugin step aside on Explore's "Actions" menu when `dashboards-observability` has claimed ownership of the Create monitor entry, so users don't see two duplicate entries when both plugins are loaded.

## What changed

- Added `observabilityDashboards` to `optionalPlugins` in `opensearch_dashboards.json`.
- Extended `AlertingSetupDeps` with an optional `observabilityDashboards?: { ownsMonitorCreation: boolean }`. The shape is inlined (not imported from the observability package) so this PR doesn't introduce a hard cross-plugin type dependency.
- Extracted the registration predicate into `public/utils/should_register_alerting_explore_action.ts` and replaced the inline gate in `plugin.tsx` with a call to it. Same behavior, but the predicate is now testable in isolation without spinning up the full plugin lifecycle.
- The existing `explore.queryPanelActionsRegistry.register({...})` call in `setup()` is now guarded by `shouldRegisterAlertingExploreAction({ explore, observabilityDashboards })`.

## Why

The companion change in `dashboards-observability` registers its own Create monitor action on Explore that opens the observability alert-manager flyout (PPL-only, with inline datasource/index/time-field pickers and a "Run preview" affordance). When `observability.alertManager.enabled: true`, observability's flag is the source of truth and we want only its entry visible. When the flag is off — or observability isn't installed — alerting's existing entry behaves exactly as before.

## Behavior

| Observability loaded? | `observability.alertManager.enabled`? | Result |
| --- | --- | --- |
| No | n/a | Alerting's entry only (status quo) |
| Yes | `false` | Alerting's entry only — observability ships quiet |
| Yes | `true` | Alerting defers; observability's entry only |

## Tests

`public/utils/should_register_alerting_explore_action.test.ts` covers the predicate end-to-end. Six cases mirror the behavior matrix plus two defensive paths:

- does not register when Explore is absent
- does not register when Explore is absent even if observability is present
- registers when Explore is present and observability is absent
- registers when observability is loaded but did not claim monitor creation (the `alertManager.enabled: false` case)
- defers when observability has claimed monitor creation
- treats a missing `ownsMonitorCreation` field as "not claimed" — covers older observability builds that predate the contract

The test file uses a triple-slash `/// <reference types="jest" />` directive at the top so editors that don't already pick up `@types/jest` from the workspace resolve `describe` / `it`. No `tsconfig.json` change required (this plugin doesn't ship one).

## Backwards compatibility

The new dep is optional and the gate is structural. In any cluster where the companion observability change hasn't landed, `observabilityDashboards?.ownsMonitorCreation` is `undefined` → falsy → alerting registers as before. No-op on existing installations.

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
