### PR TITLE
fix: render alerts for local-cluster monitors when data source is enabled (#1488)

### DIFF
--- a/public/pages/Dashboard/containers/DashboardClassic.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.js
@@ -98,8 +98,8 @@ export default class DashboardClassic extends Component {
         typeof totalAlerts === 'number'
           ? totalAlerts
           : Number.isFinite(Number(totalAlerts))
-          ? Number(totalAlerts)
-          : NaN;
+            ? Number(totalAlerts)
+            : NaN;
       const normalizedTotal = Number.isFinite(numeric) ? numeric : 0;
       this.props.onTotalsChange({ totalAlerts: normalizedTotal });
     }
@@ -172,10 +172,6 @@ export default class DashboardClassic extends Component {
       const storedDataSourceId = _.get(this.dataSourceQuery, 'query.dataSourceId');
       const resolvedDataSourceId =
         storedDataSourceId ?? getDataSourceId(this.props.landingDataSourceId);
-
-      if (dataSourceEnabled() && resolvedDataSourceId === undefined) {
-        return;
-      }
 
       if (resolvedDataSourceId !== undefined && !storedDataSourceId) {
         this.dataSourceQuery = { query: { dataSourceId: resolvedDataSourceId } };

--- a/public/pages/Dashboard/containers/DashboardClassic.test.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+jest.mock('../../../services', () => {
+  const services = jest.requireActual('../../../services/services');
+  return {
+    ...services,
+    getUseUpdatedUx: jest.fn(() => false),
+  };
+});
+
+import DashboardClassic from './DashboardClassic';
+import {
+  setDataSourceEnabled,
+  setDataSource,
+  setAssistantClient,
+} from '../../../services/services';
+import { historyMock, httpClientMock } from '../../../../test/mocks';
+import { setupCoreStart } from '../../../../test/utils/helpers';
+
+const location = {
+  hash: '',
+  search: '',
+  state: undefined,
+};
+
+const getAlertsQuery = () => {
+  const call = httpClientMock.get.mock.calls.find(([path]) => path === '../api/alerting/alerts');
+  return call ? call[1].query : undefined;
+};
+
+beforeAll(() => {
+  setupCoreStart();
+  // The agent-config lookup runs during mount; provide a stub so the real code
+  // path resolves instead of throwing "AssistantClient was not set."
+  setAssistantClient({ agentConfigExists: jest.fn().mockResolvedValue({ exists: false }) });
+});
+
+describe('DashboardClassic getAlerts (issue #1488)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    httpClientMock.get.mockResolvedValue({
+      ok: true,
+      alerts: [],
+      totalAlerts: 0,
+      resp: { totalAlerts: 0, alerts: [] },
+    });
+  });
+
+  afterEach(() => {
+    // Reset the module-level MDS singletons to their default.
+    setDataSourceEnabled({ enabled: false });
+    setDataSource({ dataSourceId: undefined });
+  });
+
+  const mount = (props = {}) =>
+    shallow(
+      <DashboardClassic
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        perAlertView={true}
+        monitorIds={['monitor-1']}
+        {...props}
+      />
+    );
+
+  test('fetches alerts for a local-cluster monitor when the data source feature is enabled', () => {
+    // Regression for #1488: data_source.enabled is true, but this is a plain
+    // local-cluster monitor with no data source association, so no dataSourceId
+    // resolves. The request must still be issued (previously an early-return
+    // guard silently no-op'd here, rendering a blank page).
+    setDataSourceEnabled({ enabled: true });
+    setDataSource({ dataSourceId: undefined });
+
+    mount();
+
+    const query = getAlertsQuery();
+    expect(query).toBeDefined();
+    // Local cluster -> dataSourceId must be omitted (the server treats a missing
+    // dataSourceId as "use the local cluster").
+    expect(query).not.toHaveProperty('dataSourceId');
+    expect(query.monitorIds).toEqual(['monitor-1']);
+  });
+
+  test('includes dataSourceId when the data source feature is enabled and a data source resolves', () => {
+    setDataSourceEnabled({ enabled: true });
+    setDataSource({ dataSourceId: 'ds-123' });
+
+    mount();
+
+    const query = getAlertsQuery();
+    expect(query).toBeDefined();
+    expect(query.dataSourceId).toBe('ds-123');
+  });
+
+  test('fetches alerts when the data source feature is disabled', () => {
+    setDataSourceEnabled({ enabled: false });
+
+    mount();
+
+    const query = getAlertsQuery();
+    expect(query).toBeDefined();
+    expect(query).not.toHaveProperty('dataSourceId');
+  });
+});


### PR DESCRIPTION
### Description

When `data_source.enabled: true`, viewing a local-cluster monitor's own **Alerts** tab — or clicking through from an alert on the Alerting overview into an individual alert — rendered a **blank page**: no alerts, no error, and no request to `/api/alerting/alerts` ever issued.

Root cause is in `public/pages/Dashboard/containers/DashboardClassic.js`, `getAlerts()`:

```js
if (dataSourceEnabled() && resolvedDataSourceId === undefined) {
  return;
}
```

For a plain local-cluster monitor (no data source association), `resolvedDataSourceId` is `undefined`, so this guard treated the normal local-cluster case as disqualifying and silently returned before making any request. Both the monitor's own Alerts tab and the individual-alert click-through render through this same method, so both went blank.

This change removes the early-return guard. `params.dataSourceId` is still only set when a data source actually resolves (a few lines further down), so the local-cluster case correctly omits it — and the server treats a missing `dataSourceId` as the local cluster. This mirrors the fix already applied to the overview alerts card in #1099 (`DataSourceAlertsCard`), bringing `DashboardClassic` in line with that accepted pattern.

A regression test (`DashboardClassic.test.js`) is added covering three cases: local-cluster + data source enabled (issues the request with no `dataSourceId`), data source enabled + resolved id (includes `dataSourceId`), and data source disabled.

### Issues Resolved

Closes #1488

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.