### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "brace": "0.11.1",
     "formik": "^2.2.6",
-    "query-string": "^6.13.2",
+    "query-string": "^9.4.1",
     "react-redux": "^8.1.0",
     "react-vis": "^1.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "resolutions": {
     "ansi-regex": "^5.0.1",
     "async": "^3.2.3",
-    "decode-uri-component": "^0.2.1",
     "fstream": "1.0.12",
     "glob-parent": "^5.1.2",
     "json-schema": "^0.4.0",

--- a/public/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/public/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`createEuiBreadcrumbs creates breadcrumbs for EuiBreadcrumbs 1`] = `
 Object {

--- a/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
+++ b/public/components/ContentPanel/__snapshots__/ContentPanel.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ContentPanel renders 1`] = `
 <div

--- a/public/components/DelayedLoader/__tests__/__snapshots__/DelayedLoader.test.js.snap
+++ b/public/components/DelayedLoader/__tests__/__snapshots__/DelayedLoader.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DelayedLoader/> renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/AssociateExisting/__snapshots__/AssociateExisting.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/AssociateExisting/__snapshots__/AssociateExisting.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AssociateExisting renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/__snapshots__/CreateNew.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/CreateNew/__snapshots__/CreateNew.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CreateNew renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/__snapshots__/AddAlertingMonitor.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/AddAlertingMonitor/__snapshots__/AddAlertingMonitor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddAlertingMonitor renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/__snapshots__/AssociatedMonitors.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedMonitors/__snapshots__/AssociatedMonitors.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AssociatedMonitors renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/Container/__snapshots__/Container.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/Container/__snapshots__/Container.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Container renders add 1`] = `
 <Component

--- a/public/components/FeatureAnywhereContextMenu/DocumentationTitle/__snapshots__/DocumentationTitle.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/DocumentationTitle/__snapshots__/DocumentationTitle.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DocumentationTitle renders 1`] = `
 <EuiFlexGroup>

--- a/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/__snapshots__/EnhancedAccordion.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/__snapshots__/EnhancedAccordion.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EnhancedAccordion renders 1`] = `
 <div

--- a/public/components/FeatureAnywhereContextMenu/MinimalAccordion/__snapshots__/MinimalAccordion.test.js.snap
+++ b/public/components/FeatureAnywhereContextMenu/MinimalAccordion/__snapshots__/MinimalAccordion.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MinimalAccordion renders 1`] = `
 <div

--- a/public/components/Flyout/__snapshots__/Flyout.test.js.snap
+++ b/public/components/Flyout/__snapshots__/Flyout.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Flyout defaults if bad flyout data 1`] = `
 <EuiFlyout

--- a/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
+++ b/public/components/Flyout/flyouts/__snapshots__/flyouts.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Flyouts.alertsDashboard generates message JSON 1`] = `
 Object {

--- a/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
+++ b/public/components/Flyout/flyouts/components/__snapshots__/AlertsDashboardFlyoutComponent.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AlertsDashboardFlyoutComponent renders 1`] = `
 <div>

--- a/public/components/FormControls/FormikCheckableCard/__snapshots__/FormikCheckableCard.test.js.snap
+++ b/public/components/FormControls/FormikCheckableCard/__snapshots__/FormikCheckableCard.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikCheckableCard render 1`] = `
 <div

--- a/public/components/FormControls/FormikCheckbox/__snapshots__/FormikCheckbox.test.js.snap
+++ b/public/components/FormControls/FormikCheckbox/__snapshots__/FormikCheckbox.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikCheckbox render 1`] = `
 <div

--- a/public/components/FormControls/FormikCodeEditor/__snapshots__/FormikCodeEditor.test.js.snap
+++ b/public/components/FormControls/FormikCodeEditor/__snapshots__/FormikCodeEditor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikCodeEditor render formRow 1`] = `
 <div

--- a/public/components/FormControls/FormikFieldNumber/__snapshots__/FormikFieldNumber.test.js.snap
+++ b/public/components/FormControls/FormikFieldNumber/__snapshots__/FormikFieldNumber.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikFieldNumber renders 1`] = `
 <div

--- a/public/components/FormControls/FormikFieldPassword/__snapshots__/FormikFieldPassword.test.js.snap
+++ b/public/components/FormControls/FormikFieldPassword/__snapshots__/FormikFieldPassword.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikFieldPassword renders 1`] = `
 <div

--- a/public/components/FormControls/FormikFieldText/__snapshots__/FormikFieldText.test.js.snap
+++ b/public/components/FormControls/FormikFieldText/__snapshots__/FormikFieldText.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikFieldText renders 1`] = `
 <div

--- a/public/components/FormControls/FormikFormRow/__snapshots__/FormikFormRow.test.js.snap
+++ b/public/components/FormControls/FormikFormRow/__snapshots__/FormikFormRow.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikFormRow renders 1`] = `
 <div

--- a/public/components/FormControls/FormikInputWrapper/__snapshots__/FormikInputWrapper.test.js.snap
+++ b/public/components/FormControls/FormikInputWrapper/__snapshots__/FormikInputWrapper.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikInputWrapper renders 1`] = `
 <div>

--- a/public/components/FormControls/FormikSelect/__snapshots__/FormikSelect.test.js.snap
+++ b/public/components/FormControls/FormikSelect/__snapshots__/FormikSelect.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikSelect renders 1`] = `
 <div

--- a/public/components/FormControls/FormikSwitch/__snapshots__/FormikSwitch.test.js.snap
+++ b/public/components/FormControls/FormikSwitch/__snapshots__/FormikSwitch.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikSwitch renders 1`] = `
 <div

--- a/public/components/FormControls/FormikTextArea/__snapshots__/FormikTextArea.test.js.snap
+++ b/public/components/FormControls/FormikTextArea/__snapshots__/FormikTextArea.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FormikTextArea renders 1`] = `
 <textarea

--- a/public/components/IconToolTip/__snapshots__/IconToolTip.test.js.snap
+++ b/public/components/IconToolTip/__snapshots__/IconToolTip.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`IconToolTip renders 1`] = `
 <span

