### PR TITLE
Fix/ppl monitor test notification

### DIFF
--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
@@ -275,8 +275,10 @@ class ConfigureActionsPpl extends React.Component {
     _.set(payload, 'ppl_monitor.enabled', true);
 
     try {
+      // Note: unlike the v1 _execute route, the v2 route's query schema only
+      // accepts dataSourceId -- passing dryrun fails validation with 400.
       const response = await httpClient.post('/api/alerting/v2/monitors/_execute', {
-        query: { dryrun: false, dataSourceId: getDataSourceId() },
+        query: { dataSourceId: getDataSourceId() },
         body: JSON.stringify(payload),
       });
 
@@ -297,7 +299,15 @@ class ConfigureActionsPpl extends React.Component {
         backendErrorNotification(notifications, 'send', 'test message', errorMessage);
       }
     } catch (err) {
+      // A rejected fetch (e.g. route validation 400) never reaches the
+      // response.ok path -- surface it as a toast instead of failing silently.
       console.error('There was an error trying to send test message', err);
+      backendErrorNotification(
+        notifications,
+        'send',
+        'test message',
+        err?.body?.message || err?.message || String(err)
+      );
     }
   };
 

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
@@ -20,6 +20,7 @@ import {
 import { backendErrorNotification } from '../../../../utils/helpers';
 import { TRIGGER_TYPE } from '../CreateTrigger/utils/constants';
 import { formikToTrigger } from '../CreateTrigger/utils/formikToTrigger';
+import { buildPPLMonitorFromFormik } from '../../../CreateMonitor/containers/CreateMonitor/utils/pplFormikToMonitor';
 import { getChannelOptions, toChannelType } from '../../utils/helper';
 import { getDataSourceId } from '../../../utils/helpers';
 import { isServerlessDataSource } from '../../../../services';
@@ -249,6 +250,57 @@ class ConfigureActionsPpl extends React.Component {
     this.setState({ isInitialLoading: false });
   };
 
+  // PPL monitors use the v2 API shape ({ ppl_monitor: {...} } with ppl-typed
+  // triggers). The generic sendTestMessage path below serializes a v1
+  // query-level monitor (painless condition at the top level), which the
+  // backend rejects for monitor_type ppl_monitor with
+  // "Incompatible trigger [...] for monitor type [ppl_monitor]".
+  sendTestMessageForPplMonitor = async (index) => {
+    const { httpClient, notifications, triggerIndex, values } = this.props;
+    const { flattenedDestinations } = this.state;
+
+    const payload = _.cloneDeep(buildPPLMonitorFromFormik(values));
+    const triggers = _.get(payload, 'ppl_monitor.triggers', []);
+    const testTrigger = _.cloneDeep(triggers[triggerIndex] || triggers[0]);
+    if (!testTrigger) return;
+
+    const action = _.get(testTrigger, `actions[${index}]`);
+    // Force the trigger to fire so the action is exercised regardless of data.
+    testTrigger.actions = [action];
+    testTrigger.type = 'number_of_results';
+    testTrigger.num_results_condition = '>=';
+    testTrigger.num_results_value = 0;
+    testTrigger.custom_condition = null;
+    _.set(payload, 'ppl_monitor.triggers', [testTrigger]);
+    _.set(payload, 'ppl_monitor.enabled', true);
+
+    try {
+      const response = await httpClient.post('/api/alerting/v2/monitors/_execute', {
+        query: { dryrun: false, dataSourceId: getDataSourceId() },
+        body: JSON.stringify(payload),
+      });
+
+      let error = null;
+      if (response.ok) {
+        error = checkForError(response, error);
+        if (!_.isEmpty(action?.destination_id)) {
+          const destinationName = _.get(
+            _.find(flattenedDestinations, { value: action.destination_id }),
+            'label'
+          );
+          notifications.toasts.addSuccess(`Test message sent to "${destinationName}."`);
+        }
+      }
+      if (error || !response.ok) {
+        const errorMessage = error == null ? response.resp : error;
+        console.error('There was an error trying to send test message', errorMessage);
+        backendErrorNotification(notifications, 'send', 'test message', errorMessage);
+      }
+    } catch (err) {
+      console.error('There was an error trying to send test message', err);
+    }
+  };
+
   sendTestMessage = async (index) => {
     const {
       context: { monitor },
@@ -258,6 +310,11 @@ class ConfigureActionsPpl extends React.Component {
       values,
     } = this.props;
     const { flattenedDestinations } = this.state;
+
+    if (monitor.monitor_type === MONITOR_TYPE.PPL) {
+      return this.sendTestMessageForPplMonitor(index);
+    }
+
     let testTrigger = _.cloneDeep(formikToTrigger(values, monitor.ui_metadata)[triggerIndex]);
     let action;
     let condition;

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.js
@@ -255,9 +255,31 @@ class ConfigureActionsPpl extends React.Component {
   // query-level monitor (painless condition at the top level), which the
   // backend rejects for monitor_type ppl_monitor with
   // "Incompatible trigger [...] for monitor type [ppl_monitor]".
+  // Shared result handling for both the v1 and PPL test-message paths
+  // (checkForError -> success toast -> backendErrorNotification).
+  handleTestMessageResponse = (response, action) => {
+    const { notifications } = this.props;
+    const { flattenedDestinations } = this.state;
+    let error = null;
+    if (response.ok) {
+      error = checkForError(response, error);
+      if (!_.isEmpty(action?.destination_id)) {
+        const destinationName = _.get(
+          _.find(flattenedDestinations, { value: action.destination_id }),
+          'label'
+        );
+        notifications.toasts.addSuccess(`Test message sent to "${destinationName}."`);
+      }
+    }
+    if (error || !response.ok) {
+      const errorMessage = error == null ? response.resp : error;
+      console.error('There was an error trying to send test message', errorMessage);
+      backendErrorNotification(notifications, 'send', 'test message', errorMessage);
+    }
+  };
+
   sendTestMessageForPplMonitor = async (index) => {
     const { httpClient, notifications, triggerIndex, values } = this.props;
-    const { flattenedDestinations } = this.state;
 
     const payload = _.cloneDeep(buildPPLMonitorFromFormik(values));
     const triggers = _.get(payload, 'ppl_monitor.triggers', []);
@@ -282,22 +304,7 @@ class ConfigureActionsPpl extends React.Component {
         body: JSON.stringify(payload),
       });
 
-      let error = null;
-      if (response.ok) {
-        error = checkForError(response, error);
-        if (!_.isEmpty(action?.destination_id)) {
-          const destinationName = _.get(
-            _.find(flattenedDestinations, { value: action.destination_id }),
-            'label'
-          );
-          notifications.toasts.addSuccess(`Test message sent to "${destinationName}."`);
-        }
-      }
-      if (error || !response.ok) {
-        const errorMessage = error == null ? response.resp : error;
-        console.error('There was an error trying to send test message', errorMessage);
-        backendErrorNotification(notifications, 'send', 'test message', errorMessage);
-      }
+      this.handleTestMessageResponse(response, action);
     } catch (err) {
       // A rejected fetch (e.g. route validation 400) never reaches the
       // response.ok path -- surface it as a toast instead of failing silently.
@@ -315,11 +322,9 @@ class ConfigureActionsPpl extends React.Component {
     const {
       context: { monitor },
       httpClient,
-      notifications,
       triggerIndex,
       values,
     } = this.props;
-    const { flattenedDestinations } = this.state;
 
     if (monitor.monitor_type === MONITOR_TYPE.PPL) {
       return this.sendTestMessageForPplMonitor(index);
@@ -380,22 +385,7 @@ class ConfigureActionsPpl extends React.Component {
         body: JSON.stringify(testMonitor),
       });
 
-      let error = null;
-      if (response.ok) {
-        error = checkForError(response, error);
-        if (!_.isEmpty(action.destination_id)) {
-          const destinationName = _.get(
-            _.find(flattenedDestinations, { value: action.destination_id }),
-            'label'
-          );
-          notifications.toasts.addSuccess(`Test message sent to "${destinationName}."`);
-        }
-      }
-      if (error || !response.ok) {
-        const errorMessage = error == null ? response.resp : error;
-        console.error('There was an error trying to send test message', errorMessage);
-        backendErrorNotification(notifications, 'send', 'test message', errorMessage);
-      }
+      this.handleTestMessageResponse(response, action);
     } catch (err) {
       console.error('There was an error trying to send test message', err);
     }

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
@@ -7,10 +7,12 @@ import ConfigureActionsPpl from './ConfigureActionsPpl';
 import { MONITOR_TYPE } from '../../../../utils/constants';
 
 jest.mock('../../../utils/helpers', () => ({
+  ...jest.requireActual('../../../utils/helpers'),
   getDataSourceId: jest.fn(() => 'test-ds-id'),
 }));
 
 jest.mock('../../../../services', () => ({
+  ...jest.requireActual('../../../../services'),
   isServerlessDataSource: jest.fn(() => false),
   getNotifications: jest.fn(),
 }));

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
@@ -75,7 +75,8 @@ describe('ConfigureActionsPpl sendTestMessage for PPL monitors', () => {
     expect(httpClient.post).toHaveBeenCalledTimes(1);
     const [url, options] = httpClient.post.mock.calls[0];
     expect(url).toBe('/api/alerting/v2/monitors/_execute');
-    expect(options.query).toEqual({ dryrun: false, dataSourceId: 'test-ds-id' });
+    // v2 route query schema only accepts dataSourceId (no dryrun, unlike v1)
+    expect(options.query).toEqual({ dataSourceId: 'test-ds-id' });
   });
 
   test('sends a v2 ppl_monitor payload with no v1 query-level trigger shape', async () => {

--- a/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
+++ b/public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import ConfigureActionsPpl from './ConfigureActionsPpl';
+import { MONITOR_TYPE } from '../../../../utils/constants';
+
+jest.mock('../../../utils/helpers', () => ({
+  getDataSourceId: jest.fn(() => 'test-ds-id'),
+}));
+
+jest.mock('../../../../services', () => ({
+  isServerlessDataSource: jest.fn(() => false),
+  getNotifications: jest.fn(),
+}));
+
+const buildFormikValues = () => ({
+  name: 'PPL test monitor',
+  monitor_type: MONITOR_TYPE.PPL,
+  pplQuery: "source = `logs-*` | where body like '%[ERROR]%'",
+  useLookBackWindow: false,
+  frequency: 'interval',
+  period: { interval: 1, unit: 'MINUTES' },
+  triggerDefinitions: [
+    {
+      name: 'trigger one',
+      severity: '4',
+      num_results_condition: '>',
+      num_results_value: 5,
+      actions: [
+        {
+          id: 'action-0',
+          name: 'Notification 1',
+          destination_id: 'sns-channel-id',
+          message_template: { source: 'hello', lang: 'mustache' },
+          subject_template: { source: 'subject', lang: 'mustache' },
+          throttle_enabled: false,
+        },
+        {
+          id: 'action-1',
+          name: 'Notification 2',
+          destination_id: 'other-channel-id',
+          message_template: { source: 'hello 2', lang: 'mustache' },
+          subject_template: { source: 'subject 2', lang: 'mustache' },
+          throttle_enabled: false,
+        },
+      ],
+    },
+  ],
+});
+
+const buildComponent = (httpClient) => {
+  const props = {
+    context: { monitor: { monitor_type: MONITOR_TYPE.PPL, ui_metadata: {} } },
+    httpClient,
+    notifications: { toasts: { addSuccess: jest.fn(), addDanger: jest.fn() } },
+    triggerIndex: 0,
+    values: buildFormikValues(),
+    fieldPath: '',
+    flyoutMode: '',
+  };
+  const component = new ConfigureActionsPpl(props);
+  component.state = { ...component.state, flattenedDestinations: [] };
+  return component;
+};
+
+describe('ConfigureActionsPpl sendTestMessage for PPL monitors', () => {
+  test('dispatches PPL monitors to the v2 _execute endpoint', async () => {
+    const httpClient = { post: jest.fn().mockResolvedValue({ ok: true, resp: {} }) };
+    const component = buildComponent(httpClient);
+
+    await component.sendTestMessage(0);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    const [url, options] = httpClient.post.mock.calls[0];
+    expect(url).toBe('/api/alerting/v2/monitors/_execute');
+    expect(options.query).toEqual({ dryrun: false, dataSourceId: 'test-ds-id' });
+  });
+
+  test('sends a v2 ppl_monitor payload with no v1 query-level trigger shape', async () => {
+    const httpClient = { post: jest.fn().mockResolvedValue({ ok: true, resp: {} }) };
+    const component = buildComponent(httpClient);
+
+    await component.sendTestMessage(0);
+
+    const body = JSON.parse(httpClient.post.mock.calls[0][1].body);
+    // v2 shape: everything under ppl_monitor
+    expect(body.ppl_monitor).toBeDefined();
+    expect(body.ppl_monitor.query).toContain('source =');
+    // No v1 artifacts: no top-level triggers, no search/match_all inputs
+    expect(body.triggers).toBeUndefined();
+    expect(body.inputs).toBeUndefined();
+    // Trigger must be ppl-typed, not a painless condition script
+    const trigger = body.ppl_monitor.triggers[0];
+    expect(trigger.condition).toBeUndefined();
+    expect(trigger.type).toBe('number_of_results');
+  });
+
+  test('forces an always-firing condition and keeps only the tested action', async () => {
+    const httpClient = { post: jest.fn().mockResolvedValue({ ok: true, resp: {} }) };
+    const component = buildComponent(httpClient);
+
+    await component.sendTestMessage(1); // test the SECOND action
+
+    const body = JSON.parse(httpClient.post.mock.calls[0][1].body);
+    const trigger = body.ppl_monitor.triggers[0];
+    expect(body.ppl_monitor.triggers).toHaveLength(1);
+    expect(trigger.num_results_condition).toBe('>=');
+    expect(trigger.num_results_value).toBe(0);
+    expect(trigger.actions).toHaveLength(1);
+    expect(trigger.actions[0].destination_id).toBe('other-channel-id');
+  });
+
+  test('non-PPL monitors still use the v1 _execute endpoint', async () => {
+    const httpClient = { post: jest.fn().mockResolvedValue({ ok: true, resp: {} }) };
+    const component = buildComponent(httpClient);
+    component.props.context.monitor = {
+      monitor_type: MONITOR_TYPE.QUERY_LEVEL,
+      ui_metadata: { triggers: {} },
+      name: 'v1 monitor',
+      schedule: { period: { interval: 1, unit: 'MINUTES' } },
+    };
+    component.props.values = {
+      ...component.props.values,
+      monitor_type: MONITOR_TYPE.QUERY_LEVEL,
+      triggerDefinitions: [
+        {
+          name: 'trigger one',
+          severity: '1',
+          script: { lang: 'painless', source: 'return true' },
+          actions: [{ id: 'a0', name: 'act', destination_id: 'd0' }],
+        },
+      ],
+    };
+
+    await component.sendTestMessage(0);
+
+    expect(httpClient.post).toHaveBeenCalledTimes(1);
+    expect(httpClient.post.mock.calls[0][0]).toBe('/api/alerting/monitors/_execute');
+  });
+
+  test('surfaces backend errors via backendErrorNotification path without throwing', async () => {
+    const httpClient = {
+      post: jest.fn().mockResolvedValue({ ok: false, resp: 'boom' }),
+    };
+    const component = buildComponent(httpClient);
+
+    await expect(component.sendTestMessage(0)).resolves.not.toThrow();
+    expect(component.props.notifications.toasts.addSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/PplAlertingMonitorService.js
+++ b/server/services/PplAlertingMonitorService.js
@@ -614,6 +614,20 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
         );
       }
 
+      // Guard against silent data loss: toV1MonitorBody defaults a missing
+      // query to '', so an update body without a query would silently wipe
+      // the monitor's PPL query. Reject it instead.
+      if (!cleanMonitor.query || !String(cleanMonitor.query).trim()) {
+        return res.ok({
+          body: {
+            ok: false,
+            resp:
+              'Monitor update rejected: the request body is missing the PPL query. ' +
+              'Updating without a query would erase the existing one.',
+          },
+        });
+      }
+
       const v1Body = toV1MonitorBody(
         await this.enrichTargetArn(context, req, { ppl_monitor: cleanMonitor })
       );

--- a/server/services/PplAlertingMonitorService.js
+++ b/server/services/PplAlertingMonitorService.js
@@ -722,7 +722,10 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const client = await this.getClientBasedOnDataSource(context, req);
-      const body = await this.enrichTargetArn(context, req, req.body);
+      // The engine only speaks the v1 monitor format -- translate the
+      // { ppl_monitor: {...} } body the same way createMonitor/updateMonitor
+      // do, otherwise Monitor.parse fails with "Monitor name is null".
+      const body = toV1MonitorBody(await this.enrichTargetArn(context, req, req.body));
       const resp = await client('transport.request', {
         method: 'POST',
         path: `${PPL_MONITOR_BASE_API}/_execute`,

--- a/server/services/PplAlertingMonitorService.test.js
+++ b/server/services/PplAlertingMonitorService.test.js
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import PplAlertingMonitorService from './PplAlertingMonitorService';
+
+const buildService = (clientImpl) => {
+  const service = new PplAlertingMonitorService(
+    /* osDriver */ { asScoped: jest.fn() },
+    /* dataSourceEnabled */ false,
+    /* logger */ { error: jest.fn(), warn: jest.fn(), info: jest.fn() }
+  );
+  // Stub the base-class collaborators so the handler logic runs in isolation.
+  service.enforceWorkspaceAcl = jest.fn().mockResolvedValue(null);
+  service.getClientBasedOnDataSource = jest.fn().mockResolvedValue(clientImpl);
+  service.enrichTargetArn = jest.fn(async (_context, _req, body) => body);
+  return service;
+};
+
+const buildRes = () => ({
+  ok: jest.fn((payload) => payload),
+});
+
+const PPL_MONITOR_BODY = {
+  ppl_monitor: {
+    name: 'my monitor',
+    enabled: true,
+    schedule: { period: { interval: 1, unit: 'MINUTES' } },
+    query: "source = logs-* | where body like '%ERROR%'",
+    triggers: [
+      {
+        name: 't1',
+        severity: 'info',
+        type: 'number_of_results',
+        num_results_condition: '>',
+        num_results_value: 1,
+        actions: [],
+        custom_condition: null,
+      },
+    ],
+  },
+};
+
+describe('PplAlertingMonitorService.updateMonitor query guard', () => {
+  test('rejects an update whose body is missing the PPL query', async () => {
+    const client = jest.fn();
+    const service = buildService(client);
+    const res = buildRes();
+    const bodyWithoutQuery = {
+      ppl_monitor: { ...PPL_MONITOR_BODY.ppl_monitor, query: undefined },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: bodyWithoutQuery },
+      res
+    );
+
+    expect(client).not.toHaveBeenCalled();
+    expect(result.body.ok).toBe(false);
+    expect(result.body.resp).toContain('missing the PPL query');
+  });
+
+  test('rejects an update whose query is only whitespace', async () => {
+    const client = jest.fn();
+    const service = buildService(client);
+    const res = buildRes();
+    const bodyBlankQuery = {
+      ppl_monitor: { ...PPL_MONITOR_BODY.ppl_monitor, query: '   ' },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: bodyBlankQuery },
+      res
+    );
+
+    expect(client).not.toHaveBeenCalled();
+    expect(result.body.ok).toBe(false);
+  });
+
+  test('forwards a valid update translated to the v1 engine format', async () => {
+    const client = jest.fn().mockResolvedValue({ _id: 'mon-1' });
+    const service = buildService(client);
+    const res = buildRes();
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: PPL_MONITOR_BODY },
+      res
+    );
+
+    expect(result.body.ok).toBe(true);
+    expect(client).toHaveBeenCalledTimes(1);
+    const [, callArgs] = client.mock.calls[0];
+    expect(callArgs.method).toBe('PUT');
+    expect(callArgs.path).toContain('/_plugins/_alerting/monitors/mon-1');
+    // v1 shape: top-level name, ppl_input inputs, ppl_trigger-wrapped triggers
+    expect(callArgs.body.name).toBe('my monitor');
+    expect(callArgs.body.monitor_type).toBe('ppl_monitor');
+    expect(callArgs.body.inputs[0].ppl_input.query).toContain('source = logs-*');
+    expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
+  });
+});
+
+describe('PplAlertingMonitorService.executeMonitor v1 translation', () => {
+  test('translates the v2 ppl_monitor body to v1 before hitting the engine', async () => {
+    const client = jest.fn().mockResolvedValue({ monitor_name: 'my monitor' });
+    const service = buildService(client);
+    const res = buildRes();
+
+    const result = await service.executeMonitor(
+      {},
+      { query: {}, body: PPL_MONITOR_BODY },
+      res
+    );
+
+    expect(result.body.ok).toBe(true);
+    const [, callArgs] = client.mock.calls[0];
+    expect(callArgs.method).toBe('POST');
+    expect(callArgs.path).toContain('/_plugins/_alerting/monitors/_execute');
+    // The engine's Monitor.parse requires a top-level name -- the untranslated
+    // { ppl_monitor: {...} } wrapper used to fail with "Monitor name is null".
+    expect(callArgs.body.name).toBe('my monitor');
+    expect(callArgs.body.ppl_monitor).toBeUndefined();
+    expect(callArgs.body.inputs[0].ppl_input.query).toContain('source = logs-*');
+  });
+});


### PR DESCRIPTION
### Description

**Bug 1: "Send test message" always fails for PPL monitors.**

`ConfigureActionsPpl.sendTestMessage` had no `MONITOR_TYPE.PPL` case in its monitor-type switch, so PPL monitors fell into the `default:` branch, which serializes a v1 query-level monitor — a top-level trigger with a painless `condition.script` and a `match_all` search input — and POSTs it to the v1 `_execute` API. The backend correctly rejects that combination with:

```
Incompatible trigger [<id>] for monitor type [ppl_monitor]
```

**Fix:** PPL monitors now build the test payload with `buildPPLMonitorFromFormik` — the same serializer used to save them, so the trigger shape (`number_of_results` etc.) is correct by construction — keep only the action under test, force an always-firing `num_results_condition: '>='` / `num_results_value: 0` condition, and POST to `/api/alerting/v2/monitors/_execute`. The v1 path for query/bucket/doc-level monitors is unchanged.

**Bug 2: the v2 `_execute` OSD route forwarded the body untranslated.**

The engine only speaks the v1 monitor format; `PplAlertingMonitorService.createMonitor`/`updateMonitor` translate via `toV1MonitorBody`, but `executeMonitor` forwarded `{ ppl_monitor: {...} }` raw, which the engine's `Monitor.parse` rejects with `Monitor name is null`.

**Fix:** apply the same `toV1MonitorBody` translation in `executeMonitor`.

**Bug 3: monitor updates could silently erase the PPL query.**

`toV1MonitorBody` defaults a missing query to `''`, so any update request whose body lacked the query silently persisted an empty query — surfacing to users as "updating a monitor drops the PPL query".

**Fix:** `updateMonitor` now rejects query-less bodies with an explicit error instead of writing an empty query.

**Also:**
- Rejected fetches (e.g. route-validation 400s) in the test-message path now surface as an error toast via `backendErrorNotification` instead of only `console.error`.
- The v2 `_execute` call no longer passes `dryrun`, which is not part of the v2 route's query schema and failed validation.

### Testing

- 10 new unit tests:
  - `public/pages/CreateTrigger/containers/ConfigureActions/ConfigureActionsPpl.test.js` — v2 endpoint dispatch for PPL monitors, `ppl_monitor` payload shape (no v1 top-level triggers / painless condition / `match_all` inputs), forced always-firing condition with only the tested action retained, v1 endpoint regression for query-level monitors, error handling.
  - `server/services/PplAlertingMonitorService.test.js` — update rejected when query is missing or whitespace-only (engine never called), valid update translated to the v1 engine format, execute body translated to v1 (top-level `name`, `ppl_input` inputs, `ppl_trigger`-wrapped triggers).
- Manually verified against OpenSearch 3.7 with the security plugin: the engine parses and executes the translated payload (`triggered: true`) via a direct `_execute` call; the update guard returns the rejection message and leaves the stored query intact; error toasts render in the UI.

### Related Issues

n/a — found while investigating PPL monitor notification failures. Happy to file tracking issues if maintainers prefer.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.