### PR TITLE
Drop unused observabilityDashboards optional dep + fix #1461 indentation

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -8,7 +8,6 @@
     "dataSourceManagement",
     "assistantDashboards",
     "explore",
-    "observabilityDashboards",
     "workspace"
   ],
   "requiredPlugins": [

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -302,86 +302,91 @@ export class AlertingPlugin implements Plugin<void, AlertingStart, AlertingSetup
       // correct trade-off given the constraints.
       this.startServicesPromise
         .then(([coreStart]) => {
-        const capabilities = coreStart.application.capabilities as {
-          observability?: { alertManagerEnabled?: boolean };
-        };
-        // Strict `=== true` rather than truthy: capability values can be
-        // non-boolean (e.g. structured objects from a dynamic-config
-        // store), and we must only stand down when the field is
-        // explicitly `true`. Do not "simplify" to a truthy check.
-        if (capabilities?.observability?.alertManagerEnabled === true) {
-          return;
-        }
-        explorePlugin.queryPanelActionsRegistry.register({
-        id: 'alerting-create-monitor-from-explore',
-        order: 1,
-        getIsEnabled: (deps) => {
-          if (!isPplAlertingEnabled()) {
-            return false;
-          }
-          // Allow monitor creation for READY, NO_RESULTS, and ERROR statuses
-          const allowedStatuses = [ResultStatus.READY, ResultStatus.NO_RESULTS, ResultStatus.ERROR];
-          const isStatusAllowed = allowedStatuses.includes(deps.resultStatus.status);
-
-          // Check if data source is AOSS collection - if so, disable the button
-          const isAOSSCollection = deps.query?.dataset?.dataSource?.type === 'OpenSearch Serverless';
-
-          return isStatusAllowed && !isAOSSCollection;
-        },
-        getLabel: () => 'Create monitor',
-        getIcon: () => 'bell',
-        onClick: async (deps) => {
-          const actionsButton = document.querySelector<HTMLButtonElement>(
-            '[data-test-subj="queryPanelFooterActionsButton"]'
-          );
-          if (actionsButton) {
-            const triggerClose = () => {
-            actionsButton.click();
-            };
-            if (typeof requestAnimationFrame === 'function') {
-              requestAnimationFrame(triggerClose);
-            } else {
-              setTimeout(triggerClose, 0);
-            }
-          }
-          const [coreStart, depsStart] = await this.startServicesPromise;
-          if (!isPplAlertingEnabled()) {
+          const capabilities = coreStart.application.capabilities as {
+            observability?: { alertManagerEnabled?: boolean };
+          };
+          // Strict `=== true` rather than truthy: capability values can be
+          // non-boolean (e.g. structured objects from a dynamic-config
+          // store), and we must only stand down when the field is
+          // explicitly `true`. Do not "simplify" to a truthy check.
+          if (capabilities?.observability?.alertManagerEnabled === true) {
             return;
           }
-          const { overlays, http, notifications, chrome, uiSettings, i18n } = coreStart;
-          const services = {
-            ...(coreStart as unknown as Record<string, unknown>),
-            ...(depsStart as unknown as Record<string, unknown>),
-          };
-          const contextValue = {
-            http,
-            isDarkMode: uiSettings.get('theme:darkMode'),
-            notifications,
-            chrome,
-            defaultRoute: '/',
-            data: (depsStart as any)?.data,
-            services,
-          };
-          const queryInEditor =
-            (deps.query as any)?.query ?? (deps.query as any)?.queryString ?? '';
-          let flyoutSession: OverlayRef | undefined;
-          const flyoutContent = (
-            <CoreContext.Provider value={contextValue}>
-              <CreateMonitorFlyout
-                closeFlyout={() => flyoutSession?.close()}
-                dependencies={{
-                  query: deps.query,
-                  resultStatus: deps.resultStatus,
-                  queryInEditor,
-                }}
-                services={services}
-              />
-            </CoreContext.Provider>
-          );
-          flyoutSession = overlays.openFlyout(toMountPoint(flyoutContent));
-        },
-        });
-      })
+          explorePlugin.queryPanelActionsRegistry.register({
+            id: 'alerting-create-monitor-from-explore',
+            order: 1,
+            getIsEnabled: (deps) => {
+              if (!isPplAlertingEnabled()) {
+                return false;
+              }
+              // Allow monitor creation for READY, NO_RESULTS, and ERROR statuses
+              const allowedStatuses = [
+                ResultStatus.READY,
+                ResultStatus.NO_RESULTS,
+                ResultStatus.ERROR,
+              ];
+              const isStatusAllowed = allowedStatuses.includes(deps.resultStatus.status);
+
+              // Check if data source is AOSS collection - if so, disable the button
+              const isAOSSCollection =
+                deps.query?.dataset?.dataSource?.type === 'OpenSearch Serverless';
+
+              return isStatusAllowed && !isAOSSCollection;
+            },
+            getLabel: () => 'Create monitor',
+            getIcon: () => 'bell',
+            onClick: async (deps) => {
+              const actionsButton = document.querySelector<HTMLButtonElement>(
+                '[data-test-subj="queryPanelFooterActionsButton"]'
+              );
+              if (actionsButton) {
+                const triggerClose = () => {
+                  actionsButton.click();
+                };
+                if (typeof requestAnimationFrame === 'function') {
+                  requestAnimationFrame(triggerClose);
+                } else {
+                  setTimeout(triggerClose, 0);
+                }
+              }
+              const [innerCoreStart, depsStart] = await this.startServicesPromise;
+              if (!isPplAlertingEnabled()) {
+                return;
+              }
+              const { overlays, http, notifications, chrome, uiSettings } = innerCoreStart;
+              const services = {
+                ...((innerCoreStart as unknown) as Record<string, unknown>),
+                ...((depsStart as unknown) as Record<string, unknown>),
+              };
+              const contextValue = {
+                http,
+                isDarkMode: uiSettings.get('theme:darkMode'),
+                notifications,
+                chrome,
+                defaultRoute: '/',
+                data: (depsStart as any)?.data,
+                services,
+              };
+              const queryInEditor =
+                (deps.query as any)?.query ?? (deps.query as any)?.queryString ?? '';
+              let flyoutSession: OverlayRef | undefined;
+              const flyoutContent = (
+                <CoreContext.Provider value={contextValue}>
+                  <CreateMonitorFlyout
+                    closeFlyout={() => flyoutSession?.close()}
+                    dependencies={{
+                      query: deps.query,
+                      resultStatus: deps.resultStatus,
+                      queryInEditor,
+                    }}
+                    services={services}
+                  />
+                </CoreContext.Provider>
+              );
+              flyoutSession = overlays.openFlyout(toMountPoint(flyoutContent));
+            },
+          });
+        })
         .catch((error) => {
           // Surface failures from the deferred-registration path. Without
           // this catch, a `getStartServices()` rejection (rare, but

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -58,14 +58,6 @@ export interface AlertingSetupDeps {
   dataSource: DataSourcePluginSetup;
   assistantDashboards?: AssistantSetup;
   explore?: ExplorePluginSetup;
-  /**
-   * Optional. Present when dashboards-observability is loaded. We no
-   * longer read its setup contract; coordination of which "Create
-   * monitor" entry shows happens at request time via
-   * `capabilities.observability.alertManagerEnabled`. Field kept so
-   * declared optional plugin deps still resolve without warnings.
-   */
-  observabilityDashboards?: unknown;
 }
 
 export interface AlertingStartDeps {


### PR DESCRIPTION
## Description

Drops the now-dead `observabilityDashboards` optional plugin dependency, and fixes the indentation of the deferred Explore registration block introduced in #1461.

#1461 moved coordination of the Explore "Create monitor" / "Create alert rule" menu entry from a setup-time boolean to a request-time capability check (`capabilities.observability.alertManagerEnabled`). After that change this plugin no longer reads anything off `setupDeps.observabilityDashboards`, but the optional dep declaration was left in place. The companion observability PR ([opensearch-project/dashboards-observability#2719](https://github.com/opensearch-project/dashboards-observability/pull/2719)) finishes the cleanup on its side by removing `ownsMonitorCreation` from its setup contract entirely, so the field has zero readers anywhere.

Also fixes the indentation review comment on #1461: the `.then(...)` callback body and the inner `register({...})` body were sitting at the same column as their parent calls. The body is now indented one level deeper, and the trailing `.catch(...)` chains visually off the promise instead of looking like a sibling of `if (explore) { ... }`.

## Changes

- `public/plugin.tsx`
  - Re-indented the `this.startServicesPromise.then(...).catch(...)` block so callback bodies nest correctly. Callable behavior is unchanged — purely whitespace.
  - Removed `observabilityDashboards?: unknown` from `AlertingSetupDeps`. Interface now matches reality: alerting takes no setup deps from observability.
  - Renamed the inner `coreStart` binding inside the `onClick` handler to `innerCoreStart` so it no longer shadows the outer `.then` callback's `coreStart`. Same data, clearer scope.
  - Dropped the unused `i18n` field from `const { overlays, http, notifications, chrome, uiSettings, i18n } = …` — destructured but never read.
- `opensearch_dashboards.json`
  - Removed `"observabilityDashboards"` from `optionalPlugins`. Manifest now matches reality.

## Why this is safe

- The dynamic-flag coordination still works exactly as before. The capability is published by observability's `registerSwitcher` at the core level and read off `coreStart.application.capabilities` inside our deferred `getStartServices().then(...)` registration. That path doesn't require a plugin dep — it's a CoreStart capability read.
- `observabilityDashboards?: unknown` was never read after #1461 merged. The manifest entry was load-ordering metadata for a relationship that no longer exists.
- The indentation change is whitespace-only; no logic moved.

## Testing

- `yarn test:jest public/plugin.test public/plugin_nav` — all 7 tests pass (5 deferred-registration coordination tests from #1461 + 2 nav tests).

## Issues Resolved

N/A — cleanup follow-up to #1461.

## Check List

- [x] All tests pass
  - [x] `yarn test:jest`
- [x] Commits are signed per the DCO using `--signoff`