--- a/public/components/SubHeader/__snapshots__/SubHeader.test.js.snap
+++ b/public/components/SubHeader/__snapshots__/SubHeader.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SubHeader renders 1`] = `
 Array [

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/__snapshots__/AnomaliesChart.test.js.snap
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/AnomaliesChart/__snapshots__/AnomaliesChart.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AnomaliesChart renders  1`] = `
 Array [

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/__snapshots__/EmptyFeaturesMessage.test.js.snap
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/EmptyFeaturesMessage/__snapshots__/EmptyFeaturesMessage.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EmptyFeaturesMessage renders no feature 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/__snapshots__/FeatureChart.test.js.snap
+++ b/public/pages/CreateMonitor/components/AnomalyDetectors/FeatureChart/__snapshots__/FeatureChart.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FeatureChart renders  1`] = `<div />`;

--- a/public/pages/CreateMonitor/components/AssociateMonitors/__snapshots__/AssociateMonitors.test.js.snap
+++ b/public/pages/CreateMonitor/components/AssociateMonitors/__snapshots__/AssociateMonitors.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AssociateMonitors renders 1`] = `
 Array [

--- a/public/pages/CreateMonitor/components/AssociateMonitors/components/__snapshots__/MonitorsEditor.test.js.snap
+++ b/public/pages/CreateMonitor/components/AssociateMonitors/components/__snapshots__/MonitorsEditor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorsEditor renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/AssociateMonitors/components/__snapshots__/MonitorsList.test.js.snap
+++ b/public/pages/CreateMonitor/components/AssociateMonitors/components/__snapshots__/MonitorsList.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorsList renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/ClusterMetricsMonitor/__snapshots__/ClusterMetricsMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/components/ClusterMetricsMonitor/__snapshots__/ClusterMetricsMonitor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ClusterMetricsMonitor renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/ExtractionQuery/__snapshots__/ExtractionQuery.test.js.snap
+++ b/public/pages/CreateMonitor/components/ExtractionQuery/__snapshots__/ExtractionQuery.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExtractionQuery renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinition/__snapshots__/MonitorDefinition.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorDefinition renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorDefinitionCard/__snapshots__/MonitorDefinitionCard.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorDefinitionCard renders without AD plugin 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/__snapshots__/MonitorExpressions.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorExpressions renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/ForExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/ForExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ForExpression renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/OfExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/OfExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OfExpression renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/OverExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/OverExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OverExpression renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhenExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhenExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`WhenExpression renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorExpressions/expressions/__snapshots__/WhereExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`WhereExpression renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/components/MonitorState/__snapshots__/MonitorState.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorState/__snapshots__/MonitorState.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorState renders 1`] = `
 Array [

--- a/public/pages/CreateMonitor/components/MonitorTimeField/__snapshots__/MonitorTimeField.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorTimeField/__snapshots__/MonitorTimeField.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorTimeField displays options includes date_nanos 1`] = `
 <Formik

--- a/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
+++ b/public/pages/CreateMonitor/components/MonitorType/__snapshots__/MonitorType.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorType renders 1`] = `
 Array [

--- a/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
+++ b/public/pages/CreateMonitor/components/QueryPerformance/__snapshots__/QueryPerformance.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`QueryPerformance renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
+++ b/public/pages/CreateMonitor/components/Schedule/Frequencies/__snapshots__/Frequencies.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Frequencies renders CustomCron 1`] = `
 <div

