### PR TITLE
fix: don't auto-run monitor preview before index/time field are set

### DIFF
--- a/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
+++ b/public/pages/CreateMonitor/containers/DefineMonitor/DefineMonitor.js
@@ -348,8 +348,8 @@ class DefineMonitor extends Component {
                     'Invalid input in data filter. Remove data filter or adjust filter '
                   )
                 : loadingResponse
-                ? renderEmptyMessage()
-                : previewContent()}
+                  ? renderEmptyMessage()
+                  : previewContent()}
             </EuiAccordion>
             <EuiSpacer size="m" />
           </>
@@ -369,6 +369,24 @@ class DefineMonitor extends Component {
         const canExecute = searchType === SEARCH_TYPE.GRAPH && validDocLevelGraphQueries(queries);
         if (!canExecute) return;
     }
+
+    // Don't attempt to run a preview until the query is actually executable.
+    // A freshly-opened monitor (e.g. reached via a direct deep-link to
+    // #/create-monitor, which mounts CreateMonitor before the data source
+    // resolves) has no index and no time field yet. Building a graph/query
+    // request from that state yields a `range` clause with an empty field
+    // name (`{ range: { "": {...} } }`), which the backend rejects with
+    // "[bool] failed to parse field [filter]" and surfaces as a spurious
+    // "Failed to run the query" toast. componentDidMount already gates the
+    // initial run on these conditions; centralize the same guard here so the
+    // componentDidUpdate aggregation/bucket branch can't bypass it.
+    const isIndexBackedSearch =
+      searchType === SEARCH_TYPE.GRAPH || searchType === SEARCH_TYPE.QUERY;
+    const hasIndices = Array.isArray(values.index) && values.index.length > 0;
+    if (isIndexBackedSearch && (!hasIndices || (this.requiresTimeField() && !values.timeField))) {
+      return;
+    }
+
     this.setState({ loadingResponse: true });
 
     const formikSnapshot = _.cloneDeep(values);


### PR DESCRIPTION
### Description

The Define Monitor step auto-runs a preview query (`_execute`) as soon as the create-monitor page mounts and its Formik state settles. For a **fresh** monitor that state is empty (`index: []`, `timeField: ''`), so the graph request builder emits a range clause with an empty field name:

```json
{ "query": { "bool": { "filter": [ { "range": { "": { ... } } } ] } } }
```

The backend rejects this and the user is greeted with a spurious error toast on landing:

> Failed to run the query  
> `[alerting_exception] [1:443] [bool] failed to parse field [filter]`

Why it shows up now: the `/create-monitor` route in `Main.js` renders outside the `!dataSourceLoading` guard, so it mounts before the data source resolves. When the data source resolves post-mount, `componentDidUpdate`'s aggregation/bucket/groupBy branch calls `onRunQuery()` while index/time field are still empty. This is most reliably hit when landing on `#/create-monitor` via a full-page navigation (e.g. an external deep-link), which cold-boots the app; clicking "Create monitor" from within the already-loaded app is "warm" and usually doesn't trigger it.

`componentDidMount` already gates its initial run on `hasIndices + (hasTimeField || !requiresTimeField())`, but `onRunQuery` itself and the `componentDidUpdate` branch had no such guard.

### Changes

- Add an early return at the top of `onRunQuery()` that skips execution for index-backed search types (`GRAPH`, `QUERY`) when no index is selected, or when a time field is required but not yet set. This centralizes the guard that previously lived only in `componentDidMount`, so every caller is covered.
- `CLUSTER_METRICS` and `PPL` are intentionally unaffected (they don't build an index/time-field range query); `requiresTimeField()` already returns `false` for non-graph and cluster-metrics/doc-level types, so the time-field half of the guard only applies where a time field is genuinely required.
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
