### PR TITLE
Integrate centralized resource-sharing share button for monitors and workflows

### DIFF
--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -136,7 +136,7 @@ export default class Monitors extends Component {
               // button is mounted here by security-dashboards-plugin when
               // installed and resource sharing is enabled for monitors.
               field: 'id',
-              name: 'Share',
+              name: 'Access',
               sortable: false,
               width: '50px',
               render: (id, item) => {
@@ -149,6 +149,7 @@ export default class Monitors extends Component {
                     data-resource-share-button
                     data-resource-id={id}
                     data-resource-type={resourceType}
+                    {...(item.name ? { 'data-resource-name': item.name } : {})}
                     data-resource-share-display="icon"
                   />
                 ) : null;

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -25,7 +25,12 @@ import {
   isDataSourceChanged,
   getDataSourceId,
 } from '../../../utils/helpers';
-import { getUseUpdatedUx } from '../../../../services';
+import {
+  ALERTING_WORKFLOW_RESOURCE_TYPE,
+  getUseUpdatedUx,
+  isResourceSharingAvailable,
+  MONITOR_RESOURCE_TYPE,
+} from '../../../../services';
 
 const MAX_MONITOR_COUNT = 1000;
 
@@ -124,6 +129,33 @@ export default class Monitors extends Component {
 
     return [
       ...staticColumns,
+      ...(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)
+        ? [
+            {
+              // Resource-sharing SPI marker column: the centralized Share
+              // button is mounted here by security-dashboards-plugin when
+              // installed and resource sharing is enabled for monitors.
+              field: 'id',
+              name: 'Share',
+              sortable: false,
+              width: '50px',
+              render: (id, item) => {
+                const resourceType =
+                  item.monitor?.type === 'workflow'
+                    ? ALERTING_WORKFLOW_RESOURCE_TYPE
+                    : MONITOR_RESOURCE_TYPE;
+                return isResourceSharingAvailable(resourceType) ? (
+                  <div
+                    data-resource-share-button
+                    data-resource-id={id}
+                    data-resource-type={resourceType}
+                    data-resource-share-display="icon"
+                  />
+                ) : null;
+              },
+            },
+          ]
+        : []),
       {
         name: 'Actions',
         width: '60px',

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -129,12 +129,14 @@ export default class Monitors extends Component {
 
     return [
       ...staticColumns,
-      ...(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)
+      ...(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE) ||
+      isResourceSharingAvailable(ALERTING_WORKFLOW_RESOURCE_TYPE)
         ? [
             {
               // Resource-sharing SPI marker column: the centralized Share
               // button is mounted here by security-dashboards-plugin when
-              // installed and resource sharing is enabled for monitors.
+              // installed and resource sharing is enabled for monitors or
+              // composite (workflow) monitors.
               field: 'id',
               name: 'Access',
               sortable: false,

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -138,7 +138,7 @@ export default class Monitors extends Component {
               field: 'id',
               name: 'Access',
               sortable: false,
-              width: '50px',
+              width: '120px',
               render: (id, item) => {
                 const resourceType =
                   item.monitor?.type === 'workflow'

--- a/public/pages/Monitors/containers/Monitors/Monitors.test.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.test.js
@@ -478,4 +478,27 @@ describe('Monitors resource sharing Access column', () => {
       .find((column) => column.name === 'Access');
     expect(accessColumn).toBeUndefined();
   });
+
+  test('renders the Access column when only the workflow type is available', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'workflow' });
+    const accessColumn = getMountWrapper()
+      .instance()
+      .buildColumns()
+      .find((column) => column.name === 'Access');
+    expect(accessColumn).toBeDefined();
+
+    // A composite (workflow) monitor row still gets a share-button marker.
+    const workflowMarker = accessColumn.render('workflow-1', {
+      name: 'My Workflow',
+      monitor: { type: 'workflow' },
+    });
+    expect(workflowMarker.props['data-resource-type']).toBe('workflow');
+
+    // A regular monitor row renders nothing, since the monitor type is not shared.
+    const monitorMarker = accessColumn.render('monitor-1', {
+      name: 'My Monitor',
+      monitor: { type: 'query_level_monitor' },
+    });
+    expect(monitorMarker).toBeNull();
+  });
 });

--- a/public/pages/Monitors/containers/Monitors/Monitors.test.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.test.js
@@ -8,6 +8,7 @@ import { mount, shallow } from 'enzyme';
 import _ from 'lodash';
 
 import Monitors from './Monitors';
+import { getApplication, setApplication } from '../../../../services';
 import { historyMock, httpClientMock } from '../../../../../test/mocks';
 import { AlertingFakes, setupCoreStart } from '../../../../../test/utils/helpers';
 
@@ -414,5 +415,67 @@ describe('Monitors', () => {
 
     expect(getItemId).toHaveBeenCalled();
     expect(response).toBe('item_id-143534534345');
+  });
+});
+
+describe('Monitors resource sharing Access column', () => {
+  let originalApplication;
+
+  beforeEach(() => {
+    httpClientMock.get.mockResolvedValue({ ok: true, monitors: [], totalMonitors: 0 });
+    originalApplication = getApplication();
+  });
+
+  afterEach(() => setApplication(originalApplication));
+
+  const setResourceSharing = (resourceSharing) =>
+    setApplication({
+      ...originalApplication,
+      capabilities: { ...(originalApplication?.capabilities || {}), resourceSharing },
+    });
+
+  test('adds an Access column with a share-button marker when resource sharing is available', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'monitor,workflow' });
+    const wrapper = getMountWrapper();
+    const accessColumn = wrapper
+      .instance()
+      .buildColumns()
+      .find((column) => column.name === 'Access');
+    expect(accessColumn).toBeDefined();
+
+    const marker = accessColumn.render('monitor-1', {
+      name: 'My Monitor',
+      monitor: { type: 'query_level_monitor' },
+    });
+    expect(marker.props['data-resource-id']).toBe('monitor-1');
+    expect(marker.props['data-resource-type']).toBe('monitor');
+    expect(marker.props['data-resource-name']).toBe('My Monitor');
+    expect(marker.props['data-resource-share-display']).toBe('icon');
+  });
+
+  test('uses the workflow resource type for composite (workflow) monitors', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'monitor,workflow' });
+    const wrapper = getMountWrapper();
+    const accessColumn = wrapper
+      .instance()
+      .buildColumns()
+      .find((column) => column.name === 'Access');
+
+    const marker = accessColumn.render('workflow-1', {
+      name: 'My Workflow',
+      monitor: { type: 'workflow' },
+    });
+    expect(marker.props['data-resource-id']).toBe('workflow-1');
+    expect(marker.props['data-resource-type']).toBe('workflow');
+  });
+
+  test('does not add the Access column when resource sharing is unavailable', () => {
+    setResourceSharing(undefined);
+    const wrapper = getMountWrapper();
+    const accessColumn = wrapper
+      .instance()
+      .buildColumns()
+      .find((column) => column.name === 'Access');
+    expect(accessColumn).toBeUndefined();
   });
 });