--- a/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
+++ b/public/pages/CreateMonitor/components/VisualGraph/__snapshots__/VisualGraph.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`VisualGraph renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
+++ b/public/pages/CreateMonitor/containers/AnomalyDetectors/__tests__/__snapshots__/AnomalyDetector.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AnomalyDetectors renders 1`] = `
 <Formik

--- a/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/__snapshots__/CreateMonitor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CreateMonitor renders 1`] = `
 <div

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/__snapshots__/formikToMonitor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`buildSchedule can build cron schedule 1`] = `
 Object {

--- a/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DataSource/__snapshots__/DataSource.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DataSource renders 1`] = `
 <ContentPanel

--- a/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/__snapshots__/DefineMonitor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DefineMonitor renders 1`] = `
 <div>

--- a/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
+++ b/public/pages/CreateMonitor/containers/MonitorIndex/__snapshots__/MonitorIndex.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorIndex renders 1`] = `
 <Formik

--- a/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
+++ b/public/pages/CreateMonitor/containers/WorkflowDetails/__snapshots__/WorkflowDetails.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`WorkflowDetails renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/__snapshots__/Action.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Action renders with Notifications plugin installed 1`] = `
 <div>

--- a/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
+++ b/public/pages/CreateTrigger/components/Action/actions/__snapshots__/Message.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Message renders 1`] = `
 <div>

--- a/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
+++ b/public/pages/CreateTrigger/components/ActionEmptyPrompt/__snapshots__/ActionEmptyPrompt.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ActionEmptyPrompt renders 1`] = `
 <EuiEmptyPrompt

--- a/public/pages/CreateTrigger/components/AddActionButton/__snapshots__/AddActionButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddActionButton/__snapshots__/AddActionButton.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddActionButton renders 1`] = `
 <EuiButton

--- a/public/pages/CreateTrigger/components/AddTriggerButton/__snapshots__/AddTriggerButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddTriggerButton/__snapshots__/AddTriggerButton.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddTriggerButton renders 1`] = `
 <EuiButton

--- a/public/pages/CreateTrigger/components/AddTriggerConditionButton/__snapshots__/AddTriggerConditionButton.test.js.snap
+++ b/public/pages/CreateTrigger/components/AddTriggerConditionButton/__snapshots__/AddTriggerConditionButton.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddTriggerConditionButton renders 1`] = `
 <EuiButtonEmpty

--- a/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/__snapshots__/BucketLevelTriggerExpression.test.js.snap
+++ b/public/pages/CreateTrigger/components/BucketLevelTriggerExpression/__snapshots__/BucketLevelTriggerExpression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BucketLevelTriggerExpression renders 1`] = `
 <EuiFlexGroup

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/CompositeTriggerCondition.test.js.snap
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/CompositeTriggerCondition.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CompositeTriggerCondition renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/ExpressionBuilder.test.js.snap
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/ExpressionBuilder.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExpressionBuilder renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/ExpressionEditor.test.js.snap
+++ b/public/pages/CreateTrigger/components/CompositeTriggerCondition/__snapshots__/ExpressionEditor.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExpressionEditor renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/components/NotificationsCallOut/__snapshots__/NotificationsCallOut.test.js.snap
+++ b/public/pages/CreateTrigger/components/NotificationsCallOut/__snapshots__/NotificationsCallOut.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotifictionsCallOut renders 1`] = `
 <div>

--- a/public/pages/CreateTrigger/components/TriggerExpressions/__snapshots__/TriggerExpressions.test.js.snap
+++ b/public/pages/CreateTrigger/components/TriggerExpressions/__snapshots__/TriggerExpressions.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TriggerExpressions renders 1`] = `
 <EuiCompressedFormRow

--- a/public/pages/CreateTrigger/components/TriggerQuery/__snapshots__/TriggerQuery.test.js.snap
+++ b/public/pages/CreateTrigger/components/TriggerQuery/__snapshots__/TriggerQuery.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TriggerQuery renders 1`] = `
 <div>

--- a/public/pages/CreateTrigger/components/__snapshots__/BucketLevelTriggerGraph.test.js.snap
+++ b/public/pages/CreateTrigger/components/__snapshots__/BucketLevelTriggerGraph.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BucketLevelTriggerGraph renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/components/__snapshots__/TriggerGraph.test.js.snap
+++ b/public/pages/CreateTrigger/components/__snapshots__/TriggerGraph.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TriggerGraph renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/DefineCompositeLevelTrigger.test.js.snap
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/DefineCompositeLevelTrigger.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DefineCompositeLevelTrigger renders 1`] = `
 <div

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/NotificationConfigDialog.test.js.snap
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/NotificationConfigDialog.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotificationConfigDialog renders 1`] = `null`;

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/TriggerNotifications.test.js.snap
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/TriggerNotifications.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TriggerNotifications renders 1`] = `
 Array [

--- a/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/TriggerNotificationsContent.test.js.snap
+++ b/public/pages/CreateTrigger/containers/DefineCompositeLevelTrigger/__snapshots__/TriggerNotificationsContent.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TriggerNotificationsContent renders with notifications 1`] = `
 <div

--- a/public/pages/CreateTrigger/containers/DefineTrigger/__snapshots__/AnomalyDetectorTrigger.test.js.snap
+++ b/public/pages/CreateTrigger/containers/DefineTrigger/__snapshots__/AnomalyDetectorTrigger.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AnomalyDetectorTrigger renders no detector id 1`] = `
 <div

--- a/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
+++ b/public/pages/Dashboard/components/AcknowledgeAlertsModal/__snapshots__/AcknowledgeAlertsModal.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AcknowledgeAlertsModal renders 1`] = `
 <AcknowledgeAlertsModal

--- a/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardControls/__snapshots__/DashboardControls.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DashboardControls renders 1`] = `
 <div

--- a/public/pages/Dashboard/components/DashboardEmptyPrompt/__snapshots__/DashboardEmptyPrompt.test.js.snap
+++ b/public/pages/Dashboard/components/DashboardEmptyPrompt/__snapshots__/DashboardEmptyPrompt.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DashboardEmptyPrompt renders 1`] = `
 <div

--- a/public/pages/Dashboard/components/FindingsDashboard/__snapshots__/FindingFlyout.test.js.snap
+++ b/public/pages/Dashboard/components/FindingsDashboard/__snapshots__/FindingFlyout.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FindingFlyout renders 1`] = `
 <div>

--- a/public/pages/Dashboard/components/FindingsDashboard/__snapshots__/FindingsPopover.test.js.snap
+++ b/public/pages/Dashboard/components/FindingsDashboard/__snapshots__/FindingsPopover.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FindingsPopover renders 1`] = `
 <div

--- a/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/__snapshots__/DeleteConfirmation.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/DeleteConfirmation/__snapshots__/DeleteConfirmation.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DeleteConfirmation /> should render if isVisible is provided to true 1`] = `
 <div>

--- a/public/pages/Destinations/components/DestinationsList/DestinationsActions/__snapshots__/DestinationsActions.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsActions/__snapshots__/DestinationsActions.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DestinationsActions /> should render DestinationsActions 1`] = `
 <div

--- a/public/pages/Destinations/components/DestinationsList/DestinationsControls/__snapshots__/DestinationsControls.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/DestinationsControls/__snapshots__/DestinationsControls.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DestinationsControls /> should render DestinationsControls 1`] = `
 <div

--- a/public/pages/Destinations/components/DestinationsList/EmptyDestinations/__snapshots__/EmptyDestinations.test.js.snap
+++ b/public/pages/Destinations/components/DestinationsList/EmptyDestinations/__snapshots__/EmptyDestinations.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EmptyDestinations /> should render empty destinations message 1`] = `
 <div

--- a/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/__snapshots__/FullPageNotificationsInfoCallOut.test.js.snap
+++ b/public/pages/Destinations/components/FullPageNotificationsInfoCallOut/__snapshots__/FullPageNotificationsInfoCallOut.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FullPageNotificationsInfoCallOut renders when Notifications plugin is installed 1`] = `
 <div

--- a/public/pages/Destinations/components/NotificationsInfoCallOut/__snapshots__/NotificationsInfoCallOut.test.js.snap
+++ b/public/pages/Destinations/components/NotificationsInfoCallOut/__snapshots__/NotificationsInfoCallOut.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NotificationsInfoCallOut renders when Notifications plugin is installed 1`] = `
 <div>

--- a/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageEmailGroups/__snapshots__/ManageEmailGroups.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ManageEmailGroups renders 1`] = `
 <ManageEmailGroups

--- a/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/ManageSenders/__snapshots__/ManageSenders.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ManageSenders renders 1`] = `
 <ManageSenders

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/destinationToFormik.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/destinationToFormik.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`destinationToFormik should able to convert chime destination to Formik object 1`] = `
 Object {

--- a/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/formikToDestination.test.js.snap
+++ b/public/pages/Destinations/containers/CreateDestination/utils/__tests__/__snapshots__/formikToDestination.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`formikToDestination should able to build chime destination 1`] = `
 Object {

--- a/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/__snapshots__/DestinationsList.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DestinationsList renders when Notification plugin is installed 1`] = `
 <DestinationsList

--- a/public/pages/Destinations/containers/DestinationsList/utils/__tests__/__snapshots__/helpers.test.js.snap
+++ b/public/pages/Destinations/containers/DestinationsList/utils/__tests__/__snapshots__/helpers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Helpers getURLQueryParams should return query string value if provided else default value 1`] = `
 Object {

--- a/public/pages/Home/__snapshots__/Home.test.js.snap
+++ b/public/pages/Home/__snapshots__/Home.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Home renders 1`] = `
 <div>

--- a/public/pages/Main/__snapshots__/Main.test.js.snap
+++ b/public/pages/Main/__snapshots__/Main.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Main renders 1`] = `null`;

--- a/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/__snapshots__/EmptyHistory.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/EmptyHistory/__snapshots__/EmptyHistory.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<EmptyHistory/> renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/components/MonitorHistory/Legend/__snapshots__/Legende.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/Legend/__snapshots__/Legende.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Legend/> renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/components/MonitorHistory/POIChart/__snapshots__/POIChart.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/POIChart/__snapshots__/POIChart.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<POIChart/> renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/__snapshots__/TriggersTimeSeries.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/__snapshots__/TriggersTimeSeries.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TriggersTimeSeries/> renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/__snapshots__/helpers.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorHistory/TriggersTimeSeries/utils/__snapshots__/helpers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Helpers formatToolTip should generate tool tip for NO_ALERTS state 1`] = `
 Array [

--- a/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
+++ b/public/pages/MonitorDetails/components/MonitorOverview/__snapshots__/MonitorOverview.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorOverview renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/components/OverviewStat/__snapshots__/OverviewStat.test.js.snap
+++ b/public/pages/MonitorDetails/components/OverviewStat/__snapshots__/OverviewStat.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`OverviewStat renders 1`] = `
 <div

--- a/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/__snapshots__/MonitorHistory.test.js.snap
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/__tests__/__snapshots__/MonitorHistory.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<MonitorHistory/> should create appropriate alerts data 1`] = `Object {}`;
 

--- a/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/__snapshots__/chartHelpers.test.js.snap
+++ b/public/pages/MonitorDetails/containers/MonitorHistory/utils/__tests__/__snapshots__/chartHelpers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Chart Helpers Time Series dataPointsGenerator should generate correct data point for an alert has acknowledged_time 1`] = `
 Array [

--- a/public/pages/MonitorDetails/containers/Triggers/__snapshots__/Triggers.test.js.snap
+++ b/public/pages/MonitorDetails/containers/Triggers/__snapshots__/Triggers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Triggers renders 1`] = `
 <ContentPanel

--- a/public/pages/Monitors/components/AcknowledgeModal/__snapshots__/AcknowledgeModal.test.js.snap
+++ b/public/pages/Monitors/components/AcknowledgeModal/__snapshots__/AcknowledgeModal.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AcknowledgeModal renders 1`] = `
 <EuiOverlayMask>

--- a/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
+++ b/public/pages/Monitors/components/MonitorActions/__snapshots__/MonitorActions.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorActions renders 1`] = `
 <div

--- a/public/pages/Monitors/components/MonitorEmptyPrompt/__snapshots__/MonitorEmptyPrompt.test.js.snap
+++ b/public/pages/Monitors/components/MonitorEmptyPrompt/__snapshots__/MonitorEmptyPrompt.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MonitorEmptyPrompt renders 1`] = `
 <div

--- a/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
+++ b/public/pages/Monitors/containers/Monitors/__snapshots__/Monitors.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Monitors renders 1`] = `
 <Fragment>

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -54,7 +54,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '<rootDir>/test/enzyme.js',
   ],
   setupFilesAfterEnv: [
+    'jest-location-mock',
     '<rootDir>/test/setup.jest.js',
     '<rootDir>../../src/dev/jest/setup/monaco_mock.js',
   ],
@@ -20,7 +21,7 @@ module.exports = {
     '\\.(css|less|scss)$': '<rootDir>/test/mocks/styleMock.js',
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
     '^opensearch-dashboards/public$': '<rootDir>/../../src/core/public',
-    '^!!raw-loader!.*': 'jest-raw-loader',
+    '^!!raw-loader!.*': '<rootDir>/test/mocks/rawLoaderMock.js',
   },
   snapshotSerializers: ['../../node_modules/enzyme-to-json/serializer'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
@@ -47,6 +48,17 @@ module.exports = {
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   modulePathIgnorePatterns: ['alertingDashboards'],
   testEnvironment: 'jest-environment-jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '^.+\\.svg$': '<rootDir>/test/utils/mockTransform.js',
@@ -55,6 +67,6 @@ module.exports = {
   transformIgnorePatterns: [
     // ignore all node_modules except d3-color which requires babel transforms to handle export statement
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios|uuid))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios|uuid|query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
   ],
 };

--- a/test/mocks/rawLoaderMock.js
+++ b/test/mocks/rawLoaderMock.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Stub for `!!raw-loader!` imports. jest-raw-loader is incompatible with the
+// Jest 28+ transformer API and was removed during the Jest 30 upgrade. No test
+// asserts the real raw file contents, so a string stub preserves the prior
+// behaviour.
+module.exports = 'raw-loader-stub';

--- a/test/setup.jest.js
+++ b/test/setup.jest.js
@@ -24,6 +24,42 @@ jest.mock('@elastic/eui/lib/services/accessibility', () => ({
   accessibleClickKeys: require('@elastic/eui/lib/services/accessibility/accessible_click_keys'),
 }));
 
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'
+// in all jsdom tests, consistent with the rest of the suite.
+process.env.HOST = 'http://localhost:5601';
+
+// Mock window.matchMedia for Monaco editor / EUI. Declared configurable so tests
+// may override it without hitting "Cannot redefine property" under jsdom 26.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
+});
+
 // https://github.com/facebook/jest/issues/5785
 // https://github.com/facebook/jest/pull/5267#issuecomment-356605468
 beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decode-uri-component@^0.2.1, decode-uri-component@^0.4.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
 
 dedent@^0.7.0:
   version "0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decode-uri-component@^0.2.0, decode-uri-component@^0.2.1:
+decode-uri-component@^0.2.1, decode-uri-component@^0.4.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -1236,10 +1236,10 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 find-root@^1.1.0:
   version "1.1.0"
@@ -2436,15 +2436,14 @@ qs@^6.15.2, qs@~6.14.1:
   dependencies:
     side-channel "^1.1.0"
 
-query-string@^6.13.2:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
-  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+query-string@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-9.4.1.tgz#fc5b1cc5c1944eaa1c8e6d4912b5bb90dc66fa2d"
+  integrity sha512-lSyJeN3RuaG7DZGWThtYRhk96+kEyZ/+doZpERuWbjeFL+Ok3vEat/swU498rAI0NcVt5/RJp8UDuLz7FckxrA==
   dependencies:
-    decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -2856,10 +2855,10 @@ source-map@^0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 sshpk@^1.18.0:
   version "1.18.0"
@@ -2883,11 +2882,6 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-argv@0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Closes #1489

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `145 suites passed (5 skipped) / 833 tests passed (49 skipped) /
190 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  is `http://localhost:5601` rather than the jsdom default; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults to `false`, which would invalidate existing snapshots); replaced the
  `jest-raw-loader` moduleNameMapper with a local stub (`test/mocks/rawLoaderMock.js`) since
  jest-raw-loader is incompatible with the Jest 28+ transformer API.
