### PR TITLE
Accept v1-shape monitor body in PPL update guard and toV1MonitorBody

### DIFF
--- a/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
+++ b/public/pages/CreateMonitor/containers/CreateMonitor/utils/pplAlertingHelpers.test.js
@@ -112,6 +112,7 @@ describe('addTimeFilterToQuery', () => {
     // Simulates: edit a monitor saved with lookback ON, uncheck the lookback
     // window, save. The persisted query must no longer carry the old filter.
     const storedQuery = addTimeFilterToQuery('source=logs | stats count()', 60, '@timestamp');
+    // buildPPLMonitorFromFormik returns the wrapped shape { ppl_monitor: {...} }.
     const monitor = buildPPLMonitorFromFormik({
       name: 'm',
       pplQuery: storedQuery,
@@ -121,9 +122,9 @@ describe('addTimeFilterToQuery', () => {
       period: { interval: 1, unit: 'MINUTES' },
       triggerDefinitions: [],
     });
-    expect(monitor.query).not.toContain('DATE_SUB');
-    expect(monitor.query).toContain('source=logs');
-    expect(monitor.query).toContain('| stats count()');
+    expect(monitor.ppl_monitor.query).not.toContain('DATE_SUB');
+    expect(monitor.ppl_monitor.query).toContain('source=logs');
+    expect(monitor.ppl_monitor.query).toContain('| stats count()');
   });
 
   test('replaces a legacy absolute TIMESTAMP filter persisted by older saves', () => {

--- a/server/services/PplAlertingMonitorService.js
+++ b/server/services/PplAlertingMonitorService.js
@@ -15,13 +15,13 @@ const ALERTS_BASE_PATH = `${PPL_MONITOR_BASE_API}/alerts`;
 
 /**
  * Transforms the frontend body format ({ ppl_monitor: { name, query, triggers, ... } })
- * into the v1 backend format ({ name, monitor_type, inputs, triggers, ... }).
+ * into the engine's native monitor format ({ name, monitor_type, inputs, triggers, ... }).
  */
-const toV1MonitorBody = (body) => {
+const toEngineMonitorBody = (body) => {
   const pplMon = body?.ppl_monitor || body;
   // Accept both the flattened frontend shape (query at top level) and the
-  // raw v1 shape (query nested in inputs[0].ppl_input.query). Callers that
-  // round-trip a v1-format monitor (e.g. the monitor details page
+  // raw engine shape (query nested in inputs[0].ppl_input.query). Callers that
+  // round-trip an engine-format monitor (e.g. the monitor details page
   // enable/disable toggle) send the latter.
   const query = pplMon.query || pplMon.inputs?.[0]?.ppl_input?.query || '';
   const rawTriggers = Array.isArray(pplMon.triggers) ? pplMon.triggers : [];
@@ -30,7 +30,7 @@ const toV1MonitorBody = (body) => {
     return { ppl_trigger: t };
   });
 
-  const v1 = {
+  const engineMonitor = {
     name: pplMon.name,
     monitor_type: 'ppl_monitor',
     enabled: pplMon.enabled !== false,
@@ -39,25 +39,25 @@ const toV1MonitorBody = (body) => {
     triggers,
   };
 
-  if (pplMon.description !== undefined) v1.description = pplMon.description;
-  if (pplMon.ui_metadata !== undefined) v1.ui_metadata = pplMon.ui_metadata;
+  if (pplMon.description !== undefined) engineMonitor.description = pplMon.description;
+  if (pplMon.ui_metadata !== undefined) engineMonitor.ui_metadata = pplMon.ui_metadata;
   if (pplMon.look_back_window_minutes !== undefined)
-    v1.look_back_window_minutes = pplMon.look_back_window_minutes;
-  if (pplMon.timestamp_field !== undefined) v1.timestamp_field = pplMon.timestamp_field;
-  if (body?.look_back_window_minutes !== undefined && v1.look_back_window_minutes === undefined)
-    v1.look_back_window_minutes = body.look_back_window_minutes;
-  if (body?.timestamp_field !== undefined && v1.timestamp_field === undefined)
-    v1.timestamp_field = body.timestamp_field;
-  if (body?.target !== undefined) v1.target = body.target;
+    engineMonitor.look_back_window_minutes = pplMon.look_back_window_minutes;
+  if (pplMon.timestamp_field !== undefined) engineMonitor.timestamp_field = pplMon.timestamp_field;
+  if (body?.look_back_window_minutes !== undefined && engineMonitor.look_back_window_minutes === undefined)
+    engineMonitor.look_back_window_minutes = body.look_back_window_minutes;
+  if (body?.timestamp_field !== undefined && engineMonitor.timestamp_field === undefined)
+    engineMonitor.timestamp_field = body.timestamp_field;
+  if (body?.target !== undefined) engineMonitor.target = body.target;
 
-  return v1;
+  return engineMonitor;
 };
 
 /**
- * Flattens a v1 monitor object (with wrapped inputs/triggers) into the
+ * Flattens an engine-format monitor object (with wrapped inputs/triggers) into the
  * flat format the frontend expects (query at top level, unwrapped triggers).
  */
-const flattenV1Monitor = (monitor) => {
+const flattenEngineMonitor = (monitor) => {
   if (!monitor) return {};
 
   const pplInput = monitor.inputs?.[0]?.ppl_input;
@@ -369,7 +369,7 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
         } = result;
 
         let monitor = _source?.monitor ? _source.monitor : _source || {};
-        monitor = flattenV1Monitor(monitor);
+        monitor = flattenEngineMonitor(monitor);
 
         if (!monitor.monitor_type) {
           monitor.monitor_type = 'query_level';
@@ -571,11 +571,11 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const client = await this.getClientBasedOnDataSource(context, req);
-      const v1Body = toV1MonitorBody(await this.enrichTargetArn(context, req, req.body));
+      const engineBody = toEngineMonitorBody(await this.enrichTargetArn(context, req, req.body));
       const resp = await client('transport.request', {
         method: 'POST',
         path: PPL_MONITOR_BASE_API,
-        body: v1Body,
+        body: engineBody,
         headers: DEFAULT_HEADERS,
       });
       return res.ok({ body: { ok: true, resp } });
@@ -618,11 +618,11 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
         );
       }
 
-      // Guard against silent data loss: toV1MonitorBody defaults a missing
+      // Guard against silent data loss: toEngineMonitorBody defaults a missing
       // query to '', so an update body without a query would silently wipe
       // the monitor's PPL query. Accept the query from either the flattened
-      // shape (top-level query) or the raw v1 shape (inputs[0].ppl_input.query,
-      // sent by callers that round-trip a v1-format monitor such as the
+      // shape (top-level query) or the raw engine shape (inputs[0].ppl_input.query,
+      // sent by callers that round-trip an engine-format monitor such as the
       // details-page enable/disable toggle); reject only if neither is present.
       const bodyQuery = cleanMonitor.query || cleanMonitor.inputs?.[0]?.ppl_input?.query;
       if (!bodyQuery || !String(bodyQuery).trim()) {
@@ -636,7 +636,7 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
         });
       }
 
-      const v1Body = toV1MonitorBody(
+      const engineBody = toEngineMonitorBody(
         await this.enrichTargetArn(context, req, { ppl_monitor: cleanMonitor })
       );
 
@@ -645,7 +645,7 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
         path: `${PPL_MONITOR_BASE_API}/${encodeURIComponent(id)}${
           qs.toString() ? `?${qs.toString()}` : ''
         }`,
-        body: v1Body,
+        body: engineBody,
         headers: DEFAULT_HEADERS,
       });
       return res.ok({ body: { ok: true, resp } });
@@ -672,7 +672,7 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       });
 
       const rawMonitor = _.get(raw, 'monitor') || _.get(raw, '_source') || {};
-      const monitor = flattenV1Monitor(rawMonitor);
+      const monitor = flattenEngineMonitor(rawMonitor);
 
       const normalized = {
         ...monitor,
@@ -744,10 +744,10 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       const aclResponse = await this.enforceWorkspaceAcl(context, req, res, ['library_write']);
       if (aclResponse) return aclResponse;
       const client = await this.getClientBasedOnDataSource(context, req);
-      // The engine only speaks the v1 monitor format -- translate the
+      // The engine only speaks its native monitor format -- translate the
       // { ppl_monitor: {...} } body the same way createMonitor/updateMonitor
       // do, otherwise Monitor.parse fails with "Monitor name is null".
-      const body = toV1MonitorBody(await this.enrichTargetArn(context, req, req.body));
+      const body = toEngineMonitorBody(await this.enrichTargetArn(context, req, req.body));
       const resp = await client('transport.request', {
         method: 'POST',
         path: `${PPL_MONITOR_BASE_API}/_execute`,

--- a/server/services/PplAlertingMonitorService.js
+++ b/server/services/PplAlertingMonitorService.js
@@ -17,13 +17,25 @@ const ALERTS_BASE_PATH = `${PPL_MONITOR_BASE_API}/alerts`;
  * Transforms the frontend body format ({ ppl_monitor: { name, query, triggers, ... } })
  * into the engine's native monitor format ({ name, monitor_type, inputs, triggers, ... }).
  */
+/**
+ * Extracts the PPL query from a monitor object, accepting both the flattened
+ * frontend shape (query at top level) and the raw engine shape (query nested
+ * in inputs[0].ppl_input.query). Callers that round-trip an engine-format
+ * monitor (e.g. the monitor details page enable/disable toggle) send the
+ * latter. A blank (whitespace-only) top-level query does not short-circuit
+ * the nested fallback. Shared by toEngineMonitorBody and the update guard so
+ * the two can never drift apart.
+ */
+const extractPplQuery = (pplMon) => {
+  const topLevel = typeof pplMon?.query === 'string' ? pplMon.query : '';
+  if (topLevel.trim()) return topLevel;
+  const nested = pplMon?.inputs?.[0]?.ppl_input?.query;
+  return typeof nested === 'string' ? nested : '';
+};
+
 const toEngineMonitorBody = (body) => {
   const pplMon = body?.ppl_monitor || body;
-  // Accept both the flattened frontend shape (query at top level) and the
-  // raw engine shape (query nested in inputs[0].ppl_input.query). Callers that
-  // round-trip an engine-format monitor (e.g. the monitor details page
-  // enable/disable toggle) send the latter.
-  const query = pplMon.query || pplMon.inputs?.[0]?.ppl_input?.query || '';
+  const query = extractPplQuery(pplMon);
   const rawTriggers = Array.isArray(pplMon.triggers) ? pplMon.triggers : [];
   const triggers = rawTriggers.map((t) => {
     if (t.ppl_trigger) return t;
@@ -613,9 +625,17 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       } = pplMon;
 
       if (Array.isArray(cleanMonitor.triggers)) {
-        cleanMonitor.triggers = cleanMonitor.triggers.map(
-          ({ id: triggerId, last_triggered_time, last_execution_time, ...trigger }) => trigger
-        );
+        // Strip stale ids/run timestamps from both trigger shapes: unwrapped
+        // (flattened frontend) and ppl_trigger-wrapped (raw engine shape).
+        cleanMonitor.triggers = cleanMonitor.triggers.map((t) => {
+          const {
+            id: triggerId,
+            last_triggered_time,
+            last_execution_time,
+            ...trigger
+          } = t?.ppl_trigger || t;
+          return t?.ppl_trigger ? { ppl_trigger: trigger } : trigger;
+        });
       }
 
       // Guard against silent data loss: toEngineMonitorBody defaults a missing
@@ -624,8 +644,8 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
       // shape (top-level query) or the raw engine shape (inputs[0].ppl_input.query,
       // sent by callers that round-trip an engine-format monitor such as the
       // details-page enable/disable toggle); reject only if neither is present.
-      const bodyQuery = cleanMonitor.query || cleanMonitor.inputs?.[0]?.ppl_input?.query;
-      if (!bodyQuery || !String(bodyQuery).trim()) {
+      const bodyQuery = extractPplQuery(cleanMonitor);
+      if (!bodyQuery.trim()) {
         return res.ok({
           body: {
             ok: false,

--- a/server/services/PplAlertingMonitorService.js
+++ b/server/services/PplAlertingMonitorService.js
@@ -19,7 +19,11 @@ const ALERTS_BASE_PATH = `${PPL_MONITOR_BASE_API}/alerts`;
  */
 const toV1MonitorBody = (body) => {
   const pplMon = body?.ppl_monitor || body;
-  const query = pplMon.query || '';
+  // Accept both the flattened frontend shape (query at top level) and the
+  // raw v1 shape (query nested in inputs[0].ppl_input.query). Callers that
+  // round-trip a v1-format monitor (e.g. the monitor details page
+  // enable/disable toggle) send the latter.
+  const query = pplMon.query || pplMon.inputs?.[0]?.ppl_input?.query || '';
   const rawTriggers = Array.isArray(pplMon.triggers) ? pplMon.triggers : [];
   const triggers = rawTriggers.map((t) => {
     if (t.ppl_trigger) return t;
@@ -616,8 +620,12 @@ export default class PplAlertingMonitorService extends MDSEnabledClientService {
 
       // Guard against silent data loss: toV1MonitorBody defaults a missing
       // query to '', so an update body without a query would silently wipe
-      // the monitor's PPL query. Reject it instead.
-      if (!cleanMonitor.query || !String(cleanMonitor.query).trim()) {
+      // the monitor's PPL query. Accept the query from either the flattened
+      // shape (top-level query) or the raw v1 shape (inputs[0].ppl_input.query,
+      // sent by callers that round-trip a v1-format monitor such as the
+      // details-page enable/disable toggle); reject only if neither is present.
+      const bodyQuery = cleanMonitor.query || cleanMonitor.inputs?.[0]?.ppl_input?.query;
+      if (!bodyQuery || !String(bodyQuery).trim()) {
         return res.ok({
           body: {
             ok: false,

--- a/server/services/PplAlertingMonitorService.test.js
+++ b/server/services/PplAlertingMonitorService.test.js
@@ -102,6 +102,61 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
     expect(callArgs.body.inputs[0].ppl_input.query).toContain('source = logs-*');
     expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
   });
+
+  test('accepts a raw v1-shape body whose query is nested in inputs[0].ppl_input (details-page enable/disable round-trip)', async () => {
+    const client = jest.fn().mockResolvedValue({ _id: 'mon-1' });
+    const service = buildService(client);
+    const res = buildRes();
+    // Shape sent by the monitor details page enable/disable toggle: the raw
+    // v1 monitor round-tripped verbatim -- query nested, nothing at top level.
+    const v1ShapeBody = {
+      ppl_monitor: {
+        type: 'monitor',
+        schema_version: 8,
+        name: 'ppl-monitor-test',
+        enabled: false,
+        schedule: { period: { interval: 1, unit: 'MINUTES' } },
+        inputs: [
+          {
+            ppl_input: {
+              query: "source = logs-otel* | where severityText = 'ERROR'",
+              query_language: 'ppl',
+            },
+          },
+        ],
+        triggers: [
+          {
+            ppl_trigger: {
+              id: 'trigger-id-1',
+              name: 'results-trigger',
+              severity: '1',
+              actions: [],
+              type: 'number_of_results',
+              num_results_condition: '>',
+              num_results_value: 0,
+            },
+          },
+        ],
+      },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: v1ShapeBody },
+      res
+    );
+
+    // The guard must not reject it, and the query must survive the translation
+    // instead of being wiped to ''.
+    expect(result.body.ok).toBe(true);
+    expect(client).toHaveBeenCalledTimes(1);
+    const [, callArgs] = client.mock.calls[0];
+    expect(callArgs.body.inputs[0].ppl_input.query).toBe(
+      "source = logs-otel* | where severityText = 'ERROR'"
+    );
+    expect(callArgs.body.enabled).toBe(false);
+    expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
+  });
 });
 
 describe('PplAlertingMonitorService.executeMonitor v1 translation', () => {

--- a/server/services/PplAlertingMonitorService.test.js
+++ b/server/services/PplAlertingMonitorService.test.js
@@ -80,7 +80,7 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
     expect(result.body.ok).toBe(false);
   });
 
-  test('forwards a valid update translated to the v1 engine format', async () => {
+  test('forwards a valid update translated to the engine format', async () => {
     const client = jest.fn().mockResolvedValue({ _id: 'mon-1' });
     const service = buildService(client);
     const res = buildRes();
@@ -96,20 +96,20 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
     const [, callArgs] = client.mock.calls[0];
     expect(callArgs.method).toBe('PUT');
     expect(callArgs.path).toContain('/_plugins/_alerting/monitors/mon-1');
-    // v1 shape: top-level name, ppl_input inputs, ppl_trigger-wrapped triggers
+    // engine shape: top-level name, ppl_input inputs, ppl_trigger-wrapped triggers
     expect(callArgs.body.name).toBe('my monitor');
     expect(callArgs.body.monitor_type).toBe('ppl_monitor');
     expect(callArgs.body.inputs[0].ppl_input.query).toContain('source = logs-*');
     expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
   });
 
-  test('accepts a raw v1-shape body whose query is nested in inputs[0].ppl_input (details-page enable/disable round-trip)', async () => {
+  test('accepts a raw engine-shape body whose query is nested in inputs[0].ppl_input (details-page enable/disable round-trip)', async () => {
     const client = jest.fn().mockResolvedValue({ _id: 'mon-1' });
     const service = buildService(client);
     const res = buildRes();
     // Shape sent by the monitor details page enable/disable toggle: the raw
-    // v1 monitor round-tripped verbatim -- query nested, nothing at top level.
-    const v1ShapeBody = {
+    // engine-format monitor round-tripped verbatim -- query nested, nothing at top level.
+    const engineShapeBody = {
       ppl_monitor: {
         type: 'monitor',
         schema_version: 8,
@@ -142,7 +142,7 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
 
     const result = await service.updateMonitor(
       {},
-      { params: { id: 'mon-1' }, query: {}, body: v1ShapeBody },
+      { params: { id: 'mon-1' }, query: {}, body: engineShapeBody },
       res
     );
 
@@ -157,10 +157,60 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
     expect(callArgs.body.enabled).toBe(false);
     expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
   });
+
+  test('rejects an engine-shape body whose nested query is empty', async () => {
+    const client = jest.fn();
+    const service = buildService(client);
+    const res = buildRes();
+    const emptyNestedQueryBody = {
+      ppl_monitor: {
+        name: 'ppl-monitor-test',
+        enabled: true,
+        schedule: { period: { interval: 1, unit: 'MINUTES' } },
+        inputs: [{ ppl_input: { query: '', query_language: 'ppl' } }],
+        triggers: [],
+      },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: emptyNestedQueryBody },
+      res
+    );
+
+    expect(client).not.toHaveBeenCalled();
+    expect(result.body.ok).toBe(false);
+    expect(result.body.resp).toContain('missing the PPL query');
+  });
+
+  test('rejects an engine-shape body whose ppl_input is empty', async () => {
+    const client = jest.fn();
+    const service = buildService(client);
+    const res = buildRes();
+    const emptyInputBody = {
+      ppl_monitor: {
+        name: 'ppl-monitor-test',
+        enabled: true,
+        schedule: { period: { interval: 1, unit: 'MINUTES' } },
+        inputs: [{ ppl_input: {} }],
+        triggers: [],
+      },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: emptyInputBody },
+      res
+    );
+
+    expect(client).not.toHaveBeenCalled();
+    expect(result.body.ok).toBe(false);
+    expect(result.body.resp).toContain('missing the PPL query');
+  });
 });
 
-describe('PplAlertingMonitorService.executeMonitor v1 translation', () => {
-  test('translates the v2 ppl_monitor body to v1 before hitting the engine', async () => {
+describe('PplAlertingMonitorService.executeMonitor engine-format translation', () => {
+  test('translates the flattened ppl_monitor body to the engine format before hitting the engine', async () => {
     const client = jest.fn().mockResolvedValue({ monitor_name: 'my monitor' });
     const service = buildService(client);
     const res = buildRes();

--- a/server/services/PplAlertingMonitorService.test.js
+++ b/server/services/PplAlertingMonitorService.test.js
@@ -156,6 +156,40 @@ describe('PplAlertingMonitorService.updateMonitor query guard', () => {
     );
     expect(callArgs.body.enabled).toBe(false);
     expect(callArgs.body.triggers[0].ppl_trigger).toBeDefined();
+    // Stale trigger metadata must be stripped from the wrapped shape too,
+    // matching what the flattened path does for unwrapped triggers.
+    expect(callArgs.body.triggers[0].ppl_trigger.id).toBeUndefined();
+    expect(callArgs.body.triggers[0].ppl_trigger.last_triggered_time).toBeUndefined();
+    expect(callArgs.body.triggers[0].ppl_trigger.last_execution_time).toBeUndefined();
+    expect(callArgs.body.triggers[0].ppl_trigger.name).toBe('results-trigger');
+  });
+
+  test('falls back to the nested query when the top-level query is whitespace-only', async () => {
+    const client = jest.fn().mockResolvedValue({ _id: 'mon-1' });
+    const service = buildService(client);
+    const res = buildRes();
+    const blankTopLevelBody = {
+      ppl_monitor: {
+        name: 'ppl-monitor-test',
+        enabled: true,
+        query: '   ',
+        schedule: { period: { interval: 1, unit: 'MINUTES' } },
+        inputs: [{ ppl_input: { query: 'source = logs | stats count()', query_language: 'ppl' } }],
+        triggers: [],
+      },
+    };
+
+    const result = await service.updateMonitor(
+      {},
+      { params: { id: 'mon-1' }, query: {}, body: blankTopLevelBody },
+      res
+    );
+
+    // A blank top-level query must not short-circuit the nested fallback.
+    expect(result.body.ok).toBe(true);
+    expect(client).toHaveBeenCalledTimes(1);
+    const [, callArgs] = client.mock.calls[0];
+    expect(callArgs.body.inputs[0].ppl_input.query).toBe('source = logs | stats count()');
   });
 
   test('rejects an engine-shape body whose nested query is empty', async () => {


### PR DESCRIPTION
The monitor details page enable/disable toggle round-trips the monitor in raw v1 shape (query nested in inputs[0].ppl_input.query, nothing at top level). toV1MonitorBody read only the top-level query and defaulted to '', so before the empty-query guard this path silently wiped the monitor's PPL query on every toggle; after the guard it was rejected outright.

Fall back to inputs[0].ppl_input.query in both toV1MonitorBody and the updateMonitor guard so v1-shape bodies pass through with their query intact, while truly query-less bodies are still rejected.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting-dashboards-plugin/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