--- a/public/services/__tests__/resource_sharing.test.ts
+++ b/public/services/__tests__/resource_sharing.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  isResourceSharingAvailable,
+  setApplication,
+  MONITOR_RESOURCE_TYPE,
+  ALERTING_WORKFLOW_RESOURCE_TYPE,
+} from '../services';
+
+const setResourceSharing = (resourceSharing?: Record<string, unknown>) =>
+  setApplication({ capabilities: resourceSharing ? { resourceSharing } : {} } as any);
+
+describe('isResourceSharingAvailable', () => {
+  it('returns false when the resourceSharing capability is absent', () => {
+    setResourceSharing();
+    expect(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)).toBe(false);
+  });
+
+  it('returns false when resource sharing is disabled', () => {
+    setResourceSharing({ enabled: false, availableTypes: 'monitor' });
+    expect(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)).toBe(false);
+  });
+
+  it('returns false when the resource type is not in availableTypes', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'anomaly-detector,notification_config' });
+    expect(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)).toBe(false);
+  });
+
+  it('returns true when enabled and the monitor type is present', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'monitor,workflow' });
+    expect(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)).toBe(true);
+  });
+
+  it('returns true for the workflow resource type when present', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'monitor,workflow' });
+    expect(isResourceSharingAvailable(ALERTING_WORKFLOW_RESOURCE_TYPE)).toBe(true);
+  });
+});

