### PR TITLE
Fix/ppl lookback preview alert disable

### DIFF
--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
@@ -34,10 +34,11 @@ export const getInitialValues = ({
   detectorId,
   embeddable,
 }) => {
+  const queryParams = queryString.parse(location.search);
   let initialValues = _.mergeWith(
     {},
     _.cloneDeep(FORMIK_INITIAL_VALUES),
-    initializeFromQueryParams(queryString.parse(location.search)),
+    initializeFromQueryParams(queryParams),
     (initialValue, queryValue) => (_.isEmpty(queryValue) ? initialValue : queryValue)
   );
 
@@ -69,7 +70,7 @@ export const getInitialValues = ({
     // pplAlertingMonitorToFormik/monitorToFormik rebuild initialValues from the
     // stored monitor, which has no dataSourceId — preserve it from the edit-page
     // URL so preview/field-detection calls route to the monitor's data source.
-    const { dataSourceId } = queryString.parse(location.search);
+    const { dataSourceId } = queryParams;
     switch (monitorToEdit.monitor_type) {
       case MONITOR_TYPE.PPL:
         initialValues = {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.js
@@ -66,17 +66,23 @@ export const getInitialValues = ({
 
   if (edit && monitorToEdit) {
     const triggers = triggerToFormik(_.get(monitorToEdit, 'triggers', []), monitorToEdit);
+    // pplAlertingMonitorToFormik/monitorToFormik rebuild initialValues from the
+    // stored monitor, which has no dataSourceId — preserve it from the edit-page
+    // URL so preview/field-detection calls route to the monitor's data source.
+    const { dataSourceId } = queryString.parse(location.search);
     switch (monitorToEdit.monitor_type) {
       case MONITOR_TYPE.PPL:
         initialValues = {
           ...pplAlertingMonitorToFormik(monitorToEdit),
           triggerDefinitions: triggers.triggerDefinitions,
+          ...(dataSourceId ? { dataSourceId } : {}),
         };
         break;
       default:
         initialValues = {
           ...monitorToFormik(monitorToEdit),
           triggerDefinitions: triggers.triggerDefinitions,
+          ...(dataSourceId ? { dataSourceId } : {}),
         };
     }
   }

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/helpers.test.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getInitialValues } from './helpers';
+import { MONITOR_TYPE, SEARCH_TYPE } from '../../../../../utils/constants';
+
+const pplMonitorToEdit = {
+  name: 'ppl-monitor',
+  monitor_type: MONITOR_TYPE.PPL,
+  enabled: true,
+  query: 'source = logs | stats count() by status',
+  schedule: { period: { interval: 1, unit: 'MINUTES' } },
+  triggers: [],
+};
+
+const queryLevelMonitorToEdit = {
+  name: 'query-monitor',
+  monitor_type: MONITOR_TYPE.QUERY_LEVEL,
+  enabled: true,
+  schedule: { period: { interval: 1, unit: 'MINUTES' } },
+  inputs: [
+    {
+      search: {
+        indices: ['logs'],
+        query: { size: 0, query: { match_all: {} } },
+      },
+    },
+  ],
+  triggers: [],
+  ui_metadata: {
+    schedule: { frequency: 'interval', period: { interval: 1, unit: 'MINUTES' } },
+    search: { searchType: SEARCH_TYPE.QUERY },
+  },
+};
+
+describe('getInitialValues on edit', () => {
+  test('preserves dataSourceId from the edit-page URL for PPL monitors', () => {
+    const initialValues = getInitialValues({
+      location: { search: '?action=edit-monitor&dataSourceId=my-data-source-id' },
+      monitorToEdit: pplMonitorToEdit,
+      edit: true,
+    });
+
+    // The hydrated monitor carries no dataSourceId, so it must be retained
+    // from the URL for preview/field-detection calls to route correctly.
+    expect(initialValues.dataSourceId).toBe('my-data-source-id');
+    // Sanity: PPL hydration still populated the query.
+    expect(initialValues.pplQuery).toBe(pplMonitorToEdit.query);
+    expect(initialValues.monitor_type).toBe(MONITOR_TYPE.PPL);
+  });
+
+  test('preserves dataSourceId from the edit-page URL for non-PPL monitors', () => {
+    const initialValues = getInitialValues({
+      location: { search: '?action=edit-monitor&dataSourceId=my-data-source-id' },
+      monitorToEdit: queryLevelMonitorToEdit,
+      edit: true,
+    });
+
+    expect(initialValues.dataSourceId).toBe('my-data-source-id');
+  });
+
+  test('does not fabricate a dataSourceId when the URL has none', () => {
+    const initialValues = getInitialValues({
+      location: { search: '?action=edit-monitor' },
+      monitorToEdit: pplMonitorToEdit,
+      edit: true,
+    });
+
+    // Falls back to whatever the hydrator produced (no URL override applied).
+    expect(initialValues.dataSourceId).not.toBe('my-data-source-id');
+  });
+});

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
@@ -670,8 +670,9 @@ export const addTimeFilterToQuery = (query, lookBackMinutes, timestampField) => 
   )})`;
 
   if (cleanQuery.includes('|')) {
-    // Inject time filter before the first pipe so it runs before aggregations
-    return cleanQuery.replace('|', `${timeFilterClause} |`);
+    // Inject time filter before the first pipe so it runs before aggregations.
+    // Function replacer inserts the clause literally ($-patterns not interpreted).
+    return cleanQuery.replace('|', () => `${timeFilterClause} |`);
   }
   // No pipes — append at the end
   return `${cleanQuery} ${timeFilterClause}`;

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.js
@@ -621,40 +621,60 @@ export const computeLookBackMinutes = (values) => {
   return Math.floor(amount);
 };
 
-//Formats date 'yyyy-MM-dd HH:mm:ss' in UTC
-const formatPplTimestamp = (date) => {
-  const pad = (n) => String(n).padStart(2, '0');
-  return (
-    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ` +
-    `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
-  );
+const escapeRegExp = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+//Formats the lookback window as a PPL INTERVAL expression (e.g. 1 HOUR, 2 DAY, 30 MINUTE).
+const formatPplInterval = (lookBackMinutes) => {
+  if (lookBackMinutes % 1440 === 0) return `${lookBackMinutes / 1440} DAY`;
+  if (lookBackMinutes % 60 === 0) return `${lookBackMinutes / 60} HOUR`;
+  return `${lookBackMinutes} MINUTE`;
 };
 
-//Injects a time-range filter into a PPL query based on the lookback window.
-export const addTimeFilterToQuery = (
-  query,
-  lookBackMinutes,
-  timestampField,
-  endTime = new Date()
-) => {
+/**
+ * Removes a previously injected lookback time filter for the given timestamp
+ * field. Handles both the current sliding-window form
+ * (`| where ts > DATE_SUB(NOW(), INTERVAL n UNIT)`) and the legacy
+ * absolute-timestamp form (`| where ts > TIMESTAMP('...') and ts < TIMESTAMP('...')`)
+ * that older monitors persisted at save time. Makes injection idempotent so
+ * editing/previewing a monitor never stacks stale filters.
+ */
+export const stripTimeFilterFromQuery = (query, timestampField) => {
+  if (!query || !timestampField) return query;
+  const field = escapeRegExp(timestampField);
+  const legacyAbsoluteClause = new RegExp(
+    `\\s*\\|\\s*where\\s+${field}\\s*>\\s*TIMESTAMP\\('[^']*'\\)\\s+and\\s+${field}\\s*<\\s*TIMESTAMP\\('[^']*'\\)`,
+    'gi'
+  );
+  const slidingWindowClause = new RegExp(
+    `\\s*\\|\\s*where\\s+${field}\\s*>\\s*DATE_SUB\\(NOW\\(\\),\\s*INTERVAL\\s+\\d+\\s+(?:MINUTE|HOUR|DAY)S?\\)`,
+    'gi'
+  );
+  return query.replace(legacyAbsoluteClause, '').replace(slidingWindowClause, '').trim();
+};
+
+/**
+ * Injects a sliding time-window filter into a PPL query based on the lookback
+ * window: `| where <field> > DATE_SUB(NOW(), INTERVAL <n> <UNIT>)`.
+ * The window is evaluated dynamically at each execution — unlike the previous
+ * absolute TIMESTAMP('...') literals, which froze the window at save time so
+ * every scheduled run forever queried the same static range.
+ * Any previously injected filter (either form) is stripped first, so calling
+ * this on an already-filtered query replaces the filter instead of stacking.
+ */
+export const addTimeFilterToQuery = (query, lookBackMinutes, timestampField) => {
   if (!query || !timestampField || !lookBackMinutes || lookBackMinutes <= 0) return query;
 
-  const periodEnd = endTime;
-  const periodStart = new Date(periodEnd.getTime() - lookBackMinutes * 60 * 1000);
+  const cleanQuery = stripTimeFilterFromQuery(query, timestampField);
+  const timeFilterClause = `| where ${timestampField} > DATE_SUB(NOW(), INTERVAL ${formatPplInterval(
+    lookBackMinutes
+  )})`;
 
-  const startTs = formatPplTimestamp(periodStart);
-  const endTs = formatPplTimestamp(periodEnd);
-
-  const timeFilterClause =
-    `| where ${timestampField} > TIMESTAMP('${startTs}') ` +
-    `and ${timestampField} < TIMESTAMP('${endTs}')`;
-
-  if (query.includes('|')) {
+  if (cleanQuery.includes('|')) {
     // Inject time filter before the first pipe so it runs before aggregations
-    return query.replace('|', `${timeFilterClause} |`);
+    return cleanQuery.replace('|', `${timeFilterClause} |`);
   }
   // No pipes — append at the end
-  return `${query} ${timeFilterClause}`;
+  return `${cleanQuery} ${timeFilterClause}`;
 };
 
 /**

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
@@ -58,25 +58,21 @@ describe('computeLookBackMinutes', () => {
 });
 
 describe('addTimeFilterToQuery', () => {
-  const fixedEnd = new Date('2025-06-15T12:00:00Z');
-
   test('returns original query when inputs are missing', () => {
     expect(addTimeFilterToQuery('', 60, '@timestamp')).toBe('');
     expect(addTimeFilterToQuery('source=logs', 0, '@timestamp')).toBe('source=logs');
     expect(addTimeFilterToQuery('source=logs', 60, '')).toBe('source=logs');
   });
 
-  test('appends time filter when query has no pipes', () => {
-    const result = addTimeFilterToQuery('source=logs', 60, '@timestamp', fixedEnd);
-    expect(result).toContain("| where @timestamp > TIMESTAMP('2025-06-15 11:00:00')");
-    expect(result).toContain("and @timestamp < TIMESTAMP('2025-06-15 12:00:00')");
-    expect(result).toMatch(/^source=logs \|/);
+  test('appends sliding time filter when query has no pipes', () => {
+    const result = addTimeFilterToQuery('source=logs', 60, '@timestamp');
+    expect(result).toBe('source=logs | where @timestamp > DATE_SUB(NOW(), INTERVAL 1 HOUR)');
   });
 
   test('injects time filter before first pipe when query has pipes', () => {
     const query = 'source=logs | stats count() by status';
-    const result = addTimeFilterToQuery(query, 120, '@timestamp', fixedEnd);
-    expect(result).toContain("| where @timestamp > TIMESTAMP('2025-06-15 10:00:00')");
+    const result = addTimeFilterToQuery(query, 120, '@timestamp');
+    expect(result).toContain('| where @timestamp > DATE_SUB(NOW(), INTERVAL 2 HOUR)');
     expect(result).toContain('| stats count() by status');
     // Time filter should come before the stats command
     const timeFilterIdx = result.indexOf('| where @timestamp');
@@ -84,25 +80,51 @@ describe('addTimeFilterToQuery', () => {
     expect(timeFilterIdx).toBeLessThan(statsIdx);
   });
 
-  test('uses correct lookback window in minutes', () => {
-    const result = addTimeFilterToQuery('source=idx', 30, 'event_time', fixedEnd);
-    expect(result).toContain("event_time > TIMESTAMP('2025-06-15 11:30:00')");
-    expect(result).toContain("event_time < TIMESTAMP('2025-06-15 12:00:00')");
+  test('uses MINUTE unit for sub-hour lookback', () => {
+    const result = addTimeFilterToQuery('source=idx', 30, 'event_time');
+    expect(result).toContain('event_time > DATE_SUB(NOW(), INTERVAL 30 MINUTE)');
   });
 
-  test('handles multi-day lookback', () => {
-    const result = addTimeFilterToQuery('source=idx', 1440, 'ts', fixedEnd);
-    expect(result).toContain("ts > TIMESTAMP('2025-06-14 12:00:00')");
-    expect(result).toContain("ts < TIMESTAMP('2025-06-15 12:00:00')");
+  test('uses DAY unit for multi-day lookback', () => {
+    const result = addTimeFilterToQuery('source=idx', 2880, 'ts');
+    expect(result).toContain('ts > DATE_SUB(NOW(), INTERVAL 2 DAY)');
   });
 
   test('preserves original query structure with complex piped query', () => {
     const query = 'source=logs | where status=500 | stats avg(latency) as avg_lat by region';
-    const result = addTimeFilterToQuery(query, 60, '@timestamp', fixedEnd);
+    const result = addTimeFilterToQuery(query, 60, '@timestamp');
     expect(result).toContain('| where status=500');
     expect(result).toContain('| stats avg(latency) as avg_lat by region');
     // Time filter injected before the first original pipe
     expect(result.indexOf('| where @timestamp')).toBeLessThan(result.indexOf('| where status=500'));
+  });
+
+  test('is idempotent — re-injecting replaces the existing sliding filter instead of stacking', () => {
+    const once = addTimeFilterToQuery('source=logs | stats count()', 60, '@timestamp');
+    const twice = addTimeFilterToQuery(once, 120, '@timestamp');
+    expect(twice.match(/DATE_SUB/g)).toHaveLength(1);
+    expect(twice).toContain('INTERVAL 2 HOUR');
+    expect(twice).not.toContain('INTERVAL 1 HOUR');
+  });
+
+  test('replaces a legacy absolute TIMESTAMP filter persisted by older saves', () => {
+    // Shape persisted by the previous implementation at save time
+    const stored =
+      "source=logs | where @timestamp > TIMESTAMP('2025-06-15 11:00:00') " +
+      "and @timestamp < TIMESTAMP('2025-06-15 12:00:00') | stats count() by status";
+    const result = addTimeFilterToQuery(stored, 60, '@timestamp');
+    expect(result).not.toContain('TIMESTAMP(');
+    expect(result.match(/DATE_SUB/g)).toHaveLength(1);
+    expect(result).toContain('| where @timestamp > DATE_SUB(NOW(), INTERVAL 1 HOUR)');
+    expect(result).toContain('| stats count() by status');
+  });
+
+  test('does not strip user-written filters on other fields', () => {
+    const query = "source=logs | where created > TIMESTAMP('2025-01-01 00:00:00') | stats count()";
+    const result = addTimeFilterToQuery(query, 60, '@timestamp');
+    // User filter on 'created' untouched (single-bound clause on another field)
+    expect(result).toContain("created > TIMESTAMP('2025-01-01 00:00:00')");
+    expect(result).toContain('DATE_SUB(NOW(), INTERVAL 1 HOUR)');
   });
 });
 

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
@@ -9,6 +9,7 @@ import {
   extractIndicesFromPPL,
   formatDuration,
 } from './pplAlertingHelpers';
+import { buildPPLMonitorFromFormik } from './pplFormikToMonitor';
 
 describe('computeLookBackMinutes', () => {
   test('returns 0 when lookback is disabled', () => {
@@ -105,6 +106,24 @@ describe('addTimeFilterToQuery', () => {
     expect(twice.match(/DATE_SUB/g)).toHaveLength(1);
     expect(twice).toContain('INTERVAL 2 HOUR');
     expect(twice).not.toContain('INTERVAL 1 HOUR');
+  });
+
+  test('buildPPLMonitorFromFormik strips the injected filter when lookback is disabled', () => {
+    // Simulates: edit a monitor saved with lookback ON, uncheck the lookback
+    // window, save. The persisted query must no longer carry the old filter.
+    const storedQuery = addTimeFilterToQuery('source=logs | stats count()', 60, '@timestamp');
+    const monitor = buildPPLMonitorFromFormik({
+      name: 'm',
+      pplQuery: storedQuery,
+      timestampField: '@timestamp',
+      useLookBackWindow: false,
+      frequency: 'interval',
+      period: { interval: 1, unit: 'MINUTES' },
+      triggerDefinitions: [],
+    });
+    expect(monitor.query).not.toContain('DATE_SUB');
+    expect(monitor.query).toContain('source=logs');
+    expect(monitor.query).toContain('| stats count()');
   });
 
   test('replaces a legacy absolute TIMESTAMP filter persisted by older saves', () => {

--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplFormikToMonitor.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplFormikToMonitor.js
@@ -4,7 +4,11 @@
  */
 
 import _ from 'lodash';
-import { computeLookBackMinutes, addTimeFilterToQuery } from './pplAlertingHelpers';
+import {
+  computeLookBackMinutes,
+  addTimeFilterToQuery,
+  stripTimeFilterFromQuery,
+} from './pplAlertingHelpers';
 /**
  * Normalize timezone coming from formik (can be array/object/string)
  */
@@ -206,6 +210,10 @@ export const buildPPLMonitorFromFormik = (values) => {
       const lbMinutes = computeLookBackMinutes(values);
       if (lbMinutes > 0 && values.timestampField) {
         q = addTimeFilterToQuery(q, lbMinutes, values.timestampField);
+      } else if (values.timestampField) {
+        // Lookback disabled: remove any previously injected time filter so the
+        // persisted query stops filtering by a window the user just turned off.
+        q = stripTimeFilterFromQuery(q, values.timestampField);
       }
       return q;
     })(),

--- a/public/pages/Dashboard/containers/DashboardClassic.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.js
@@ -304,6 +304,82 @@ export default class DashboardClassic extends Component {
     this.refreshDashboard();
   };
 
+  // Disables the monitors behind the selected alerts (Fidelity issue #4:
+  // previously monitors could only be disabled from the Monitors page).
+  // Mirrors Monitors.updateMonitor: fetch the full monitor body and PUT it
+  // back with enabled=false, so all monitor types (including PPL) round-trip
+  // through the same v1 route the Monitors page uses.
+  disableSelectedMonitors = async () => {
+    const { httpClient, notifications } = this.props;
+    const { selectedItems } = this.state;
+
+    const monitorIds = Array.from(
+      new Set(
+        selectedItems
+          // Chained (workflow) alerts are not backed by a single monitor
+          .filter((item) => item.alert_source !== 'workflow' && !item.workflow_id)
+          .map((item) => item.monitor_id)
+          .filter(Boolean)
+      )
+    );
+    if (!monitorIds.length) return;
+
+    const dataSourceQuery = getDataSourceQueryObj();
+    const dataSourceId = dataSourceQuery?.query?.dataSourceId;
+
+    const results = await Promise.all(
+      monitorIds.map(async (monitorId) => {
+        try {
+          const detailResp = await httpClient.get(
+            `../api/alerting/monitors/${monitorId}`,
+            dataSourceQuery
+          );
+          if (!detailResp?.ok) {
+            backendErrorNotification(notifications, 'get', 'monitor', detailResp?.resp);
+            return detailResp;
+          }
+
+          const monitorDetail = detailResp.resp || {};
+          const query = {};
+          if (detailResp.ifSeqNo !== undefined) query.ifSeqNo = detailResp.ifSeqNo;
+          if (detailResp.ifPrimaryTerm !== undefined) query.ifPrimaryTerm = detailResp.ifPrimaryTerm;
+          if (dataSourceId !== undefined) query.dataSourceId = dataSourceId;
+
+          const payload = _.omit({ ...monitorDetail, enabled: false }, [
+            'id',
+            '_id',
+            'item_type',
+            'currentTime',
+            'version',
+            '_version',
+            'ifSeqNo',
+            'ifPrimaryTerm',
+          ]);
+
+          const resp = await httpClient.put(`../api/alerting/monitors/${monitorId}`, {
+            query,
+            body: JSON.stringify(payload),
+          });
+          if (!resp?.ok) {
+            backendErrorNotification(notifications, 'update', 'monitor', resp?.resp);
+          }
+          return resp;
+        } catch (err) {
+          return err;
+        }
+      })
+    );
+
+    const successCount = results.filter((resp) => resp?.ok).length;
+    if (successCount) {
+      notifications.toasts.addSuccess(
+        `Disabled ${successCount} monitor${successCount === 1 ? '' : 's'}.`
+      );
+    }
+    this.setState({ selectedItems: [] });
+    this.refreshDashboard();
+  };
+
   onTableChange = ({ page: tablePage = {}, sort = {} }) => {
     const { index: page, size } = tablePage;
     const { field: sortField, direction: sortDirection } = sort;
@@ -545,7 +621,17 @@ export default class DashboardClassic extends Component {
     };
 
     const actions = () => {
+      const hasDisableableSelection = selectedItems.some(
+        (item) => item.monitor_id && item.alert_source !== 'workflow' && !item.workflow_id
+      );
       const actions = [
+        <EuiSmallButton
+          onClick={this.disableSelectedMonitors}
+          disabled={!hasDisableableSelection}
+          data-test-subj={'disableMonitorsButton'}
+        >
+          Disable monitors
+        </EuiSmallButton>,
         <EuiSmallButton
           onClick={perAlertView ? this.acknowledgeAlert : this.openModal}
           disabled={perAlertView ? !selectedItems.length : selectedItems.length !== 1}

--- a/public/pages/Dashboard/containers/DashboardClassic.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.js
@@ -27,7 +27,11 @@ import {
   MONITOR_TYPE,
   OPENSEARCH_DASHBOARDS_AD_PLUGIN,
 } from '../../../utils/constants';
-import { acknowledgeAlerts, backendErrorNotification } from '../../../utils/helpers';
+import {
+  acknowledgeAlerts,
+  backendErrorNotification,
+  fetchAndUpdateMonitor,
+} from '../../../utils/helpers';
 import {
   getInitialSize,
   getQueryObjectFromState,
@@ -306,9 +310,9 @@ export default class DashboardClassic extends Component {
 
   // Disables the monitors behind the selected alerts (Fidelity issue #4:
   // previously monitors could only be disabled from the Monitors page).
-  // Mirrors Monitors.updateMonitor: fetch the full monitor body and PUT it
-  // back with enabled=false, so all monitor types (including PPL) round-trip
-  // through the same v1 route the Monitors page uses.
+  // Uses the shared fetchAndUpdateMonitor round-trip (same as the Monitors
+  // page), so all monitor types (including PPL) are handled and failures —
+  // including thrown/network errors — surface as error notifications.
   disableSelectedMonitors = async () => {
     const { httpClient, notifications } = this.props;
     const { selectedItems } = this.state;
@@ -325,49 +329,10 @@ export default class DashboardClassic extends Component {
     if (!monitorIds.length) return;
 
     const dataSourceQuery = getDataSourceQueryObj();
-    const dataSourceId = dataSourceQuery?.query?.dataSourceId;
-
     const results = await Promise.all(
-      monitorIds.map(async (monitorId) => {
-        try {
-          const detailResp = await httpClient.get(
-            `../api/alerting/monitors/${monitorId}`,
-            dataSourceQuery
-          );
-          if (!detailResp?.ok) {
-            backendErrorNotification(notifications, 'get', 'monitor', detailResp?.resp);
-            return detailResp;
-          }
-
-          const monitorDetail = detailResp.resp || {};
-          const query = {};
-          if (detailResp.ifSeqNo !== undefined) query.ifSeqNo = detailResp.ifSeqNo;
-          if (detailResp.ifPrimaryTerm !== undefined) query.ifPrimaryTerm = detailResp.ifPrimaryTerm;
-          if (dataSourceId !== undefined) query.dataSourceId = dataSourceId;
-
-          const payload = _.omit({ ...monitorDetail, enabled: false }, [
-            'id',
-            '_id',
-            'item_type',
-            'currentTime',
-            'version',
-            '_version',
-            'ifSeqNo',
-            'ifPrimaryTerm',
-          ]);
-
-          const resp = await httpClient.put(`../api/alerting/monitors/${monitorId}`, {
-            query,
-            body: JSON.stringify(payload),
-          });
-          if (!resp?.ok) {
-            backendErrorNotification(notifications, 'update', 'monitor', resp?.resp);
-          }
-          return resp;
-        } catch (err) {
-          return err;
-        }
-      })
+      monitorIds.map((monitorId) =>
+        fetchAndUpdateMonitor(httpClient, notifications, monitorId, { enabled: false }, dataSourceQuery)
+      )
     );
 
     const successCount = results.filter((resp) => resp?.ok).length;

--- a/public/pages/Dashboard/containers/DashboardClassic.test.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.test.js
@@ -141,4 +141,17 @@ describe('DashboardClassic disableSelectedMonitors', () => {
     expect(notifications.toasts.addDanger).toHaveBeenCalled();
     expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
   });
+
+  test('surfaces a backend error notification when the request throws', async () => {
+    const wrapper = render();
+    const instance = wrapper.instance();
+    httpClientMock.get.mockResolvedValue(monitorDetail);
+    httpClientMock.put.mockRejectedValue(new Error('socket hang up'));
+
+    instance.setState({ selectedItems: [{ id: 'alert-1', monitor_id: 'monitor-1' }] });
+    await instance.disableSelectedMonitors();
+
+    expect(notifications.toasts.addDanger).toHaveBeenCalled();
+    expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/public/pages/Dashboard/containers/DashboardClassic.test.js
+++ b/public/pages/Dashboard/containers/DashboardClassic.test.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+jest.mock('../../../services', () => {
+  const services = jest.requireActual('../../../services/services');
+  return {
+    ...services,
+    NotificationService: function NotificationServiceMock() {},
+    getUseUpdatedUx: jest.fn(() => false),
+  };
+});
+
+jest.mock('../../utils/helpers', () => {
+  const helpers = jest.requireActual('../../utils/helpers');
+  return {
+    ...helpers,
+    getIsAgentConfigured: jest.fn().mockResolvedValue(false),
+    getDataSourceQueryObj: jest.fn(() => ({ query: { dataSourceId: 'test-ds-id' } })),
+  };
+});
+
+import DashboardClassic from './DashboardClassic';
+import { historyMock, httpClientMock } from '../../../../test/mocks';
+import { setupCoreStart } from '../../../../test/utils/helpers';
+
+const location = {
+  hash: '',
+  search: '',
+  state: undefined,
+};
+
+const notifications = {
+  toasts: {
+    addSuccess: jest.fn(),
+    addDanger: jest.fn(),
+  },
+};
+
+const monitorDetail = {
+  ok: true,
+  resp: {
+    name: 'test-monitor',
+    enabled: true,
+    monitor_type: 'ppl_monitor',
+    schedule: { period: { interval: 1, unit: 'MINUTES' } },
+    triggers: [],
+  },
+  ifSeqNo: 7,
+  ifPrimaryTerm: 2,
+};
+
+describe('DashboardClassic disableSelectedMonitors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    httpClientMock.get.mockResolvedValue({
+      ok: true,
+      alerts: [],
+      totalAlerts: 0,
+      resp: { totalAlerts: 0, alerts: [] },
+    });
+    httpClientMock.put.mockResolvedValue({ ok: true });
+  });
+
+  beforeAll(() => {
+    setupCoreStart();
+  });
+
+  const render = (props = {}) =>
+    shallow(
+      <DashboardClassic
+        httpClient={httpClientMock}
+        history={historyMock}
+        location={location}
+        notifications={notifications}
+        perAlertView={true}
+        {...props}
+      />
+    );
+
+  test('fetches the full monitor and writes it back with enabled=false', async () => {
+    const wrapper = render();
+    const instance = wrapper.instance();
+    httpClientMock.get.mockResolvedValue(monitorDetail);
+
+    instance.setState({
+      selectedItems: [
+        { id: 'alert-1', monitor_id: 'monitor-1' },
+        // Same monitor selected via a second alert -- must only disable once
+        { id: 'alert-2', monitor_id: 'monitor-1' },
+      ],
+    });
+    await instance.disableSelectedMonitors();
+
+    expect(httpClientMock.get).toHaveBeenCalledWith(
+      '../api/alerting/monitors/monitor-1',
+      expect.objectContaining({ query: { dataSourceId: 'test-ds-id' } })
+    );
+    expect(httpClientMock.put).toHaveBeenCalledTimes(1);
+    const [url, { query, body }] = httpClientMock.put.mock.calls[0];
+    expect(url).toBe('../api/alerting/monitors/monitor-1');
+    expect(query).toEqual({ ifSeqNo: 7, ifPrimaryTerm: 2, dataSourceId: 'test-ds-id' });
+    const payload = JSON.parse(body);
+    expect(payload.enabled).toBe(false);
+    expect(payload.name).toBe('test-monitor');
+    expect(notifications.toasts.addSuccess).toHaveBeenCalledWith('Disabled 1 monitor.');
+    expect(wrapper.state('selectedItems')).toEqual([]);
+  });
+
+  test('skips chained/workflow alerts', async () => {
+    const wrapper = render();
+    const instance = wrapper.instance();
+
+    instance.setState({
+      selectedItems: [
+        { id: 'alert-1', monitor_id: 'workflow-1', alert_source: 'workflow' },
+        { id: 'alert-2', workflow_id: 'workflow-2', monitor_id: 'delegate-1' },
+      ],
+    });
+    httpClientMock.get.mockClear();
+    await instance.disableSelectedMonitors();
+
+    expect(httpClientMock.get).not.toHaveBeenCalled();
+    expect(httpClientMock.put).not.toHaveBeenCalled();
+    expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
+  });
+
+  test('surfaces a backend error notification when the update fails', async () => {
+    const wrapper = render();
+    const instance = wrapper.instance();
+    httpClientMock.get.mockResolvedValue(monitorDetail);
+    httpClientMock.put.mockResolvedValue({ ok: false, resp: 'boom' });
+
+    instance.setState({ selectedItems: [{ id: 'alert-1', monitor_id: 'monitor-1' }] });
+    await instance.disableSelectedMonitors();
+
+    expect(notifications.toasts.addDanger).toHaveBeenCalled();
+    expect(notifications.toasts.addSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/public/pages/Monitors/containers/Monitors/Monitors.js
+++ b/public/pages/Monitors/containers/Monitors/Monitors.js
@@ -16,7 +16,11 @@ import { DEFAULT_PAGE_SIZE_OPTIONS, DEFAULT_QUERY_PARAMS } from './utils/constan
 import { getURLQueryParams } from './utils/helpers';
 import { columns as staticColumns } from './utils/tableUtils';
 import { MONITOR_ACTIONS, MONITOR_TYPE } from '../../../../utils/constants';
-import { backendErrorNotification, deleteMonitor } from '../../../../utils/helpers';
+import {
+  backendErrorNotification,
+  deleteMonitor,
+  fetchAndUpdateMonitor,
+} from '../../../../utils/helpers';
 import { deletePplMonitor, isPplMonitor } from '../../../../utils/pplHelpers';
 import { displayAcknowledgedAlertsToast } from '../../../Dashboard/utils/helpers';
 import { DeleteMonitorModal } from '../../../../components/DeleteModal/DeleteMonitorModal';
@@ -211,54 +215,11 @@ export default class Monitors extends Component {
   async updateMonitor(item, update) {
     const { httpClient, notifications } = this.props;
     const dataSourceQuery = getDataSourceQueryObj();
-    const dataSourceId = dataSourceQuery?.query?.dataSourceId;
 
-    try {
-      const detailResp = await httpClient.get(
-        `../api/alerting/monitors/${item.id}`,
-        dataSourceQuery
-      );
-
-      if (!detailResp?.ok) {
-        backendErrorNotification(notifications, 'get', 'monitor', detailResp?.resp);
-        return detailResp;
-      }
-
-      const monitorDetail = detailResp.resp || {};
-      const ifSeqNo = detailResp.ifSeqNo ?? item.ifSeqNo;
-      const ifPrimaryTerm = detailResp.ifPrimaryTerm ?? item.ifPrimaryTerm;
-
-      const query = {};
-      if (ifSeqNo !== undefined) query.ifSeqNo = ifSeqNo;
-      if (ifPrimaryTerm !== undefined) query.ifPrimaryTerm = ifPrimaryTerm;
-      if (dataSourceId !== undefined) query.dataSourceId = dataSourceId;
-
-      const legacyPayload = _.omit({ ...monitorDetail, ...update }, [
-        'id',
-        '_id',
-        'item_type',
-        'currentTime',
-        'version',
-        '_version',
-        'ifSeqNo',
-        'ifPrimaryTerm',
-      ]);
-
-      return httpClient
-        .put(`../api/alerting/monitors/${item.id}`, {
-          query,
-          body: JSON.stringify(legacyPayload),
-        })
-        .then((resp) => {
-          if (!resp.ok) {
-            backendErrorNotification(notifications, 'update', 'monitor', resp.resp);
-          }
-          return resp;
-        })
-        .catch((err) => err);
-    } catch (err) {
-      return err;
-    }
+    return fetchAndUpdateMonitor(httpClient, notifications, item.id, update, dataSourceQuery, {
+      ifSeqNo: item.ifSeqNo,
+      ifPrimaryTerm: item.ifPrimaryTerm,
+    });
   }
 
   async updateMonitors(items, update) {

--- a/public/utils/helpers.js
+++ b/public/utils/helpers.js
@@ -44,6 +44,77 @@ export const backendErrorNotification = (notifications, actionName, objectName, 
   });
 };
 
+// Fields that must not be echoed back when round-tripping a monitor through
+// GET -> PUT (server-managed / response-only fields).
+const MONITOR_UPDATE_OMIT_FIELDS = [
+  'id',
+  '_id',
+  'item_type',
+  'currentTime',
+  'version',
+  '_version',
+  'ifSeqNo',
+  'ifPrimaryTerm',
+];
+
+/**
+ * Fetches the full monitor body and writes it back with `update` applied —
+ * the safe way to toggle fields (e.g. enabled) for ALL monitor types,
+ * since the untouched body round-trips verbatim. Shared by the Monitors
+ * page actions and the Alerts page disable action so the omit list and
+ * concurrency handling cannot drift apart.
+ * Surfaces failures (including thrown/network errors) via
+ * backendErrorNotification and always resolves (never rejects).
+ */
+export const fetchAndUpdateMonitor = async (
+  httpClient,
+  notifications,
+  monitorId,
+  update,
+  dataSourceQuery,
+  fallbacks = {}
+) => {
+  try {
+    const detailResp = await httpClient.get(
+      `../api/alerting/monitors/${monitorId}`,
+      dataSourceQuery
+    );
+    if (!detailResp?.ok) {
+      backendErrorNotification(notifications, 'get', 'monitor', detailResp?.resp);
+      return detailResp;
+    }
+
+    const monitorDetail = detailResp.resp || {};
+    const ifSeqNo = detailResp.ifSeqNo ?? fallbacks.ifSeqNo;
+    const ifPrimaryTerm = detailResp.ifPrimaryTerm ?? fallbacks.ifPrimaryTerm;
+    const dataSourceId = dataSourceQuery?.query?.dataSourceId;
+
+    const query = {};
+    if (ifSeqNo !== undefined) query.ifSeqNo = ifSeqNo;
+    if (ifPrimaryTerm !== undefined) query.ifPrimaryTerm = ifPrimaryTerm;
+    if (dataSourceId !== undefined) query.dataSourceId = dataSourceId;
+
+    const payload = _.omit({ ...monitorDetail, ...update }, MONITOR_UPDATE_OMIT_FIELDS);
+
+    const resp = await httpClient.put(`../api/alerting/monitors/${monitorId}`, {
+      query,
+      body: JSON.stringify(payload),
+    });
+    if (!resp?.ok) {
+      backendErrorNotification(notifications, 'update', 'monitor', resp?.resp);
+    }
+    return resp;
+  } catch (err) {
+    backendErrorNotification(
+      notifications,
+      'update',
+      'monitor',
+      err?.body?.message || err?.message || String(err)
+    );
+    return { ok: false, resp: err };
+  }
+};
+
 // A helper function to generate a simple string explaining how many elements a user can add to a list.
 export const inputLimitText = (
   currCount = 0,


### PR DESCRIPTION
### Description

**Bug 1: Lookback window injects a frozen absolute time window.**

`addTimeFilterToQuery` built the lookback filter from absolute timestamps computed at save time:

```
| where @timestamp > TIMESTAMP('2026-08-19 20:00:00') and @timestamp < TIMESTAMP('2026-08-19 21:00:00')
```

Since the filter is persisted into the monitor's query, every scheduled execution forever re-queries the same static window from the moment the monitor was saved — after the first interval elapses, the monitor can never match new data again.

**Fix:** inject a dynamic sliding window instead, evaluated by the engine at each execution:

```
| where @timestamp > DATE_SUB(NOW(), INTERVAL 1 HOUR)
```

The interval unit is derived from the configured window (MINUTE/HOUR/DAY). All call sites (save serialization plus the query/trigger previews) share the same helper, so they inherit the fix.

**Bug 2: Query preview broken on monitor edit.**

Two independent causes:

1. **Stacked/stale time filters.** On edit, the hydrated query already contains the previously injected lookback filter. Preview and re-save injected a *second* filter on top. Combined with Bug 1, the old filter's upper bound is entirely in the past, so preview on edit deterministically returned zero rows while create worked.
   **Fix:** `addTimeFilterToQuery` is now idempotent — a new `stripTimeFilterFromQuery` removes any previously injected filter for the timestamp field (both the new `DATE_SUB` form and the legacy absolute `TIMESTAMP('...')` form persisted by older saves) before injecting, so injection replaces rather than stacks. This also transparently migrates monitors saved with the old frozen filter the next time they are saved.

2. **`dataSourceId` dropped on edit.** The edit branch of `getInitialValues` rebuilds the formik values wholesale from the stored monitor, discarding the query-param initialization — and the stored monitor carries no `dataSourceId`. Preview and field-detection calls then fall back to whatever data source the page happens to have selected, which in MDS environments may not be the monitor's data source.
   **Fix:** preserve `dataSourceId` from the edit-page URL when hydrating a monitor for edit (both the PPL and default hydration paths).

**Bug 3: Monitors cannot be disabled from the Alerts page.**

The Alerts page (`DashboardClassic`) offered only Acknowledge / View alert details / View detector — there was no way to stop a noisy monitor without navigating to the Monitors page and finding it by name.

**Fix:** add a **Disable monitors** action to the Alerts page toolbar. It collects the unique `monitor_id`s behind the selected alerts (skipping chained/workflow alerts, for which the button stays disabled) and disables each via the same fetch-then-PUT round-trip the Monitors page uses — the full monitor body is fetched and written back with only `enabled: false` changed, so all monitor types (including PPL) are handled safely. Sequence-number concurrency params and `dataSourceId` are forwarded, successes surface a toast, failures surface per-monitor error notifications, and the dashboard refreshes.

### Testing

- New/updated unit tests in `public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js` (9 tests for the time-filter helper): sliding `DATE_SUB` form with MINUTE/HOUR/DAY units, injection before the first pipe, preservation of complex piped queries, idempotence (re-injection replaces instead of stacking), replacement of the legacy absolute `TIMESTAMP('...')` filter, and non-interference with user-written filters on other fields.
- Manually verified against OpenSearch 3.7 with the security plugin:
  - Lookback checkbox injects `| where @timestamp > DATE_SUB(NOW(), INTERVAL 1 HOUR)` exactly once (network capture of the preview request), and the saved monitor persists the same form.
  - Preview on edit sends exactly one time filter; re-saving an edited monitor does not stack clauses; a hand-written `DATE_SUB` filter on the same field is replaced, not duplicated.
  - Sliding-window boundary: docs older than the window are excluded at 1-hour lookback and included at 1-day lookback, with no change to the stored query.
  - Alerts page: selecting an alert enables the new Disable monitors button; clicking it disables the backing monitor (success toast + monitor shows Disabled on the Monitors page).

### Related Issues

n/a — found while investigating PPL monitor reliability issues, follow-up to #1500. 

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.