### PR TITLE
Update GitHub actions to use official opensearch-project actions

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@v6
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Dashboard
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@v1
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@643b632712710159088d5f0798de7e91c1f2b8f7
         with:
           plugin_name: alerting-dashboards-plugin
           built_plugin_name: alertingDashboards


### PR DESCRIPTION
### Description

Update GitHub action references to use official `opensearch-project/opensearch-build` actions instead of personal forks.

### Changes

- Replace `derek-ho/start-opensearch` → `opensearch-project/opensearch-build/.github/actions/start-opensearch`
- Replace `derek-ho/setup-opensearch-dashboards` → `opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards`

Both pinned to SHA `dbcc45dc3e390e54f1917be9c725450548416ce6`.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.