--- a/public/services/__tests__/resource_sharing.test.ts
+++ b/public/services/__tests__/resource_sharing.test.ts
@@ -38,4 +38,10 @@ describe('isResourceSharingAvailable', () => {
     setResourceSharing({ enabled: true, availableTypes: 'monitor,workflow' });
     expect(isResourceSharingAvailable(ALERTING_WORKFLOW_RESOURCE_TYPE)).toBe(true);
   });
+
+  it('trims whitespace around availableTypes tokens', () => {
+    setResourceSharing({ enabled: true, availableTypes: 'monitor, workflow' });
+    expect(isResourceSharingAvailable(MONITOR_RESOURCE_TYPE)).toBe(true);
+    expect(isResourceSharingAvailable(ALERTING_WORKFLOW_RESOURCE_TYPE)).toBe(true);
+  });
 });

--- a/public/services/services.ts
+++ b/public/services/services.ts
@@ -101,6 +101,28 @@ export const isServerlessEnabled = () => {
   return !!capabilities?.alertingDashboards?.serverlessEnabled;
 };
 
+/**
+ * Resource types registered by the alerting backend plugin with the security
+ * plugin's resource-sharing framework (AlertingResourceSharingExtension).
+ */
+export const MONITOR_RESOURCE_TYPE = 'monitor';
+export const ALERTING_WORKFLOW_RESOURCE_TYPE = 'workflow';
+
+/**
+ * Whether resource sharing is available for the given alerting resource type,
+ * via the core capability registered by security-dashboards-plugin. False
+ * when that plugin is not installed, the feature is disabled, or the type is
+ * not registered — no plugin dependency involved.
+ */
+export const isResourceSharingAvailable = (resourceType: string): boolean => {
+  const application = getApplication();
+  const capabilities = application?.capabilities as Record<string, any> | undefined;
+  const resourceSharing = capabilities?.resourceSharing;
+  if (!resourceSharing?.enabled) return false;
+  const types: string = resourceSharing.availableTypes ?? '';
+  return types.split(',').includes(resourceType);
+};
+
 export const getUseUpdatedUx = () => {
   return getUISettings().get('home:useNewHomePage', false);
 };

--- a/public/services/services.ts
+++ b/public/services/services.ts
@@ -120,7 +120,10 @@ export const isResourceSharingAvailable = (resourceType: string): boolean => {
   const resourceSharing = capabilities?.resourceSharing;
   if (!resourceSharing?.enabled) return false;
   const types: string = resourceSharing.availableTypes ?? '';
-  return types.split(',').includes(resourceType);
+  return types
+    .split(',')
+    .map((type) => type.trim())
+    .includes(resourceType);
 };
 
 export const getUseUpdatedUx = () => {


### PR DESCRIPTION
### Description
Integrates the centralized share button from [security-dashboards-plugin PR #2491](https://github.com/opensearch-project/security-dashboards-plugin/pull/2491) via its dependency-free DOM-marker SPI, surfacing per-monitor sharing directly in the monitors list.

**How it works**
- A Share column in the monitors table renders marker elements (`data-resource-share-button` + id/type attributes); the security dashboards plugin discovers them and mounts its centralized Share/Update Access button + modal
- Rows resolve their resource type per item: composite monitors map to the `workflow` type, all other monitors to `monitor` — matching the types registered by `AlertingResourceSharingExtension` in [alerting#2180](https://github.com/opensearch-project/alerting/pull/2180)
- The column is gated on the core `resourceSharing` capability (`enabled` + type present in `availableTypes`), so it is completely absent when the security dashboards plugin is not installed, the feature is disabled, or the alerting backend does not yet contain #2180 — no dependency on the security plugin (no manifest changes, no imports)

### Draft status
Blocked on two upstream merges: security-dashboards-plugin#2491 (provides the SPI + capability) and alerting#2180 (registers the types). Safe to merge before either — the column stays dormant until both are present.

### Testing
- Compiled and loaded against OSD main + OpenSearch 3.8.0 with resource sharing enabled; column correctly absent while the backend lacks #2180
- Share flow semantics (modal, can_share graying, feature-off hiding) covered by the security-dashboards-plugin PR's unit/integration tests

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.