- **Setup (`test/setup.jest.js`):** set `process.env.HOST = 'http://localhost:5601'` so
  jest-location-mock uses a base URL consistent with `testEnvironmentOptions.url`; made the
  `matchMedia` mock `configurable` (avoids "Cannot redefine property" under jsdom 26); re-declared
  the non-configurable `localStorage`/`sessionStorage` as configurable so individual tests can still
  override them via `Object.defineProperty`.
- **Snapshots:** bulk-updated the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 109 `.snap` files — Jest 30 refuses to load the old
  header. No snapshot content was regenerated; every non-header diff is header-only, so there are no
  content regressions.

#### Plugin-specific changes
- **`query-string` ESM fix (`test/jest.config.js`):** the plugin imports `query-string` (v6) across
  ~10 source files (e.g. `public/pages/Monitors/containers/Monitors/Monitors.js`,
  `public/pages/Destinations/containers/DestinationsList/...`,
  `public/pages/Dashboard/...`). Under Jest 30 its now-ESM-only transitive deps fail to parse, so the
  `transformIgnorePatterns` allowlist was extended to also transform
  `query-string`, `decode-uri-component`, `filter-obj`, and `split-on-first`.
- **Raw-loader stub (`test/mocks/rawLoaderMock.js`):** new file — a `'raw-loader-stub'` string export
  that replaces `jest-raw-loader` for `!!raw-loader!` imports. No test asserts real raw-file contents,
  so the string stub preserves prior behaviour.

No matcher codemod, no `TextEncoder` polyfill, no enzyme adapter swap, and no source-code
(`window.location`/`window.URL`/timer) edits were required for this plugin — the change set is limited
to test config, setup, the raw-loader stub, and snapshot header bumps.

No `package.json` change needed for the migration — the plugin inherits the parent repo's Jest 30
stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
